### PR TITLE
SQL syntax for mysql 8

### DIFF
--- a/manager/actions/mutate_tv_rank.dynamic.php
+++ b/manager/actions/mutate_tv_rank.dynamic.php
@@ -34,7 +34,7 @@ if (isset($_POST['listSubmitted'])) {
     $modx->clearCache('full');
 }
 
-$rs = $modx->db->select("name, caption, id, rank", $tbl_site_tmplvars, "", "rank ASC, id ASC");
+$rs = $modx->db->select("`name`,`caption`,`id`,`rank`", $tbl_site_tmplvars, "", "`rank` ASC, `id` ASC");
 
 if ($modx->db->getRecordCount($rs)) {
     $sortableList = '<div class="clearfix"><ul id="sortlist" class="sortableList">';


### PR DESCRIPTION
Execution of a query to the database failed - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM `evo`.`ihlo_site_tmplvars` ORDER BY rank ASC, id ASC' at line 1