### PR TITLE
SQL syntax for mysql 8

### DIFF
--- a/manager/processors/duplicate_template.processor.php
+++ b/manager/processors/duplicate_template.processor.php
@@ -32,9 +32,9 @@ $modx->db->insert(
 	array(
 		'tmplvarid'=>'',
 		'templateid'=>'',
-		'rank'=>'',
+		'`rank`'=>'',
 		), $modx->getFullTableName('site_tmplvar_templates'), // Insert into
-	"tmplvarid, '{$newid}', rank", $modx->getFullTableName('site_tmplvar_templates'), "templateid='{$id}'"); // Copy from
+	"tmplvarid, '{$newid}', `rank`", $modx->getFullTableName('site_tmplvar_templates'), "templateid='{$id}'"); // Copy from
 
 // Set the item name for logger
 $name = $modx->db->getValue($modx->db->select('templatename', $modx->getFullTableName('site_templates'), "id='{$newid}'"));


### PR DESCRIPTION
Execution of a query to the database failed - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM `radmir`.`kqnr_site_tmplvar_templates` WHERE templateid='27'' at line 1