### PR TITLE
Update save_settings.processor.php

### DIFF
--- a/manager/processors/save_settings.processor.php
+++ b/manager/processors/save_settings.processor.php
@@ -146,5 +146,5 @@ if (isset($data) && count($data) > 0) {
 	// empty cache
 	$modx->clearCache('full');
 }
-$header="Location: index.php?a=17";
+$header="Location: index.php?a=17&r=10";
 header($header);

--- a/manager/processors/save_settings.processor.php
+++ b/manager/processors/save_settings.processor.php
@@ -146,5 +146,5 @@ if (isset($data) && count($data) > 0) {
 	// empty cache
 	$modx->clearCache('full');
 }
-$header="Location: index.php?a=7&r=10";
+$header="Location: index.php?a=17";
 header($header);


### PR DESCRIPTION
Возможно так было задумано, однако предлагаю - Для того, чтобы после сохранения страницы конфигурации появлялась страница конфигурации, а не редирект на главную, или если стр конфигурации открыта в новой вкладке, то идет редирект на пустой файл wait.static.php
Мне кажется, так удобнее + tabpane запоминает вкладки, поэтому вообще хорошо

тогда скорее всего нужно удалить js, который производит редирект на главную

тут как я понимаю вопрос в том, надо ли r=10 или нет
можно просто другой параметр передавать, чтобы редирект был на текущую страницу