### PR TITLE
Смена родителя ресурса на предка соседа

### DIFF
--- a/manager/processors/save_content.processor.php
+++ b/manager/processors/save_content.processor.php
@@ -463,7 +463,7 @@ switch ($actionToTake) {
         }
 
         $parents = $modx->getParentIds($parent);
-        if (in_array($oldparent, $parents)) {
+        if (in_array($id, $parents)) {
             $modx->webAlertAndQuit("Document descendant can not be it's parent!");
         }
         


### PR DESCRIPTION
Чтобы можно было перенести ресурс внутрь "соседа", нужно проверять не oldparent, а id существующего ресурса. Иначе эта проверка не даст перенести ресурс внутрь соседа, так как oldparent окажется среди массива parents, что сейчас собственно и происходит в текущей версии.