### PR TITLE
Update config.inc.tpl

### DIFF
--- a/install/config.inc.tpl
+++ b/install/config.inc.tpl
@@ -131,7 +131,9 @@ if (!empty($site_hostnames[0]) && !in_array($site_hostname, $site_hostnames)) {
 // assign site_url
 if (!defined('MODX_SITE_URL')) {
     $secured = (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
-    $site_url = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port || $secured) ? 'https://' : 'http://';
+//  $site_url = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port || $secured) ? 'https://' : 'http://';
+    $site_url = ((isset ($_SERVER['HTTPS']) && ( (strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS']) == '1')) || $_SERVER['SERVER_PORT'] == $https_port || $secured) ? 'https://' : 'http://';
+  
     $site_url .= $site_hostname;
     if ($_SERVER['SERVER_PORT'] != 80) {
         $site_url = str_replace(':' . $_SERVER['SERVER_PORT'], '', $site_url);


### PR DESCRIPTION
На одном из хостингов столкнулся с тем, что параметр $_SERVER['HTTPS'] равен не "оn", а 1. Из-за этого неправильно инициализировался $site_url, (http вместо https), и из-за этого в админке вообще ничего не возможно было сделать, так как вылезали бесконечные ошибки и алерты. Проблема решилась именно добавлением этой одной строчки в config.inc.php.