### PR TITLE
Fix install error on PHP 7.2

### DIFF
--- a/install/actions/action_connection.php
+++ b/install/actions/action_connection.php
@@ -74,39 +74,3 @@ $content = file_get_contents('./actions/tpl_connection.html');
 $content = parse($content, $_lang, '[%','%]');
 $content = parse($content, $ph);
 echo $content;
-
-if( ! function_exists('getLangs')) {
-    /**
-     * @param $install_language
-     * @return string
-     */
-    function getLangs($install_language)
-    {
-        if ($install_language !== "english" && is_file(sprintf("../%s/includes/lang/%s.inc.php", MGR_DIR, $install_language))) {
-            $manager_language = $install_language;
-        } else {
-            $manager_language = "english";
-        }
-
-        $langs = array();
-        if ($handle = opendir("../" . MGR_DIR . "/includes/lang")) {
-            while (false !== ($file = readdir($handle))) {
-                if (strpos($file, '.inc.') !== false) {
-                    $langs[] = $file;
-                }
-            }
-            closedir($handle);
-        }
-        sort($langs);
-
-        $_ = array();
-        foreach ($langs as $language) {
-            $abrv_language = explode('.', $language);
-            $selected = (strtolower($abrv_language[0]) == strtolower($manager_language)) ? ' selected' : '';
-            $_[] = sprintf('<option value="%s" %s>%s</option>', $abrv_language[0], $selected,
-                ucwords($abrv_language[0]));
-        }
-
-        return implode("\n", $_);
-    }
-}

--- a/install/connection.collation.php
+++ b/install/connection.collation.php
@@ -14,8 +14,13 @@ if(!defined('MGR_DIR') && is_dir("{$base_path}manager")) {
 }
 require_once('lang.php');
 
-$conn = mysqli_connect($host, $uid, $pwd);
-if(!$conn) exit('can not connect');
+if(function_exists('mysqli_connect')) {  
+    $conn = mysqli_connect($host, $uid, $pwd);
+    if(!$conn) exit('can not connect');
+}
+else {
+    exit('undefined function mysqli_connect()');
+}
 
 // get collation
 $rs = mysqli_query($conn, "SHOW COLLATION");

--- a/install/connection.collation.php
+++ b/install/connection.collation.php
@@ -5,20 +5,21 @@ $uid = $_POST['uid'];
 $pwd = $_POST['pwd'];
 
 $self = 'install/connection.collation.php';
-$base_path = str_replace($self,'',str_replace('\\','/', __FILE__));
+$base_path = str_replace($self, '', str_replace('\\', '/', __FILE__));
 if (is_file("{$base_path}assets/cache/siteManager.php")) {
-	include_once("{$base_path}assets/cache/siteManager.php");
+    include_once("{$base_path}assets/cache/siteManager.php");
 }
-if(!defined('MGR_DIR') && is_dir("{$base_path}manager")) {
-	define('MGR_DIR','manager');
+if (!defined('MGR_DIR') && is_dir("{$base_path}manager")) {
+    define('MGR_DIR', 'manager');
 }
 require_once('lang.php');
 
-if(function_exists('mysqli_connect')) {  
+if (function_exists('mysqli_connect')) {
     $conn = mysqli_connect($host, $uid, $pwd);
-    if(!$conn) exit('can not connect');
-}
-else {
+    if (!$conn) {
+        exit('can not connect');
+    }
+} else {
     exit('undefined function mysqli_connect()');
 }
 
@@ -30,27 +31,35 @@ if (mysqli_num_rows($rs) > 0) {
     while ($row = mysqli_fetch_row($rs)) {
         $_[$row[0]] = '';
     }
-    
+
     $database_collation = htmlentities($_POST['database_collation']);
     $recommend_collation = $_lang['recommend_collation'];
-    
-    if    (isset($_[$recommend_collation])) $_[$recommend_collation] = ' selected';
-    elseif(isset($_['utf8mb4_general_ci'])) $_['utf8mb4_general_ci'] = ' selected';
-    elseif(isset($_['utf8_general_ci']))    $_['utf8_general_ci']    = ' selected';
-    elseif(isset($_[$database_collation]))  $_[$database_collation]  = ' selected';
-    
-    $_ = sortItem($_,$_lang['recommend_collations_order']);
-    
-    foreach($_ as $collation=>$selected) {
+
+    if (isset($_[$recommend_collation])) {
+        $_[$recommend_collation] = ' selected';
+    } elseif (isset($_['utf8mb4_general_ci'])) {
+        $_['utf8mb4_general_ci'] = ' selected';
+    } elseif (isset($_['utf8_general_ci'])) {
+        $_['utf8_general_ci']    = ' selected';
+    } elseif (isset($_[$database_collation])) {
+        $_[$database_collation]  = ' selected';
+    }
+
+    $_ = sortItem($_, $_lang['recommend_collations_order']);
+
+    foreach ($_ as $collation=>$selected) {
         $collation = htmlentities($collation);
         // if(substr($collation,0,4)!=='utf8') continue;
-        if(strpos($collation,'sjis')===0) continue;
-        if($collation=='recommend')
+        if (strpos($collation, 'sjis')===0) {
+            continue;
+        }
+        if ($collation=='recommend') {
             $output .= '<optgroup label="recommend">';
-        elseif($collation=='unrecommend')
+        } elseif ($collation=='unrecommend') {
             $output .= '</optgroup><optgroup label="unrecommend">';
-        else
+        } else {
             $output .= sprintf('<option value="%s" %s>%s</option>', $collation, $selected, $collation);
+        }
     }
     $output .= '</optgroup></select>';
 }
@@ -58,18 +67,17 @@ if (mysqli_num_rows($rs) > 0) {
 echo $output;
 exit;
 
-
-
-function sortItem($array=array(),$order='utf8mb4,utf8') {
+function sortItem($array=array(), $order='utf8mb4,utf8')
+{
     $rs = array('recommend'=>'');
     $order = explode(',', $order);
-    foreach($order as $v) {
-    	foreach($array as $name=>$sel) {
-        	if(strpos($name,$v)!==false) {
-        		$rs[$name] = $array[$name];
-        		unset($array[$name]);
-        	}
-    	}
+    foreach ($order as $v) {
+        foreach ($array as $name=>$sel) {
+            if (strpos($name, $v)!==false) {
+                $rs[$name] = $array[$name];
+                unset($array[$name]);
+            }
+        }
     }
     $rs['unrecommend']='';
     return $rs + $array;

--- a/install/connection.servertest.php
+++ b/install/connection.servertest.php
@@ -5,40 +5,42 @@ $uid = $_POST['uid'];
 $pwd = $_POST['pwd'];
 
 $self = 'install/connection.servertest.php';
-$base_path = str_replace($self,'',str_replace('\\','/', __FILE__));
+$base_path = str_replace($self, '', str_replace('\\', '/', __FILE__));
 if (is_file("{$base_path}assets/cache/siteManager.php")) {
-	include_once("{$base_path}assets/cache/siteManager.php");
+    include_once("{$base_path}assets/cache/siteManager.php");
 }
-if(!defined('MGR_DIR') && is_dir("{$base_path}manager")) {
-	define('MGR_DIR','manager');
+if (!defined('MGR_DIR') && is_dir("{$base_path}manager")) {
+    define('MGR_DIR', 'manager');
 }
 require_once("lang.php");
 
 $output = $_lang["status_connecting"];
-if(function_exists('mysqli_connect')) {
+if (function_exists('mysqli_connect')) {
     if (!$conn = @mysqli_connect($host, $uid, $pwd)) {
         $output .= '<span id="server_fail" style="color:#FF0000;"> '.$_lang['status_failed'].'</span>';
-    }
-    else {
+    } else {
         $output .= '<span id="server_pass" style="color:#80c000;"> '.$_lang['status_passed_server'].'</span>';
 
         // Mysql version check
-        if ( version_compare(mysqli_get_server_info($conn), '5.0.51', '=') ) {
+        if (version_compare(mysqli_get_server_info($conn), '5.0.51', '=')) {
             $output .= '<br /><span style="color:#FF0000;"> '.$_lang['mysql_5051'].'</span>';
         }
         // Mode check
         $mysqlmode = mysqli_query($conn, "SELECT @@session.sql_mode");
-        if (@mysqli_num_rows($mysqlmode) > 0){
+        if (@mysqli_num_rows($mysqlmode) > 0) {
             $modes = mysqli_fetch_array($mysqlmode, MYSQLI_NUM);
             $strictMode = false;
             foreach ($modes as $mode) {
-    		    if (stristr($mode, "STRICT_TRANS_TABLES") !== false || stristr($mode, "STRICT_ALL_TABLES") !== false) $strictMode = true;
+                if (stristr($mode, "STRICT_TRANS_TABLES") !== false || stristr($mode, "STRICT_ALL_TABLES") !== false) {
+                    $strictMode = true;
+                }
             }
-            if ($strictMode) $output .= '<br /><span style="color:#FF0000;"> '.$_lang['strict_mode'].'</span>';
+            if ($strictMode) {
+                $output .= '<br /><span style="color:#FF0000;"> '.$_lang['strict_mode'].'</span>';
+            }
         }
     }
-}
-else {
+} else {
     $output .= '<span id="server_fail" style="color:#FF0000;"> '.$_lang['status_failed_mysqli'].'</span>';
 }
 echo $output;

--- a/install/connection.servertest.php
+++ b/install/connection.servertest.php
@@ -15,25 +15,30 @@ if(!defined('MGR_DIR') && is_dir("{$base_path}manager")) {
 require_once("lang.php");
 
 $output = $_lang["status_connecting"];
-if (!$conn = @mysqli_connect($host, $uid, $pwd)) {
-    $output .= '<span id="server_fail" style="color:#FF0000;"> '.$_lang['status_failed'].'</span>';
+if(function_exists('mysqli_connect')) {
+    if (!$conn = @mysqli_connect($host, $uid, $pwd)) {
+        $output .= '<span id="server_fail" style="color:#FF0000;"> '.$_lang['status_failed'].'</span>';
+    }
+    else {
+        $output .= '<span id="server_pass" style="color:#80c000;"> '.$_lang['status_passed_server'].'</span>';
+
+        // Mysql version check
+        if ( version_compare(mysqli_get_server_info($conn), '5.0.51', '=') ) {
+            $output .= '<br /><span style="color:#FF0000;"> '.$_lang['mysql_5051'].'</span>';
+        }
+        // Mode check
+        $mysqlmode = mysqli_query($conn, "SELECT @@session.sql_mode");
+        if (@mysqli_num_rows($mysqlmode) > 0){
+            $modes = mysqli_fetch_array($mysqlmode, MYSQLI_NUM);
+            $strictMode = false;
+            foreach ($modes as $mode) {
+    		    if (stristr($mode, "STRICT_TRANS_TABLES") !== false || stristr($mode, "STRICT_ALL_TABLES") !== false) $strictMode = true;
+            }
+            if ($strictMode) $output .= '<br /><span style="color:#FF0000;"> '.$_lang['strict_mode'].'</span>';
+        }
+    }
 }
 else {
-    $output .= '<span id="server_pass" style="color:#80c000;"> '.$_lang['status_passed_server'].'</span>';
-
-    // Mysql version check
-    if ( version_compare(mysqli_get_server_info($conn), '5.0.51', '=') ) {
-        $output .= '<br /><span style="color:#FF0000;"> '.$_lang['mysql_5051'].'</span>';
-    }
-    // Mode check
-    $mysqlmode = mysqli_query($conn, "SELECT @@session.sql_mode");
-    if (@mysqli_num_rows($mysqlmode) > 0){
-        $modes = mysqli_fetch_array($mysqlmode, MYSQLI_NUM);
-        $strictMode = false;
-        foreach ($modes as $mode) {
-    		    if (stristr($mode, "STRICT_TRANS_TABLES") !== false || stristr($mode, "STRICT_ALL_TABLES") !== false) $strictMode = true;
-        }
-        if ($strictMode) $output .= '<br /><span style="color:#FF0000;"> '.$_lang['strict_mode'].'</span>';
-    }
+    $output .= '<span id="server_fail" style="color:#FF0000;"> '.$_lang['status_failed_mysqli'].'</span>';
 }
 echo $output;

--- a/install/functions.php
+++ b/install/functions.php
@@ -111,6 +111,10 @@ function get_installmode()
 	return $installmode;
 }
 
+/**
+* @param $install_language
+* @return string
+*/
 function getLangs($install_language)
 {
     if ($install_language !== "english" && is_file(sprintf("../%s/includes/lang/%s.inc.php", MGR_DIR, $install_language))) {
@@ -131,11 +135,11 @@ function getLangs($install_language)
     sort($langs);
 
     $_ = array();
-   foreach ($langs as $language) {
+    foreach ($langs as $language) {
         $abrv_language = explode('.', $language);
         $selected = (strtolower($abrv_language[0]) == strtolower($manager_language)) ? ' selected' : '';
         $_[] = sprintf('<option value="%s" %s>%s</option>', $abrv_language[0], $selected,
-            ucwords($abrv_language[0]));
+                       ucwords($abrv_language[0]));
     }
 
     return implode("\n", $_);

--- a/install/functions.php
+++ b/install/functions.php
@@ -110,3 +110,33 @@ function get_installmode()
 	}
 	return $installmode;
 }
+
+function getLangs($install_language)
+{
+    if ($install_language !== "english" && is_file(sprintf("../%s/includes/lang/%s.inc.php", MGR_DIR, $install_language))) {
+        $manager_language = $install_language;
+    } else {
+        $manager_language = "english";
+    }
+
+    $langs = array();
+    if ($handle = opendir("../" . MGR_DIR . "/includes/lang")) {
+        while (false !== ($file = readdir($handle))) {
+            if (strpos($file, '.inc.') !== false) {
+                $langs[] = $file;
+            }
+        }
+        closedir($handle);
+    }
+    sort($langs);
+
+    $_ = array();
+   foreach ($langs as $language) {
+        $abrv_language = explode('.', $language);
+        $selected = (strtolower($abrv_language[0]) == strtolower($manager_language)) ? ' selected' : '';
+        $_[] = sprintf('<option value="%s" %s>%s</option>', $abrv_language[0], $selected,
+            ucwords($abrv_language[0]));
+    }
+
+    return implode("\n", $_);
+}

--- a/install/lang/bulgarian.inc.php
+++ b/install/lang/bulgarian.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author MODX Team
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Bulgarian
  * @package modx

--- a/install/lang/bulgarian.inc.php
+++ b/install/lang/bulgarian.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'Неуспешно!';
 $_lang["status_failed_could_not_create_database"] = 'Неуспешно - не може да бъде създадена БД';
 $_lang["status_failed_database_collation_does_not_match"] = 'failed - database collation mismatch; use SET NAMES or choose %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'Неуспешно - префикса на таблицата вече се използва!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'Успешно - БД е избрана';
 $_lang["status_passed_database_created"] = 'Успешно - БД е създадена';
 $_lang["status_passed_server"] = 'Успешно - колациите са достъпни';

--- a/install/lang/czech.inc.php
+++ b/install/lang/czech.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author modxcms.cz
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Czech
  * @package modx

--- a/install/lang/czech.inc.php
+++ b/install/lang/czech.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'nezdařilo se!';
 $_lang["status_failed_could_not_create_database"] = 'nezdařilo se - nelze vytvořit databázi';
 $_lang["status_failed_database_collation_does_not_match"] = 'nezdařilo se - nesoulad porovnání databáze; použijte SET NAMES nebo vyberte %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'nezdařilo se - zvolený prefix tabulek se již používá!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'v pořádku - databáze vybrána';
 $_lang["status_passed_database_created"] = 'v pořádku - databáze vytvořena';
 $_lang["status_passed_server"] = 'v pořádku - porovnání je dostupné';

--- a/install/lang/danish.inc.php
+++ b/install/lang/danish.inc.php
@@ -4,8 +4,8 @@
  *
  * @author Henrik Nielsen
  * @author Mads Vestmar
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Danish
  * @package modx

--- a/install/lang/danish.inc.php
+++ b/install/lang/danish.inc.php
@@ -166,6 +166,7 @@ $_lang["status_failed"] = 'Fejlede!';
 $_lang["status_failed_could_not_create_database"] = 'fejlede - kunne ikke oprette databasen';
 $_lang["status_failed_database_collation_does_not_match"] = 'fejlede - databasens collation stemmer ikke overens; brug SET NAMES eller vælg %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'fejlede - tabellernes præfiks eksisterer allerede!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'gennemført - databasen er valgt';
 $_lang["status_passed_database_created"] = 'gennemført - databasen er oprettet';
 $_lang["status_passed_server"] = 'gennemført - collations er nu tilgængelige';

--- a/install/lang/english.inc.php
+++ b/install/lang/english.inc.php
@@ -170,6 +170,7 @@ $_lang["status_failed"] = 'failed!';
 $_lang["status_failed_could_not_create_database"] = 'failed - could not create database';
 $_lang["status_failed_database_collation_does_not_match"] = 'failed - database collation mismatch; use SET NAMES or choose %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'failed - table prefix already in use!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'passed - database selected';
 $_lang["status_passed_database_created"] = 'passed - database created';
 $_lang["status_passed_server"] = 'passed - collations now available';

--- a/install/lang/english.inc.php
+++ b/install/lang/english.inc.php
@@ -3,8 +3,8 @@
  * EVO Installer language file
  *
  * @author davaeron
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language English
  * @package evo

--- a/install/lang/finnish-utf8.inc.php
+++ b/install/lang/finnish-utf8.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'epäonnistui!';
 $_lang["status_failed_could_not_create_database"] = 'epäonnistui - tietokantaa ei voitu luoda';
 $_lang["status_failed_database_collation_does_not_match"] = 'epäonnistui - tietokannan merkistön yhteensopivuus ongelma. Käytä "SET NAMES" tai valitse %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'epäonnistui - tietokannan taulujen etuliite on jo käytössä!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'onnistui - tietokanta valittu';
 $_lang["status_passed_database_created"] = 'onnistui - tietokanta luotu';
 $_lang["status_passed_server"] = 'onnistui - merkistöt ovat nyt käytettävissä';

--- a/install/lang/finnish-utf8.inc.php
+++ b/install/lang/finnish-utf8.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author Anssi Rajakallio, Kari Söderholm
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Finnish
  * @package modx

--- a/install/lang/francais-utf8.inc.php
+++ b/install/lang/francais-utf8.inc.php
@@ -5,8 +5,8 @@
  * @author Grégory Pakosz (guardian)
  * @author Coroico
  * @author Jean-Christophe Brebion (Fairytree)
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language French
  * @package modx

--- a/install/lang/francais-utf8.inc.php
+++ b/install/lang/francais-utf8.inc.php
@@ -167,6 +167,7 @@ $_lang["status_failed"] = 'échec!';
 $_lang["status_failed_could_not_create_database"] = 'échec - impossible de créer la base de données';
 $_lang["status_failed_database_collation_does_not_match"] = 'échec - collation différente; utilisez SET NAMES ou choisir %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'échec - préfixe de table déjà utilisé!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'succès - base sélectionnée';
 $_lang["status_passed_database_created"] = 'succès - base créée';
 $_lang["status_passed_server"] = 'succès - collations maintenant disponibles';

--- a/install/lang/german.inc.php
+++ b/install/lang/german.inc.php
@@ -169,6 +169,7 @@ $_lang["status_failed"] = 'fehlgeschlagen!';
 $_lang["status_failed_could_not_create_database"] = 'fehlgeschlagen – konnte Datenbank nicht erstellen';
 $_lang["status_failed_database_collation_does_not_match"] = 'fehlgeschlagen – Unterschied in der Datenbank-Kollation; benutzen Sie SET NAMES oder wählen Sie %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'fehlgeschlagen – Tabellen-Präfix bereits verwendet!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'In Ordnung – Datenbank ausgewählt';
 $_lang["status_passed_database_created"] = 'In Ordnung – Datenbank erstellt';
 $_lang["status_passed_server"] = 'In Ordung – Kollationen sind nun auswählbar';

--- a/install/lang/german.inc.php
+++ b/install/lang/german.inc.php
@@ -4,8 +4,8 @@
  *
  * @author Marc Hinse
  * @author Bogdan Günther
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language German
  * @package modx

--- a/install/lang/hebrew.inc.php
+++ b/install/lang/hebrew.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'נכשל!';
 $_lang["status_failed_could_not_create_database"] = 'נכשל - לא ניתן ליצור את מסד הנתונים';
 $_lang["status_failed_database_collation_does_not_match"] = 'נכשל - אוסף הנתונים לא תואם; השתמש ב SET NAMES או בחר %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'failed - table prefix already in use!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'עבר - מסד נתונים נבחר';
 $_lang["status_passed_database_created"] = 'עבר - יצירת מסד נתונים';
 $_lang["status_passed_server"] = 'עבר - אוסף נתונים זמין';

--- a/install/lang/hebrew.inc.php
+++ b/install/lang/hebrew.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author MODX Team
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Hebrew
  * @package modx

--- a/install/lang/italian.inc.php
+++ b/install/lang/italian.inc.php
@@ -170,6 +170,7 @@ $_lang["status_failed"] = 'fallita!';
 $_lang["status_failed_could_not_create_database"] = 'fallita - impossibile creare il database';
 $_lang["status_failed_database_collation_does_not_match"] = 'fallita - problemi con la collation del database; usate SET NAMES o scegliete %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'fallita - il prefisso scelto per le tabelle &eacute; gi&agrave; in uso!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'successo - il database &eacute; stato selezionato';
 $_lang["status_passed_database_created"] = 'successo - il database &eacute; stato creato';
 $_lang["status_passed_server"] = 'successo - la collation del database &eacute; disponibile';

--- a/install/lang/italian.inc.php
+++ b/install/lang/italian.inc.php
@@ -3,8 +3,8 @@
  * EVO Installer language file
  *
  * @author Nicola
- * @version 1.4
- * @date 2017/12/13
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Italian
  * @package evo

--- a/install/lang/japanese-utf8.inc.php
+++ b/install/lang/japanese-utf8.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author MEGU, yamamoto, TxO
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Japanese
  * @package modx

--- a/install/lang/japanese-utf8.inc.php
+++ b/install/lang/japanese-utf8.inc.php
@@ -167,6 +167,7 @@ $_lang["status_failed"] = '接続できません';
 $_lang["status_failed_could_not_create_database"] = 'データベースを作成できません';
 $_lang["status_failed_database_collation_does_not_match"] = '問題があります - データベース側の照合順序のデフォルト値が「%s」になっています。phpMyAdminが利用できる場合は、該当データベースの「操作」タブで照合順序のデフォルト値を変更してください。';
 $_lang["status_failed_table_prefix_already_in_use"] = '接続できません - このTableプリフィクスはすでに使われています。異なるTableプリフィクスを指定するか、phpMyAdminなどを利用し関連Tableを削除してください。';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = '問題ありません';
 $_lang["status_passed_database_created"] = 'データベースを作成できます';
 $_lang["status_passed_server"] = '接続できます';

--- a/install/lang/nederlands-utf8.inc.php
+++ b/install/lang/nederlands-utf8.inc.php
@@ -3,8 +3,8 @@
  * EVO Installer language file
  *
  * @author marc
- * @version 1.4
- * @date 2017/12/13
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Dutch
  * @package evo

--- a/install/lang/nederlands-utf8.inc.php
+++ b/install/lang/nederlands-utf8.inc.php
@@ -170,6 +170,7 @@ $_lang["status_failed"] = 'mislukt!';
 $_lang["status_failed_could_not_create_database"] = 'mislukt - kan database niet aanmaken';
 $_lang["status_failed_database_collation_does_not_match"] = 'mislukt - database coalitie klopt niet; gebruik SET NAMES of kies% s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'mislukt - tabel prefix is al in gebruik!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'gelukt - database geselecteerd';
 $_lang["status_passed_database_created"] = 'gelukt - database is aangemaakt';
 $_lang["status_passed_server"] = 'gelukt - coalitie nu beschikbaar';

--- a/install/lang/norwegian.inc.php
+++ b/install/lang/norwegian.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author Bjørn Erik Sandbakk (Sylvaticus)
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Norsk
  * @package modx

--- a/install/lang/norwegian.inc.php
+++ b/install/lang/norwegian.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'mislyktes!';
 $_lang["status_failed_could_not_create_database"] = 'mislyktes - kunne ikke opprette database';
 $_lang["status_failed_database_collation_does_not_match"] = 'mislyktes - database collation ulikhet; bruk SET NAMES eller velg %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'mislyktes - tabellprefixet er allerede i bruk!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'godkjent - databasen valgt';
 $_lang["status_passed_database_created"] = 'godkjent - database opprettet';
 $_lang["status_passed_server"] = 'godkjent - kollasjoneringer er n&aring; tilgjengelig';

--- a/install/lang/persian.inc.php
+++ b/install/lang/persian.inc.php
@@ -166,6 +166,7 @@ $_lang["status_failed"] = 'ناموفق!';
 $_lang["status_failed_could_not_create_database"] = 'ناموفق - قادر به ایجاد پایگاه داده نمی باشیم';
 $_lang["status_failed_database_collation_does_not_match"] = 'failed - database collation mismatch; use SET NAMES or choose %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'ناموفق - پیشوند جدول هایی که انتخاب کردید پیش از این موجود می باشد';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'موفقیت آمیز - پایگاه دادهی انتخاب شد!';
 $_lang["status_passed_database_created"] = 'موفقیت آمیز - پایگاه داده ایجاد شد';
 $_lang["status_passed_server"] = 'موفقیت آمیز - تطبیق ها تهیه شد!';

--- a/install/lang/persian.inc.php
+++ b/install/lang/persian.inc.php
@@ -4,8 +4,8 @@
  *
  * @author Mohsen Zare (MotSmart), MotSmart@Gmail.com, www.modxcms.ir
  * @author AliAqua
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Persian
  * @package modx

--- a/install/lang/polish-utf8.inc.php
+++ b/install/lang/polish-utf8.inc.php
@@ -2,8 +2,8 @@
 /**
  * EVO Installer language file
  *
- * @version 1.3.6
- * @date 2018/01/19
+ * @version 1.5.0
+ * @date 2018/02/23
  * @author EVO Project Team
  *
  * @language Polish

--- a/install/lang/polish-utf8.inc.php
+++ b/install/lang/polish-utf8.inc.php
@@ -170,6 +170,7 @@ $_lang["status_failed"] = 'BŁĄD!';
 $_lang["status_failed_could_not_create_database"] = 'BŁĄD! - nie można utworzyć bazy danych';
 $_lang["status_failed_database_collation_does_not_match"] = 'BŁĄD! - niezgodność systemów porównań; użyj SET NAMES lub wybierz %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'BŁĄD! - wybrany prefiks tabeli jest już wykorzystywany!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'OK - baza danych została wybrana';
 $_lang["status_passed_database_created"] = 'OK - baza danych utworzona';
 $_lang["status_passed_server"] = 'OK - system porównań dostępny';

--- a/install/lang/portuguese-br-utf8.inc.php
+++ b/install/lang/portuguese-br-utf8.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'falhou!';
 $_lang["status_failed_could_not_create_database"] = 'falhou - não foi possível criar a base de dadose';
 $_lang["status_failed_database_collation_does_not_match"] = 'failed - database collation mismatch; use SET NAMES or choose %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'falhou - o table prefix já está em uso!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'sucesso - Base de Dados selecionada';
 $_lang["status_passed_database_created"] = 'sucesso - Base de Dados criada';
 $_lang["status_passed_server"] = 'sucesso - collations agora disponíveis';

--- a/install/lang/portuguese-br-utf8.inc.php
+++ b/install/lang/portuguese-br-utf8.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author Daniel Miguel de Melo
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Português do Brasil
  * @package modx

--- a/install/lang/portuguese.inc.php
+++ b/install/lang/portuguese.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author davaeron
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language English
  * @package modx

--- a/install/lang/portuguese.inc.php
+++ b/install/lang/portuguese.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = 'falhou!';
 $_lang["status_failed_could_not_create_database"] = 'falhou - não foi possível criar a base de dadose';
 $_lang["status_failed_database_collation_does_not_match"] = 'failed - database collation mismatch; use SET NAMES or choose %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'falhou - o table prefix já está em uso!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'sucesso - Base de Dados selecionada';
 $_lang["status_passed_database_created"] = 'sucesso - Base de Dados criada';
 $_lang["status_passed_server"] = 'sucesso - collations agora disponíveis';

--- a/install/lang/russian-UTF8.inc.php
+++ b/install/lang/russian-UTF8.inc.php
@@ -4,9 +4,10 @@
  *
  * @author Pertsev Dmitriy
  * @author Safronovich Victor
+ * @author Rudnykh Vitalii
  * @author Russian EVO Community
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Russian
  * @package modx
@@ -168,6 +169,7 @@ $_lang["status_failed"] = 'ошибка!';
 $_lang["status_failed_could_not_create_database"] = 'ошибка - не удается создать базу данных';
 $_lang["status_failed_database_collation_does_not_match"] = 'ошибка - сопоставление базы данных не соответствует; используйте SET NAMES или выберите %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'ошибка - префикс таблицы уже используется!';
+$_lang['status_failed_mysqli'] = 'ошибка - расширение mysqli для php не установлено';
 $_lang["status_passed"] = 'успех - база данных выбрана';
 $_lang["status_passed_database_created"] = 'успех - база данных создана';
 $_lang["status_passed_server"] = 'успех - сопоставление базы данных доступно';

--- a/install/lang/spanish-utf8.inc.php
+++ b/install/lang/spanish-utf8.inc.php
@@ -165,6 +165,7 @@ $_lang["status_failed"] = '¡falló!';
 $_lang["status_failed_could_not_create_database"] = 'falló - no se pudo crear la base de datos';
 $_lang["status_failed_database_collation_does_not_match"] = 'falló  - no coincide la compaginación de la base de datos; usa SET NAMES o elige %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'falló - el prefijo de tabla ya existe';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'pasó - base de datos seleccionada';
 $_lang["status_passed_database_created"] = 'pasó - base de datos creada';
 $_lang["status_passed_server"] = 'pasó - compaginaciones ahora disponibles';

--- a/install/lang/spanish-utf8.inc.php
+++ b/install/lang/spanish-utf8.inc.php
@@ -3,8 +3,8 @@
  * MODX Installer language file
  *
  * @author MODX Team
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Spanish
  * @package modx

--- a/install/lang/svenska.inc.php
+++ b/install/lang/svenska.inc.php
@@ -166,6 +166,7 @@ $_lang["status_failed"] = 'misslyckades!';
 $_lang["status_failed_could_not_create_database"] = 'misslyckades - kunde inte skapa databas';
 $_lang["status_failed_database_collation_does_not_match"] = 'misslyckades - databaskollationeringen stämmer inte; använd SET_NAMES eller välj %s';
 $_lang["status_failed_table_prefix_already_in_use"] = 'misslyckades - tabellprefixet används redan!';
+$_lang['status_failed_mysqli'] = 'error - mysqli extension for PHP is not installed!';
 $_lang["status_passed"] = 'godkänd - databasen valdes';
 $_lang["status_passed_database_created"] = 'godkänd - databas skapades';
 $_lang["status_passed_server"] = 'godkänd - kollationeringar finns nu tillgängliga';

--- a/install/lang/svenska.inc.php
+++ b/install/lang/svenska.inc.php
@@ -4,8 +4,8 @@
  *
  * @author Pontus Ågren (Pont)
  * @author Thomas Djärv (Beryl)
- * @version 1.0.15
- * @date 2014/02/24
+ * @version 1.5.0
+ * @date 2018/02/23
  *
  * @language Svenska
  * @package modx


### PR DESCRIPTION
On PHP 7.2 install crashed with an error:
`Fatal error: Uncaught Error: Call to undefined function getLangs() in /var/www/.../install/actions/action_connection.php:63 Stack trace: #0 /var/www/.../install/index.php(63): include_once() #1 {main} thrown in /var/www/.../install/actions/action_connection.php on line 63`

I moved function getLangs() in /install/functions.php before calling her.