### PR TITLE
update loadArray

### DIFF
--- a/assets/lib/Helpers/Config.php
+++ b/assets/lib/Helpers/Config.php
@@ -125,6 +125,7 @@ class Config
                 }
                 break;
             case 'array':
+                $out = $arr;
                 break;
             default:
                 $out = array();


### PR DESCRIPTION
Если в метод передан массив, то его нужно вернуть.
Из-за этого перестали работать правила в FormLister.