### PR TITLE
Update snippet.docinfo.php

### DIFF
--- a/assets/snippets/docinfo/snippet.docinfo.php
+++ b/assets/snippets/docinfo/snippet.docinfo.php
@@ -27,14 +27,14 @@ $default_field = array('type','contentType','pagetitle','longtitle','description
 $docid = (isset($docid) && (int)$docid>0) ? (int)$docid : $modx->documentIdentifier;
 if(isset($templid) && (int)$templid>=0) {
 	$doc['parent'] = $docid;
-	$limit = (isset($limit) && (int)$limit>=0) ? (int)$limit+1 : 11;
+	$limit = (isset($limit) && (int)$limit>=0) ? (int)$limit : 11;
 	do {
 		$doc = $modx->getDocument($doc['parent'], 'id, parent, template');
 		if($doc === false) return '';
 		if($doc['template'] == (int)$templid) $docid = $doc['id'];
 		$limit--;
 	}
-	while($doc['template'] != (int)$templid && (int)$doc['parent'] > 0 && $limit > 0);
+	while($doc['template'] != (int)$templid && (int)$doc['parent'] > 0 && $limit >= 0);
 	if($doc['template'] != (int)$templid) return '';
 }
 $field = (isset($field)) ? $field : 'pagetitle';

--- a/assets/snippets/docinfo/snippet.docinfo.php
+++ b/assets/snippets/docinfo/snippet.docinfo.php
@@ -3,10 +3,11 @@
  * DocInfo
  *
  * @category  parser
- * @version   0.3
+ * @version   0.4
  * @license     GNU General Public License (GPL), http://www.gnu.org/copyleft/gpl.html
  * @param string $field Значение какого поля необходимо достать
  * @param int $docid ID документа
+ * @param int $templid ID шаблона документа
  * @param int $tv является ли поле TV параметром (0 - нет || 1 - да)
  * @param int $render Преобразовывать ли значение TV параметра в соответствии с его визуальным компонентом
  * @return string Значение поля документа или его TV параметра
@@ -18,10 +19,22 @@
 *       [[DocInfo? &docid=`15` &field=`pagetitle`]]
 *       [[DocInfo? &docid=`10` &field=`tvname`]]
 *       [[DocInfo? &docid=`3` &field=`tvname` &render=`1`]]
+*       [[DocInfo? &docid=`3` &templid=`2` &field=`tvname`]]
 */
 if(!defined('MODX_BASE_PATH')){die('What are you doing? Get out of here!');}
 $default_field = array('type','contentType','pagetitle','longtitle','description','alias','link_attributes','published','pub_date','unpub_date','parent','isfolder','introtext','content','richtext','template','menuindex','searchable','cacheable','createdon','createdby','editedon','editedby','deleted','deletedon','deletedby','publishedon','publishedby','menutitle','donthit','privateweb','privatemgr','content_dispo','hidemenu','alias_visible');
 $docid = (isset($docid) && (int)$docid>0) ? (int)$docid : $modx->documentIdentifier;
+if(isset($templid) && (int)$templid>0) {
+	$doc['parent'] = $docid;
+	$limit = 20;
+	do {
+		$doc = $modx->getDocument($doc['parent'], 'id, parent, template');
+		if($doc['template'] == (int)$templid) $docid = $doc['id'];
+		$limit--;
+	}
+	while($doc['template'] != (int)$templid && (int)$doc['parent'] > 0 && $limit > 0);
+	if($doc['template'] != (int)$templid) return '';
+}
 $field = (isset($field)) ? $field : 'pagetitle';
 $render = (isset($render)) ? $render : 0;
 $output = '';

--- a/assets/snippets/docinfo/snippet.docinfo.php
+++ b/assets/snippets/docinfo/snippet.docinfo.php
@@ -3,11 +3,12 @@
  * DocInfo
  *
  * @category  parser
- * @version   0.4
+ * @version   0.5
  * @license     GNU General Public License (GPL), http://www.gnu.org/copyleft/gpl.html
  * @param string $field Значение какого поля необходимо достать
  * @param int $docid ID документа
  * @param int $templid ID шаблона документа
+ * @param int $limit Максимальная глубина вложенности для поиска по шаблону документа
  * @param int $tv является ли поле TV параметром (0 - нет || 1 - да)
  * @param int $render Преобразовывать ли значение TV параметра в соответствии с его визуальным компонентом
  * @return string Значение поля документа или его TV параметра
@@ -19,16 +20,17 @@
 *       [[DocInfo? &docid=`15` &field=`pagetitle`]]
 *       [[DocInfo? &docid=`10` &field=`tvname`]]
 *       [[DocInfo? &docid=`3` &field=`tvname` &render=`1`]]
-*       [[DocInfo? &docid=`3` &templid=`2` &field=`tvname`]]
+*       [[DocInfo? &docid=`3` &templid=`2` &field=`tvname` &limit=`2`]]
 */
 if(!defined('MODX_BASE_PATH')){die('What are you doing? Get out of here!');}
 $default_field = array('type','contentType','pagetitle','longtitle','description','alias','link_attributes','published','pub_date','unpub_date','parent','isfolder','introtext','content','richtext','template','menuindex','searchable','cacheable','createdon','createdby','editedon','editedby','deleted','deletedon','deletedby','publishedon','publishedby','menutitle','donthit','privateweb','privatemgr','content_dispo','hidemenu','alias_visible');
 $docid = (isset($docid) && (int)$docid>0) ? (int)$docid : $modx->documentIdentifier;
-if(isset($templid) && (int)$templid>0) {
+if(isset($templid) && (int)$templid>=0) {
 	$doc['parent'] = $docid;
-	$limit = 20;
+	$limit = (isset($limit) && (int)$limit>=0) ? (int)$limit+1 : 11;
 	do {
 		$doc = $modx->getDocument($doc['parent'], 'id, parent, template');
+		if($doc === false) return '';
 		if($doc['template'] == (int)$templid) $docid = $doc['id'];
 		$limit--;
 	}
@@ -51,4 +53,3 @@ if (in_array($field, $default_field)) {
     }
 }
 return $output;
-?>

--- a/assets/snippets/docinfo/snippet.docinfo.php
+++ b/assets/snippets/docinfo/snippet.docinfo.php
@@ -27,7 +27,7 @@ $default_field = array('type','contentType','pagetitle','longtitle','description
 $docid = (isset($docid) && (int)$docid>0) ? (int)$docid : $modx->documentIdentifier;
 if(isset($templid) && (int)$templid>=0) {
 	$doc['parent'] = $docid;
-	$limit = (isset($limit) && (int)$limit>=0) ? (int)$limit : 11;
+	$limit = (isset($limit) && (int)$limit>=0) ? (int)$limit : 10;
 	do {
 		$doc = $modx->getDocument($doc['parent'], 'id, parent, template');
 		if($doc === false) return '';


### PR DESCRIPTION
Imagine you have a catalog of products, which are graded by categories. Categories are represented by parental documents. And you need to show the name of the category (or other parent's TV's) on the product's page. You can't use &docid of the DocInfo snippet in the product's template, because ID is different for different categories, but the template is only one.

With the new parameter &templid you can get field's value of the document, which has the template's ID set to the &templid. Script finds that document among all parents of &docid - beginning from document with &docid and upper and upper.

books (catalog - id: 1, template: 1)
--romance (category - id: 2, template: 2)
----book1 (product - template: 4)
----book2 (product - template: 4)
--fantasy (category - id: 3, template: 2)
----for children (subcategory - id: 5, template: 3)
------book5 (product - template: 4)
----book3 (product - template: 4)
----book4 (product - template: 4)
--thriller (category - id: 4, template: 2)

In the template with ID 4 (for book) we can get `pagetitle` of categories:

[[DocInfo? &templid=`2`]]
it will return "romance" for the book1 and book2, "fantasy" for the book3, book4 and book5! (subcategory "for children" hasn't template's ID = 2)

To get any TV of category:
[[DocInfo? &templid=`2` &field=`tvname`]]

The same in the chunk with placeholders (for example, DocLister's template):
[[DocInfo? &docid=`[+id+]` &templid=`2` &field=`tvname`]]
Note you don't need to add the field `tvname` to the &tvList in the DL call for using in the DocInfo only.