### PR TITLE
Create snippet.DocCount.php

### DIFF
--- a/assets/snippets/DocCount/snippet.DocCount.php
+++ b/assets/snippets/DocCount/snippet.DocCount.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * DocCount
+ *
+ * @category  counter
+ * @version   1.0.0
+ * @license   GNU General Public License (GPL), http://www.gnu.org/copyleft/gpl.html
+ * @param int $parent ID документа родителя
+ * @param int $depth глубина вложенности (<0, 0, >9 == 10, максимум)
+ * @param int $published Какие документы считать (0 - неопубликованные || 1 - опубликованные || 2 - все)
+ * @param int $deleted Какие документы считать (0 - неудалённые || 1 - удалённые || 2 - все)
+ * @return int Количество дочерних документов
+ * @author kanstudio <kanstudio@mail.ru>
+ * 
+ * @example
+ *       [[DocCount? &parent=`[*id*]` &depth=`1` &published=`1` &deleted=`0`]] == [[DocCount]]
+ *       [[DocCount? &depth=`0` &published=`2` &deleted=`2`]]
+ */
+if(!defined('MODX_BASE_PATH')){die('What are you doing? Get out of here!');}
+
+$parent = (isset($parent) && (int)$parent>=0) ? (int)$parent : $modx->documentIdentifier;
+$depth = isset($depth) ? (((int)$depth>0 && (int)$depth<10) ? (int)$depth : 10) : 1;
+$published = isset($published) ? (((int)$published==0 || (int)$published==1) ? ' AND published = '.$published : '') : ' AND published = 1';
+$deleted = isset($deleted) ? (((int)$deleted==0 || (int)$deleted==1) ? ' AND deleted = '.$deleted : '') : ' AND deleted = 0';
+
+$tblsc = $modx->getFullTableName('site_content');
+$r = $modx->db->select("id", "{$tblsc}", "type = 'document'".$published.$deleted);
+$rArray = $modx->db->makeArray($r);
+
+if($parent == 0 && $depth == 10) return count($rArray);
+
+$cArray = $modx->aliasListing;
+$result = array_filter($rArray, function($doc) use ($parent, $depth, $cArray) {
+	for($d = $depth, $k = (int)$doc['id']; $d > 0 && $k > 0; $d--) {
+		if($cArray[$k]['parent'] == $parent) return true;
+		else $k = $cArray[$k]['parent'];
+	}
+    return false;
+});
+
+return count($result);

--- a/assets/snippets/DocCount/snippet.DocCount.php
+++ b/assets/snippets/DocCount/snippet.DocCount.php
@@ -3,28 +3,28 @@
  * DocCount
  *
  * @category  counter
- * @version   1.0.0
+ * @version   1.1.0
  * @license   GNU General Public License (GPL), http://www.gnu.org/copyleft/gpl.html
  * @param int $parent ID документа родителя
+ * @param string $templates ID шаблонов дочерних документов, несколько через запятую
  * @param int $depth глубина вложенности (<0, 0, >9 == 10, максимум)
  * @param int $published Какие документы считать (0 - неопубликованные || 1 - опубликованные || 2 - все)
- * @param int $deleted Какие документы считать (0 - неудалённые || 1 - удалённые || 2 - все)
  * @return int Количество дочерних документов
  * @author kanstudio <kanstudio@mail.ru>
  * 
  * @example
- *       [[DocCount? &parent=`[*id*]` &depth=`1` &published=`1` &deleted=`0`]] == [[DocCount]]
- *       [[DocCount? &depth=`0` &published=`2` &deleted=`2`]]
+ *       [[DocCount? &parent=`[*id*]` &templates=`0` &depth=`1` &published=`1`]] == [[DocCount]]
+ *       [[DocCount? &depth=`0` &templates=`2,3` &published=`2`]]
  */
 if(!defined('MODX_BASE_PATH')){die('What are you doing? Get out of here!');}
 
 $parent = (isset($parent) && (int)$parent>=0) ? (int)$parent : $modx->documentIdentifier;
+$templates = (isset($templates) && (int)$templates!=0) ? ' AND ('.preg_replace('/\s*,\s*/', " OR ", preg_replace('/(\d+)/', "template = $1", $templates)).')' : '';
 $depth = isset($depth) ? (((int)$depth>0 && (int)$depth<10) ? (int)$depth : 10) : 1;
 $published = isset($published) ? (((int)$published==0 || (int)$published==1) ? ' AND published = '.$published : '') : ' AND published = 1';
-$deleted = isset($deleted) ? (((int)$deleted==0 || (int)$deleted==1) ? ' AND deleted = '.$deleted : '') : ' AND deleted = 0';
 
 $tblsc = $modx->getFullTableName('site_content');
-$r = $modx->db->select("id", "{$tblsc}", "type = 'document'".$published.$deleted);
+$r = $modx->db->select("id", "{$tblsc}", "type = 'document'".$published.$templates);
 $rArray = $modx->db->makeArray($r);
 
 if($parent == 0 && $depth == 10) return count($rArray);


### PR DESCRIPTION
The new snippet, which counts a number of daughter documents. It's well suited for a little web store.
Available parameters:
&parent - ID of the parent document
&templates - IDs of the daughter document templates
&depth - nesting level (<0, 0, >9 == 10, max)
&published - which documents will be counted (0 - unpublished || 1 - published || 2 - all)

What about speed - snippet does only 1 query to database with any &depth values!

Examples:
```
[[DocCount? &parent=`[*id*]` &templates=`0` &depth=`1` &published=`1`]]  // default values
[[DocCount]]  // will return the same as the previous example
[[DocCount? &templates=`2,3,5` &depth=`0` &published=`2`]]  // will return the count 
of all children with template IDs 2,3 or 5 of the current document.
```

And I recommend this snippet for using with <@SYNTAX>, when you need to display some HTML in case the daughter documents exist and are published.