### PR TITLE
1.4.9 Связал стили иконок для обычных и web-пользователей в меню и в разделах

### DIFF
--- a/manager/actions/access_permissions.dynamic.php
+++ b/manager/actions/access_permissions.dynamic.php
@@ -62,7 +62,7 @@ if($modx->db->getRecordCount($rs) < 1) {
 </script>
 
 <h1>
-	<i class="fa fa-male"></i><?= $_lang['mgr_access_permissions']; ?><i class="fa fa-question-circle help"></i>
+	<i class="fa fa-universal-access"></i><?= $_lang['mgr_access_permissions']; ?><i class="fa fa-question-circle help"></i>
 </h1>
 
 <div class="container element-edit-message">

--- a/manager/actions/mutate_user.dynamic.php
+++ b/manager/actions/mutate_user.dynamic.php
@@ -215,7 +215,7 @@ if($which_browser == 'default') {
 	<input type="hidden" name="blockedmode" value="<?php echo ($userdata['blocked'] == 1 || ($userdata['blockeduntil'] > time() && $userdata['blockeduntil'] != 0) || ($userdata['blockedafter'] < time() && $userdata['blockedafter'] != 0) || $userdata['failedlogins'] > 3) ? "1" : "0" ?>" />
 
 	<h1>
-        <i class="fa fa fa-user"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['user_title']) ?>
+        <i class="fa fa-user-circle-o"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['user_title']) ?>
     </h1>
 
 	<?php echo $_style['actionbuttons']['dynamic']['user'] ?>

--- a/manager/actions/mutate_web_user.dynamic.php
+++ b/manager/actions/mutate_web_user.dynamic.php
@@ -201,7 +201,7 @@ $displayStyle = ($_SESSION['browser'] === 'modern') ? 'table-row' : 'block';
 	<input type="hidden" name="blockedmode" value="<?php echo ($userdata['blocked'] == 1 || ($userdata['blockeduntil'] > time() && $userdata['blockeduntil'] != 0) || ($userdata['blockedafter'] < time() && $userdata['blockedafter'] != 0) || $userdata['failedlogins'] > 3) ? "1" : "0" ?>" />
 
 	<h1>
-        <i class="fa fa fa-users"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['web_user_title']) ?>
+        <i class="fa fa-user"></i><?= ($usernamedata['username'] ? $usernamedata['username'] . '<small>(' . $usernamedata['id'] . ')</small>' : $_lang['web_user_title']) ?>
     </h1>
 
 	<?php echo $_style['actionbuttons']['dynamic']['user'] ?>
@@ -229,7 +229,7 @@ $displayStyle = ($_SESSION['browser'] === 'modern') ? 'table-row' : 'block';
 						<tr id="showname" style="display: <?php echo ($modx->manager->action == '88' && (!isset($usernamedata['oldusername']) || $usernamedata['oldusername'] == $usernamedata['username'])) ? $displayStyle : 'none'; ?> ">
 							<th><?php echo $_lang['username']; ?>:</th>
 							<td>&nbsp;</td>
-							<td><i class="<?php echo $_style["icons_user"] ?>"></i>&nbsp;<b><?php echo $modx->htmlspecialchars(!empty($usernamedata['oldusername']) ? $usernamedata['oldusername'] : $usernamedata['username']); ?></b> - <span class="comment"><a href="javascript:;" onClick="changeName();return false;"><?php echo $_lang["change_name"]; ?></a></span>
+							<td><i class="<?php echo $_style["icons_web_user"] ?>"></i>&nbsp;<b><?php echo $modx->htmlspecialchars(!empty($usernamedata['oldusername']) ? $usernamedata['oldusername'] : $usernamedata['username']); ?></b> - <span class="comment"><a href="javascript:;" onClick="changeName();return false;"><?php echo $_lang["change_name"]; ?></a></span>
 								<input type="hidden" name="oldusername" value="<?php echo $modx->htmlspecialchars(!empty($usernamedata['oldusername']) ? $usernamedata['oldusername'] : $usernamedata['username']); ?>" />
 							</td>
 						</tr>

--- a/manager/actions/user_management.static.php
+++ b/manager/actions/user_management.static.php
@@ -95,7 +95,7 @@ echo $cm->render();
 	<input type="hidden" name="op" value="" />
 
 	<h1>
-		<i class="fa fa fa-user"></i><?= $_lang['user_management_title'] ?><i class="fa fa-question-circle help"></i>
+		<i class="fa fa-user-circle-o"></i><?= $_lang['user_management_title'] ?><i class="fa fa-question-circle help"></i>
 	</h1>
 
 	<div class="container element-edit-message">

--- a/manager/actions/web_access_permissions.dynamic.php
+++ b/manager/actions/web_access_permissions.dynamic.php
@@ -53,7 +53,7 @@ if($modx->db->getRecordCount($rs) < 1) {
 </script>
 
 <h1>
-	<i class="fa fa-universal-access"></i><?= $_lang['web_access_permissions'] ?><i class="fa fa-question-circle help"></i>
+	<i class="fa fa-male"></i><?= $_lang['web_access_permissions'] ?><i class="fa fa-question-circle help"></i>
 </h1>
 
 <div class="container element-edit-message">

--- a/manager/actions/web_user_management.static.php
+++ b/manager/actions/web_user_management.static.php
@@ -95,7 +95,7 @@ echo $cm->render();
 	<input type="hidden" name="op" value="" />
 
 	<h1>
-		<i class="fa fa-users"></i><?= $_lang['web_user_management_title'] ?><i class="fa fa-question-circle help"></i>
+		<i class="fa fa-user"></i><?= $_lang['web_user_management_title'] ?><i class="fa fa-question-circle help"></i>
 	</h1>
 
 	<div class="container element-edit-message">
@@ -133,7 +133,7 @@ echo $cm->render();
 					$grd->columns = $_lang["icon"] . " ," . $_lang["name"] . " ," . $_lang["user_full_name"] . " ," . $_lang["email"] . " ," . $_lang["user_prevlogin"] . " ," . $_lang["user_logincount"] . " ," . $_lang["user_block"];
 					$grd->colWidths = "1%,,,,1%,1%,1%";
 					$grd->colAligns = "center,,,,right' nowrap='nowrap,right,center";
-					$grd->colTypes = "template:<a class='gridRowIcon' href='javascript:;' onclick='return showContentMenu([+id+],event);' title='" . $_lang["click_to_context"] . "'><i class='" . $_style["icons_user"] . "'></i></a>||template:<a href='index.php?a=88&id=[+id+]' title='" . $_lang["click_to_edit_title"] . "'>[+value+]</a>||template:[+fullname+]||template:[+email+]||date: " . $modx->toDateFormat('[+thislogin+]', 'formatOnly') . 
+					$grd->colTypes = "template:<a class='gridRowIcon' href='javascript:;' onclick='return showContentMenu([+id+],event);' title='" . $_lang["click_to_context"] . "'><i class='" . $_style["icons_web_user"] . "'></i></a>||template:<a href='index.php?a=88&id=[+id+]' title='" . $_lang["click_to_edit_title"] . "'>[+value+]</a>||template:[+fullname+]||template:[+email+]||date: " . $modx->toDateFormat('[+thislogin+]', 'formatOnly') . 
 					" %H:%M";
 					if($listmode == '1') {
 						$grd->pageSize = 0;

--- a/manager/frames/mainmenu.php
+++ b/manager/frames/mainmenu.php
@@ -306,7 +306,7 @@ if($modx->hasPermission('access_permissions')) {
 	$sitemenu['manager_permissions'] = array(
 		'manager_permissions',
 		'users',
-		'<i class="fa fa-male"></i>' . $_lang['manager_permissions'],
+		'<i class="fa fa-universal-access"></i>' . $_lang['manager_permissions'],
 		'index.php?a=40',
 		$_lang['manager_permissions'],
 		'',
@@ -322,7 +322,7 @@ if($modx->hasPermission('web_access_permissions')) {
 	$sitemenu['web_permissions'] = array(
 		'web_permissions',
 		'users',
-		'<i class="fa fa-universal-access"></i>' . $_lang['web_permissions'],
+		'<i class="fa fa-male"></i>' . $_lang['web_permissions'],
 		'index.php?a=91',
 		$_lang['web_permissions'],
 		'',

--- a/manager/media/style/default/style.php
+++ b/manager/media/style/default/style.php
@@ -218,7 +218,8 @@ $_style['icons_modules']            = 'fa fa-cubes'; //$style_path.'icons/module
 $_style['icons_run']                = $style_path.'icons/play.png';
 
 //users and webusers
-$_style['icons_user']               = 'fa fa-user'; //$style_path.'icons/user.png';
+$_style['icons_user']               = 'fa fa-user-circle-o'; //$style_path.'icons/user.png';
+$_style['icons_web_user']           = 'fa fa-user'; //$style_path.'icons/user.png';
 
 //Messages
 $_style['icons_message_unread']     = $style_path.'icons/email.png';


### PR DESCRIPTION
В меню и в разделах иконки пользователей были без визуальной логики, и повторялись.

Теперь логика появилась: "иконки пользователей в кружке" - меню и разделы для менеджеров. Простые "иконки пользователей" - меню и разделы для веб-пользователей.

Пример для менеджеров (для веб-пользователей по аналогии):

![user_1](https://user-images.githubusercontent.com/12523676/62220825-bc41ce00-b3c1-11e9-8305-56f110d2a545.png)
![user_2](https://user-images.githubusercontent.com/12523676/62220826-bc41ce00-b3c1-11e9-9b15-6c26a99c7c5a.png)
![user_3](https://user-images.githubusercontent.com/12523676/62220827-bcda6480-b3c1-11e9-86e0-6d3c44f9b477.png)
![user_4](https://user-images.githubusercontent.com/12523676/62220828-bcda6480-b3c1-11e9-98fc-932cc6989888.png)



