### PR TITLE
[I] Ajax-API for publish/delete resources in welcome.static

### DIFF
--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -524,9 +524,9 @@ function getRecentInfoList() {
 
 		if($modx->hasPermission('delete_document')) {
 			if($ph['deleted'] == 0) {
-				$delete_btn = '<a onclick="return confirm(\'[%confirm_delete_record%]\')" title="[%delete_resource%]" href="index.php?a=6&amp;id=[+id+]" target="main"><i class="fa fa-trash fa-fw"></i></a> ';
+				$delete_btn = '<a onclick="return confirm(\'[%confirm_delete_record%]\')" title="[%delete_resource%]" href="index.php?a=6&amp;id=[+id+]" target="main" data-ajaxaction="delete.res" data-id="[+id+]" data-element="row[+id+]"><i class="fa fa-trash fa-fw"></i></a> ';
 			} else {
-				$delete_btn = '<a onclick="return confirm(\'[%confirm_undelete%]\')" title="[%undelete_resource%]" href="index.php?a=63&amp;id=[+id+]" target="main"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
+				$delete_btn = '<a onclick="return confirm(\'[%confirm_undelete%]\')" title="[%undelete_resource%]" href="index.php?a=63&amp;id=[+id+]" target="main" data-ajaxaction="delete.res" data-id="[+id+]" data-element="row[+id+]"><i class="fa fa-arrow-circle-o-up fa-fw"></i></a> ';
 			}
 			$ph['delete_btn'] = str_replace('[+id+]', $docid, $delete_btn);
 		} else {
@@ -534,13 +534,13 @@ function getRecentInfoList() {
 		}
 
 		if($ph['deleted'] == 1 && $ph['published'] == 0) {
-			$publish_btn = '<a class="disabled" title="[%publish_resource%]" href="index.php?a=61&amp;id=[+id+]" target="main"><i class="fa fa-arrow-up fa-fw"></i></a> ';
+			$publish_btn = '<a class="disabled" title="[%publish_resource%]" href="index.php?a=61&amp;id=[+id+]" target="main" data-ajaxaction="publish.res" data-id="[+id+]" data-element="row[+id+]"><i class="fa fa-arrow-up fa-fw"></i></a> ';
 		} elseif($ph['deleted'] == 1 && $ph['published'] == 1) {
-			$publish_btn = '<a class="disabled" title="[%publish_resource%]" href="index.php?a=61&amp;id=[+id+]" target="main"><i class="fa fa-arrow-down fa-fw"></i></a> ';
+			$publish_btn = '<a class="disabled" title="[%publish_resource%]" href="index.php?a=61&amp;id=[+id+]" target="main" data-ajaxaction="publish.res" data-id="[+id+]" data-element="row[+id+]"><i class="fa fa-arrow-down fa-fw"></i></a> ';
 		} elseif($ph['deleted'] == 0 && $ph['published'] == 0) {
-			$publish_btn = '<a title="[%publish_resource%]" href="index.php?a=61&amp;id=[+id+]" target="main"><i class="fa fa-arrow-up fa-fw"></i></a> ';
+			$publish_btn = '<a title="[%publish_resource%]" href="index.php?a=61&amp;id=[+id+]" target="main" data-ajaxaction="publish.res" data-id="[+id+]" data-element="row[+id+]"><i class="fa fa-arrow-up fa-fw"></i></a> ';
 		} else {
-			$publish_btn = '<a title="[%unpublish_resource%]" href="index.php?a=62&amp;id=[+id+]" target="main"><i class="fa fa-arrow-down fa-fw"></i></a> ';
+			$publish_btn = '<a title="[%unpublish_resource%]" href="index.php?a=62&amp;id=[+id+]" target="main" data-ajaxaction="publish.res" data-id="[+id+]" data-element="row[+id+]"><i class="fa fa-arrow-down fa-fw"></i></a> ';
 		}
 		$ph['publish_btn'] = str_replace('[+id+]', $docid, $publish_btn);
 
@@ -566,7 +566,7 @@ function getRecentInfoList() {
 
 function getRecentInfoRowTpl() {
 	$tpl = '
-						<tr>
+						<tr id="row[+id+]">
 							<td data-toggle="collapse" data-target=".collapse[+id+]" class="text-right"><span class="label label-info">[+id+]</span></td>
 							<td data-toggle="collapse" data-target=".collapse[+id+]"><a class="[+status+]" title="[%edit_resource%]" href="index.php?a=3&amp;id=[+id+]" target="main">[+pagetitle+]</a></td>
 							<td data-toggle="collapse" data-target=".collapse[+id+]" class="text-right text-nowrap">[+editedon:math("%s+[(server_offset_time)]"):dateFormat+]</td>

--- a/manager/frames/1.php
+++ b/manager/frames/1.php
@@ -237,9 +237,11 @@ $modx->config['global_tabs'] = (int)($modx->config['global_tabs'] && ($user['rol
       <?php
       $opened = array_filter(array_map('intval', explode('|', $_SESSION['openedArray'])));
       echo (empty($opened) ? '' : 'modx.openedArray[' . implode("] = 1;\n		modx.openedArray[", $opened) . '] = 1;') . "\n";
+      if(filemtime(MODX_MANAGER_PATH.'media/style/'.$modx->config["manager_theme"].'/js/modx.js') > filemtime(MODX_MANAGER_PATH.'media/style/'.$modx->config["manager_theme"].'/js/modx.min.js')) $modxJs = 'modx.js';
+      else $modxJs = 'modx.min.js'; // For easier development
       ?>
     </script>
-    <script src="media/style/<?= $modx->config['manager_theme'] ?>/js/modx.min.js?v=<?= $lastInstallTime ?>"></script>
+    <script src="media/style/<?= $modx->config['manager_theme'] ?>/js/<?= $modxJs ?>?v=<?= $lastInstallTime ?>"></script>
     <?php if ($modx->config['show_picker'] != "0") { ?>
         <script src="media/script/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>
         <script src="media/script/spectrum/spectrum.evo.min.js" type="text/javascript"></script>

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -80,6 +80,7 @@ class DocumentParser
     public $sid;
     private $q;
     public $decoded_request_uri;
+    public $ajaxMode = false;
 
     /**
      * Document constructor
@@ -3039,6 +3040,7 @@ class DocumentParser
     function webAlertAndQuit($msg, $url = "")
     {
         global $modx_manager_charset;
+        if($this->ajaxMode === true) $this->jsonResponse(array('error'=>$msg));
         if (substr(strtolower($url), 0, 11) == "javascript:") {
             $fnc = substr($url, 11);
         } elseif ($url) {
@@ -3047,7 +3049,7 @@ class DocumentParser
             $fnc = "history.back(-1);";
         }
         echo "<html><head>
-            <title>MODX :: Alert</title>
+            <title>EVO :: Alert</title>
             <meta http-equiv=\"Content-Type\" content=\"text/html; charset={$modx_manager_charset};\">
             <script>
                 function __alertQuit() {
@@ -6476,6 +6478,25 @@ class DocumentParser
     {
         $this->loadExtension('PHPCOMPAT');
         return $this->phpcompat->htmlspecialchars($str, $flags, $encode);
+    }
+
+    /**
+     * Sets ajaxMode to handle ajax-requests, error-msg etc correctly
+     *
+     * @param boolean $state State of ajaxMode
+     */
+    function setAjaxMode($state) {
+        $this->ajaxMode = $state === true ? true : false;
+    }
+
+    /**
+     * Send array as JSON-object and exit
+     *
+     * @param array $array Array to convert
+     */
+    function jsonResponse($array) {
+        header('content-type: application/json');
+        exit(json_encode($array, JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE));
     }
 
     /**

--- a/manager/media/style/default/js/modx.js
+++ b/manager/media/style/default/js/modx.js
@@ -331,6 +331,49 @@
         modx.search.result.innerHTML = '';
       }
     },
+    ajaxActions: {
+      els: null,
+      init: function() {
+        this.els = w.main.document.querySelectorAll('[data-ajaxaction]');
+        for (var key in this.els) {
+            if (this.els.hasOwnProperty(key)) {
+                this.els[key].onclick = function(e) {
+                    e.preventDefault();
+                    var el = e.target.parentNode;
+                    var action = el.getAttribute('data-ajaxaction');
+                    var id = el.getAttribute('data-id');
+                    var respEl = w.main.document.getElementById(el.getAttribute('data-element'));
+                    modx.post(modx.MODX_MANAGER_URL + 'media/style/default/ajax.php?r='+Math.floor((Math.random()*99999999)+1), {
+                        a: action,
+                        id: id
+                    }, function(resp) {
+                        var data = JSON.parse(resp);
+                        // console.log(respEl, action, data.result);
+                        switch(action) {
+                            case 'publish.res':
+                                if(data.result == 'publish') respEl.classList.remove("unpublished");
+                                else if(data.result == 'unpublish') respEl.classList.add("unpublished");
+                                break;
+                            case 'delete.res':
+                                if(data.result == 'delete') respEl.classList.add("deleted");
+                                else if(data.result == 'undelete') respEl.classList.remove("deleted");
+                                break;
+                        }
+                        if(data.error) {
+                            modx.popup({
+                                type: 'warning',
+                                title: 'EVO :: Alert',
+                                position: 'top center alertQuit',
+                                content: data.error,
+                                wrap: 'body'
+                            });
+                        }
+                    })
+                };
+            }
+        }
+      }
+    },
     main: {
       id: 'main',
       idFrame: 'mainframe',
@@ -345,6 +388,7 @@
         if (modx.config.global_tabs) {
           w.main.document.addEventListener('click', modx.tabs, false);
         }
+        modx.ajaxActions.init();
         w.history.replaceState(null, d.title, modx.getActionFromUrl(w.main.location.search, 2) ? modx.MODX_MANAGER_URL : '#' + w.main.location.search);
         setTimeout('modx.tree.restoreTree()', 100);
       },
@@ -1583,7 +1627,7 @@
             };
             modx.popup({
               type: 'warning',
-              title: 'MODX :: Alert',
+              title: 'EVO :: Alert',
               position: 'top center alertQuit',
               content: message,
               wrap: 'body'
@@ -1967,7 +2011,7 @@
                 if (!!e.target.contentWindow.__alertQuit) {
                   modx.popup({
                     type: 'warning',
-                    title: 'MODX :: Alert',
+                    title: 'EVO :: Alert',
                     position: 'top center alertQuit',
                     content: e.target.contentWindow.document.body.querySelector('p').innerHTML
                   });
@@ -1991,6 +2035,7 @@
                   }
                 }
                 e.target.contentWindow.close = o.close;
+                modx.ajaxActions.init();
                 modx.main.stopWork();
               };
               o.el.lastChild.appendChild(o.frame);

--- a/manager/processors/delete_content.processor.php
+++ b/manager/processors/delete_content.processor.php
@@ -6,7 +6,7 @@ if (!$modx->hasPermission('delete_document')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
-$id = isset($_GET['id'])? intval($_GET['id']) : 0;
+$id = isset($_REQUEST['id'])? intval($_REQUEST['id']) : 0;
 if ($id==0) {
     $modx->webAlertAndQuit($_lang["error_no_id"]);
 }
@@ -123,5 +123,7 @@ $_SESSION['itemname'] = $content['pagetitle'];
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
-header($header);
+if($modx->ajaxMode !== true) {
+	$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
+	header($header);
+}

--- a/manager/processors/publish_content.processor.php
+++ b/manager/processors/publish_content.processor.php
@@ -57,6 +57,7 @@ $_SESSION['itemname'] = $content['pagetitle'];
 // empty cache
 $modx->clearCache('full');
 
-$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
-
-header($header);
+if($modx->ajaxMode !== true) {
+	$header="Location: index.php?a=3&id=$pid&r=1" . $add_path;
+	header($header);
+}

--- a/manager/processors/undelete_content.processor.php
+++ b/manager/processors/undelete_content.processor.php
@@ -90,5 +90,7 @@ $_SESSION['itemname'] = $content['pagetitle'];
 $modx->clearCache('full');
 
 // finished emptying cache - redirect
-$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
-header($header);
+if($modx->ajaxMode !== true) {
+	$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
+	header($header);
+}

--- a/manager/processors/unpublish_content.processor.php
+++ b/manager/processors/unpublish_content.processor.php
@@ -57,6 +57,7 @@ $_SESSION['itemname'] = $content['pagetitle'];
 // empty cache
 $modx->clearCache('full');
 
-$header="Location: index.php?a=3&id=$pid&r=1".$add_path;
-
-header($header);
+if($modx->ajaxMode !== true) {
+	$header="Location: index.php?a=3&id=$pid&r=1" . $add_path;
+	header($header);
+}


### PR DESCRIPTION
Related to #406

- issues with activated "global tabs"
- confirmation-dialog needs to be added

Example usage in welcome.static.php :
```
<a data-ajaxaction="delete.res" data-id="10" data-element="element_id">Delete Resource</a>
<a data-ajaxaction="publish.res" data-id="10" data-element="element_id">Unpublish Resource</a>

<tr id="element_id" class="deleted unpublished">
   <td>...</td>
   <td>...</td>
</tr>
```

@dmi3yy @64j What do you think about this approach? Maybe you have a better idea?