### PR TITLE
1.4.9 Заменил иконку на правильную в разделе "Сортировать категории"

### DIFF
--- a/manager/actions/category_mgr/skin/sort.tpl.phtml
+++ b/manager/actions/category_mgr/skin/sort.tpl.phtml
@@ -22,7 +22,7 @@
                 foreach ($data as $category): ?>
                     <tr id="item_<?= $category['id'] ?>">
                         <td>
-                            <i class="fa fa-list-alt"></i> <?= $category['category'] ?>
+                            <i class="fa fa-object-group"></i> <?= $category['category'] ?>
                             <input type="hidden" class="sort" name="<?= $view->get('request_key') ?>[sort][data][<?= $category['id'] ?>][rank]" value="<?= $category['rank'] ?>" />
                             <input type="hidden" name="<?= $view->get('request_key') ?>[sort][data][<?= $category['id'] ?>][id]" value="<?= $category['id'] ?>" />
                             <input type="hidden" name="<?= $view->get('request_key') ?>[sort][data][<?= $category['id'] ?>][category]" value="<?= urlencode($category['category']) ?>" />


### PR DESCRIPTION
Там стояла иконка TV, что смущает.

Было:
![before](https://user-images.githubusercontent.com/12523676/62163413-56a30280-b32b-11e9-819e-b0e39ca6a9ce.png)

Стало:
![after](https://user-images.githubusercontent.com/12523676/62163412-56a30280-b32b-11e9-9c38-316443590fd0.png)