### PR TITLE
eventlog wrap link

### DIFF
--- a/manager/actions/eventlog.dynamic.php
+++ b/manager/actions/eventlog.dynamic.php
@@ -134,7 +134,7 @@ echo $cm->render();
 					$grd->pageClass = 'page-item';
 					$grd->selPageClass = 'page-item active';
 					$grd->noRecordMsg = $_lang['no_records_found'];
-					$grd->cssClass = "table data nowrap";
+					$grd->cssClass = "table data nowrap eventlog";
 					$grd->columnHeaderClass = "tableHeader";
 					$grd->itemClass = "tableItem";
 					$grd->altItemClass = "tableAltItem";

--- a/manager/media/style/default/css/custom.css
+++ b/manager/media/style/default/css/custom.css
@@ -154,6 +154,7 @@ table.actionButtons .searchtext { padding: 5px; height: 24px; width: 150px; }
 .table.data .actions .disabled { visibility: hidden }
 /* table-data-nowrap */
 .table.data.nowrap th, .table.data.nowrap td { white-space: nowrap }
+.table.data.nowrap.eventlog a, .table.data.nowrap.eventlog span { float: left; padding-right: 5px; white-space: normal }
 /* table-data-sortable */
 .table.data thead .sortable a, .table.data thead .sortable-text a { color: #777; text-decoration: none !important; }
 .table.data thead .sortable a:hover, .table.data thead .sortable-text a:hover { color: #222 }


### PR DESCRIPTION
Когда в "Просмотре событий" становится много станиц, то благодаря классу nowrap таблица растягивается до невероятных размеров в ширину. Добавил стили чтобы номера страниц и код события переносились.

![image](https://user-images.githubusercontent.com/837429/63778574-1e74ec80-c8f6-11e9-9563-8169d4648f31.png)
