### PR TITLE
NEW configurable GitHub repo in updater plugin

### DIFF
--- a/assets/plugins/updater/plugin.updater.php
+++ b/assets/plugins/updater/plugin.updater.php
@@ -22,7 +22,7 @@ else if(($role!=$ThisRole) AND ($wdgVisibility == 'ThisRoleOnly')) {
 else if(($user!=$ThisUser) AND ($wdgVisibility == 'ThisUserOnly')) {    
 }
 else {
-$version = 'evolution-cms/evolution';
+$version = isset($version) ? $version : 'evolution-cms/evolution';
 $type = isset($type) ? $type: 'tags';
 $showButton = isset($showButton) ? $showButton: 'AdminOnly';
 

--- a/install/assets/plugins/updater.tpl
+++ b/install/assets/plugins/updater.tpl
@@ -5,13 +5,13 @@
  * show message about outdated CMS version
  *
  * @category    plugin
- * @version     0.8.1
+ * @version     0.8.2
  * @license     http://www.gnu.org/copyleft/gpl.html GNU Public License (GPL)
  * @package     evo
  * @author      Dmi3yy (dmi3yy.com) 
  * @internal    @events OnManagerWelcomeHome,OnPageNotFound,OnSiteRefresh
  * @internal    @modx_category Manager and Admin
- * @internal    @properties &wdgVisibility=Show widget for:;menu;All,AdminOnly,AdminExcluded,ThisRoleOnly,ThisUserOnly;All &ThisRole=Show only to this role id:;string;;;enter the role id &ThisUser=Show only to this username:;string;;;enter the username &showButton=Show Update Button:;menu;show,hide,AdminOnly;AdminOnly &type=Type:;menu;tags,releases,commits;tags 
+ * @internal    @properties &version=Version:;text;evolution-cms/evolution &wdgVisibility=Show widget for:;menu;All,AdminOnly,AdminExcluded,ThisRoleOnly,ThisUserOnly;All &ThisRole=Show only to this role id:;string;;;enter the role id &ThisUser=Show only to this username:;string;;;enter the username &showButton=Show Update Button:;menu;show,hide,AdminOnly;AdminOnly &type=Type:;menu;tags,releases,commits;tags 
  * @internal    @legacy_names MODX.Evolution.updateNotify
  * @internal    @installset base
  * @internal    @disabled 0


### PR DESCRIPTION
This is important for custom forks with custom installers because they may get broken if someone clicks the default update button in the home page of the manager.