### PR TITLE
Update document.parser.class.inc.php

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3570,7 +3570,8 @@ class DocumentParser {
                 list($key,$modifiers)=$this->splitKeyAndFilter($key);
             else $modifiers = false;
             
-            if(!isset($ph[$key])) continue;
+//          if(!isset($ph[$key])) continue;  
+            if(!array_key_exists($key,$ph)) continue; //NULL values must be saved in placeholders, if we got them from database string
             
             $value = $ph[$key];
             


### PR DESCRIPTION
Если в массиве есть элементы с соответствующими плейсхолдерам ключами, но из значения выставлены в  NULL - нужно заполнить соответствующие плейсхолдеры пустыми значениями, а не передавать дальше нераспарсенное наименование плейсхолдера.