### PR TITLE
кёрнинг для светлой темы

### DIFF
--- a/manager/media/style/default/css/tree.css
+++ b/manager/media/style/default/css/tree.css
@@ -44,7 +44,7 @@
 #treeRoot .fa-link { margin-right: 0; font-size: 0.8em }
 #treeRoot #binFull { display: none }
 @media (min-width: 1200px) {
-#tree { font-size: .875rem; letter-spacing: 0.0321em; }
+.dark #tree, .darkness #tree { font-size: .875rem; letter-spacing: 0.0321em; }
 }
 /* modes theme */
 /* lightness */


### PR DESCRIPTION
Межбуквенно расстояние на светлом фоне плохо смотрится, лучше оставить как было до того. А в чёрной прибавлять