### PR TITLE
Связал стили иконок для обычных и web-пользователей в меню и в разделах

### DIFF
--- a/core/src/Controllers/Frame.php
+++ b/core/src/Controllers/Frame.php
@@ -725,7 +725,7 @@ class Frame extends AbstractController implements ManagerTheme\PageControllerInt
                 'manager_permissions',
                 'users',
                 sprintf(
-                    '<i class="fa fa-male"></i>%s'
+                    '<i class="fa fa-universal-access"></i>%s'
                     , $this->managerTheme->getLexicon('manager_permissions')
                 ),
                 'index.php?a=40',
@@ -751,7 +751,7 @@ class Frame extends AbstractController implements ManagerTheme\PageControllerInt
         $this->sitemenu['web_permissions'] = [
             'web_permissions',
             'users',
-            '<i class="fa fa-universal-access"></i>' . $this->managerTheme->getLexicon('web_permissions'),
+            '<i class="fa fa-male"></i>' . $this->managerTheme->getLexicon('web_permissions'),
             'index.php?a=91',
             $this->managerTheme->getLexicon('web_permissions'),
             '',

--- a/manager/actions/mutate_user.dynamic.php
+++ b/manager/actions/mutate_user.dynamic.php
@@ -248,7 +248,7 @@ if($usersettings['which_browser'] === 'default') {
 	<input type="hidden" name="blockedmode" value="<?php echo ($userdata['blocked'] == 1 || ($userdata['blockeduntil'] > time() && $userdata['blockeduntil'] != 0) || ($userdata['blockedafter'] < time() && $userdata['blockedafter'] != 0) || $userdata['failedlogins'] > 3) ? "1" : "0" ?>" />
 
 	<h1>
-        <i class="fa fa fa-user"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['user_title']) ?>
+        <i class="fa fa-user-circle-o"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['user_title']) ?>
     </h1>
 
 	<?=ManagerTheme::getStyle('actionbuttons.dynamic.user') ?>

--- a/manager/actions/mutate_web_user.dynamic.php
+++ b/manager/actions/mutate_web_user.dynamic.php
@@ -229,7 +229,7 @@ $displayStyle = ($_SESSION['browser'] === 'modern') ? 'table-row' : 'block';
 	<input type="hidden" name="blockedmode" value="<?php echo ($userdata['blocked'] == 1 || ($userdata['blockeduntil'] > time() && $userdata['blockeduntil'] != 0) || ($userdata['blockedafter'] < time() && $userdata['blockedafter'] != 0) || $userdata['failedlogins'] > 3) ? "1" : "0" ?>" />
 
 	<h1>
-        <i class="fa fa fa-users"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['web_user_title']) ?>
+        <i class="fa fa-user"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['web_user_title']) ?>
     </h1>
 
 	<?= ManagerTheme::getStyle('actionbuttons.dynamic.user') ?>
@@ -257,7 +257,7 @@ $displayStyle = ($_SESSION['browser'] === 'modern') ? 'table-row' : 'block';
 						<tr id="showname" style="display: <?php echo ($modx->getManagerApi()->action == '88' && (!isset($usernamedata['oldusername']) || $usernamedata['oldusername'] == $usernamedata['username'])) ? $displayStyle : 'none'; ?> ">
                             <th><?php echo $_lang['username']; ?>:</th>
                             <td>&nbsp;</td>
-                            <td><i class="<?php echo $_style["icons_user"] ?>"></i>&nbsp;<b><?php echo $modx->getPhpCompat()->htmlspecialchars(!empty($usernamedata['oldusername']) ? $usernamedata['oldusername'] : $usernamedata['username']); ?></b> - <span class="comment"><a href="javascript:;" onClick="changeName();return false;"><?php echo $_lang["change_name"]; ?></a></span>
+                            <td><i class="<?php echo $_style["icons_web_user"] ?>"></i>&nbsp;<b><?php echo $modx->getPhpCompat()->htmlspecialchars(!empty($usernamedata['oldusername']) ? $usernamedata['oldusername'] : $usernamedata['username']); ?></b> - <span class="comment"><a href="javascript:;" onClick="changeName();return false;"><?php echo $_lang["change_name"]; ?></a></span>
                             	<input type="hidden" name="oldusername" value="<?php echo $modx->getPhpCompat()->htmlspecialchars(!empty($usernamedata['oldusername']) ? $usernamedata['oldusername'] : $usernamedata['username']); ?>" />
 							</td>
 						</tr>

--- a/manager/actions/user_management.static.php
+++ b/manager/actions/user_management.static.php
@@ -94,7 +94,7 @@ echo $cm->render();
 	<input type="hidden" name="op" value="" />
 
 	<h1>
-		<i class="fa fa fa-user"></i><?= $_lang['user_management_title'] ?><i class="fa fa-question-circle help"></i>
+		<i class="fa fa-user-circle-o"></i><?= $_lang['user_management_title'] ?><i class="fa fa-question-circle help"></i>
 	</h1>
 
 	<div class="container element-edit-message">

--- a/manager/actions/web_user_management.static.php
+++ b/manager/actions/web_user_management.static.php
@@ -94,7 +94,7 @@ echo $cm->render();
 	<input type="hidden" name="op" value="" />
 
 	<h1>
-		<i class="fa fa-users"></i><?= $_lang['web_user_management_title'] ?><i class="fa fa-question-circle help"></i>
+		<i class="fa fa-user"></i><?= $_lang['web_user_management_title'] ?><i class="fa fa-question-circle help"></i>
 	</h1>
 
 	<div class="container element-edit-message">
@@ -131,7 +131,7 @@ echo $cm->render();
 					$grd->columns = $_lang["icon"] . " ," . $_lang["name"] . " ," . $_lang["user_full_name"] . " ," . $_lang["email"] . " ," . $_lang["user_prevlogin"] . " ," . $_lang["user_logincount"] . " ," . $_lang["user_block"];
 					$grd->colWidths = "1%,,,,1%,1%,1%";
 					$grd->colAligns = "center,,,,right' nowrap='nowrap,right,center";
-					$grd->colTypes = "template:<a class='gridRowIcon' href='javascript:;' onclick='return showContentMenu([+id+],event);' title='" . $_lang["click_to_context"] . "'><i class='" . $_style["icons_user"] . "'></i></a>||template:<a href='index.php?a=88&id=[+id+]' title='" . $_lang["click_to_edit_title"] . "'>[+value+]</a>||template:[+fullname+]||template:[+email+]||date: " . $modx->toDateFormat('[+thislogin+]', 'formatOnly') .
+					$grd->colTypes = "template:<a class='gridRowIcon' href='javascript:;' onclick='return showContentMenu([+id+],event);' title='" . $_lang["click_to_context"] . "'><i class='" . $_style["icons_web_user"] . "'></i></a>||template:<a href='index.php?a=88&id=[+id+]' title='" . $_lang["click_to_edit_title"] . "'>[+value+]</a>||template:[+fullname+]||template:[+email+]||date: " . $modx->toDateFormat('[+thislogin+]', 'formatOnly') .
 					" %H:%M";
 					if($listmode == '1') {
 						$grd->pageSize = 0;

--- a/manager/media/style/default/style.php
+++ b/manager/media/style/default/style.php
@@ -182,7 +182,8 @@ $_style['icons_modules']            = 'fa fa-cubes'; //$style_path.'icons/module
 $_style['icons_run']                = $style_path.'icons/play.png';
 
 //users and webusers
-$_style['icons_user']               = 'fa fa-user'; //$style_path.'icons/user.png';
+$_style['icons_user']               = 'fa fa-user-circle-o'; //$style_path.'icons/user.png';
+$_style['icons_web_user']               = 'fa fa-user'; //$style_path.'icons/user.png';
 
 //Messages
 $_style['icons_message_unread']     = $style_path.'icons/email.png';

--- a/manager/views/page/access_permissions.blade.php
+++ b/manager/views/page/access_permissions.blade.php
@@ -21,7 +21,7 @@
         </script>
     @endpush
     <h1>
-        <i class="fa fa-male"></i>{{ $_lang['mgr_access_permissions'] }}<i class="fa fa-question-circle help"></i>
+        <i class="fa fa-universal-access"></i>{{ $_lang['mgr_access_permissions'] }}<i class="fa fa-question-circle help"></i>
     </h1>
 
     <div class="container element-edit-message">

--- a/manager/views/page/web_access_permissions.blade.php
+++ b/manager/views/page/web_access_permissions.blade.php
@@ -21,7 +21,7 @@
         </script>
     @endpush
     <h1>
-        <i class="fa fa-universal-access"></i>{{ $_lang['web_access_permissions'] }}<i class="fa fa-question-circle help"></i>
+        <i class="fa fa-male"></i>{{ $_lang['web_access_permissions'] }}<i class="fa fa-question-circle help"></i>
     </h1>
 
     <div class="container element-edit-message">


### PR DESCRIPTION
В меню и в разделах иконки пользователей были без визуальной логики, и повторялись.

Теперь логика появилась: "иконки пользователей в кружке" - меню и разделы для пользователей. Простые "иконки пользователей" - меню и разделы для веб-пользователей.

Пример для пользователей (для веб-пользователей по аналогии):

![icons_1](https://user-images.githubusercontent.com/12523676/62077780-0315b380-b25c-11e9-9b31-c694a7c5569b.png)
![icons_2](https://user-images.githubusercontent.com/12523676/62077781-0315b380-b25c-11e9-907f-54a2fb5cb144.png)
![icons_3](https://user-images.githubusercontent.com/12523676/62077783-03ae4a00-b25c-11e9-81e5-9002faee0965.png)
![icons_4](https://user-images.githubusercontent.com/12523676/62077784-03ae4a00-b25c-11e9-9f83-dfb6263c89f1.png)



