### PR TITLE
getDocumentObjectFromCache()

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -2801,7 +2801,7 @@ class DocumentParser
         }
 
         if ($this->config['enable_cache']) {
-            $this->documentContent = $this->getDocumentObjectFromCache($this->documentIdentifier, true);
+            $this->getDocumentObjectFromCache($this->documentIdentifier, true);
         } else {
             $this->documentContent = '';
         }


### PR DESCRIPTION
Метод присваивает результат переменной $this->documentContent и возвращает этот результат,
а в prepareResponse() присваивает его опять.
К тому же в плагине с событием "OnLoadWebPageCache" мы не сможем изменить documentContent.