### PR TITLE
[I] Add date to active users hit time

### DIFF
--- a/manager/actions/welcome.static.php
+++ b/manager/actions/welcome.static.php
@@ -204,7 +204,7 @@ if($modx->db->getRecordCount($rs) < 1) {
 			$webicon,
 			abs($activeusers['internalKey']),
 			$ip,
-			strftime('%H:%M:%S', $activeusers['lasthit'] + $server_offset_time),
+			strftime($modx->toDateFormat(0,'formatOnly').' %H:%M:%S', $activeusers['lasthit'] + $server_offset_time),
 			$currentaction
 		);
 	}


### PR DESCRIPTION
As idle users can be listed the date is needed as well as the time for last hit in the dashboard 'Online Managers and Members' table