### PR TITLE
Fix/php short tags off support

### DIFF
--- a/manager/actions/mutate_menuindex_sort.dynamic.php
+++ b/manager/actions/mutate_menuindex_sort.dynamic.php
@@ -168,7 +168,7 @@ $pagetitle = $id == 0 ? $site_name : $pagetitle;
             <?= $updateMsg ?>
             <span class="text-danger" style="display:none;" id="updating"><?= $_lang['sort_updating'] ?></span>
             <?= $ressourcelist ?>
-            <?
+            <?php
         } else {
             echo $updateMsg;
         }

--- a/manager/actions/sysinfo.static.php
+++ b/manager/actions/sysinfo.static.php
@@ -62,7 +62,7 @@ $serverArr = array(
                             <td>&nbsp;</td>
                             <td><b><?= $value ?></b></td>
                         </tr>
-                        <?
+                        <?php
                     }
                     ?>
                     </tbody>


### PR DESCRIPTION
Found a quick solution for Issue #284. The menuindex sorter works again if PHP short tags are off. Same goes for the sysinfo action.