### PR TITLE
New random method for $table_prefix

### DIFF
--- a/install/actions/action_connection.php
+++ b/install/actions/action_connection.php
@@ -6,7 +6,7 @@ $upgradeable= 0;
 if ($installMode === 0) {
     $database_name= '';
     $database_server= 'localhost';
-    $table_prefix= substr(md5(time()), rand(0, 27), rand(3, 5))."_";
+    $table_prefix = base_convert(rand(10, 20), 10, 36).substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyz'), rand(0, 33), 3).'_';
 } else {
     $database_name = '';
     if (!is_file($base_path.MGR_DIR.'/includes/config.inc.php')) $upgradeable = 0;


### PR DESCRIPTION
In templates file [tpl_connection.html](https://github.com/evolution-cms/evolution/blob/develop/install/actions/tpl_connection.html#L253) checked first char $table_prefix for a NOT-numeric.
Last random method sometimes return number.

---

В файле шаблоне [tpl_connection.html](https://github.com/evolution-cms/evolution/blob/develop/install/actions/tpl_connection.html#L253) проверяется первый символ $table_prefix на число (если число, то возвращается ошибка).

Предыдущий рандом-метод иногда возвращает значение где первый символ - число, из-за чего у пользователя могут возникнуть проблемы во время установки.
 
Так же прошлый метод not-secure т.к. имея доступ к логам и зная точное время запроса, можно перебрать значения table_prefix.