### PR TITLE
[I] Wrap TinyMCE3 Toolbar

### DIFF
--- a/manager/media/style/default/css/custom.css
+++ b/manager/media/style/default/css/custom.css
@@ -313,6 +313,8 @@ ul.mmTagList { float: left; margin-top: .25rem !important }
 #editorRow_TinyMCE tr { border: 1px dotted rgba(0, 0, 0, .05); }
 #editorRow_TinyMCE th { white-space: nowrap }
 #editorRow_TinyMCE th, #editorRow_TinyMCE td { padding: 0.5em; border: none !important }
+/* wrap TinyMCE3 toolbar */
+.mceEditor .mceToolbar td { height: 24px; float: left }
 /* codeMirror */
 .CodeMirror { width: 100%; margin: 0 !important; }
 .CodeMirror pre { word-break: break-all !important; }


### PR DESCRIPTION
For those still using TinyMCE3 this will wrap the toolbar to prevent overflow in container and so it behaves like TinyMCE4.