### PR TITLE
[F] Fix searching main fields with other criteria

### DIFF
--- a/manager/actions/search.static.php
+++ b/manager/actions/search.static.php
@@ -151,12 +151,12 @@ if (isset($_REQUEST['submitok'])) {
 
         if (!ctype_digit($searchfields)) {
             $sqladd .= $sqladd != '' ? ' AND' : '';
-            $sqladd .= " sc.pagetitle LIKE '%{$searchfields}%'";
+            $sqladd .= " (sc.pagetitle LIKE '%{$searchfields}%'";
             $sqladd .= " OR sc.longtitle LIKE '%{$searchlongtitle}%'";
             $sqladd .= " OR sc.description LIKE '%{$searchlongtitle}%'";
             $sqladd .= " OR sc.introtext LIKE '%{$searchlongtitle}%'";
             $sqladd .= " OR sc.menutitle LIKE '%{$searchlongtitle}%'";
-            $sqladd .= " OR sc.alias LIKE '%{$search_alias}%'";
+            $sqladd .= " OR sc.alias LIKE '%{$search_alias}%')";
 			$sqladd .= $articul_id_query;//search by TV
         }
     } else if ($idFromAlias) {


### PR DESCRIPTION
If searching from 'Tools -> Search' using 'main fields' and another search criteria e.g. 'search by content' the WHERE clause was not performing the correct AND between the main fields clauses and other search clause.