### PR TITLE
Исправил вывод настроек tinyMCE

### DIFF
--- a/assets/plugins/tinymce4/gsettings/gsettings.body.inc.html
+++ b/assets/plugins/tinymce4/gsettings/gsettings.body.inc.html
@@ -1,20 +1,17 @@
-<style type="text/css">
-textarea.mce {width:95%;height:53px;display:block;}
-#editorRow_TinyMCE {width:99%;}
-#editorRow_TinyMCE #editorRow_TinyMCE th {width:220px;margin-left:25px;}
-#editorRow_TinyMCE td,#editorRow_TinyMCE th {border-bottom:1px dotted #ccc;}
+<div class="row form-row form-element-input settings editorRow">
+  <div class="col-12 col-md-12 col-lg-12">
+      <h1>[+editorLogo+] [+editorLabel+] [+settings+] <b style="float: right;">v[+editorVersion+]</b></h1>
+  </div>
+</div>
 
-</style>
-<table id="editorRow_TinyMCE" class="settings editorRow">
-  <tr class="row1" style="display: [+display+];">
-    <th colspan="2" style="color:#707070; background-color:#eeeeee;line-height:50px;"><h4 style="margin:3px;">[+editorLogo+] [+editorLabel+] [+settings+] <b style="float:right">v[+editorVersion+]</b></h4></th>
-  </tr>
-  [+rows+]
-</table>
+<div class="split my-1"></div>
+
+[+rows+]
+
 <script>
-    jQuery("input.defaultCheckbox").on('change', function() {
-        hiddenId = jQuery(this).attr("id") + '_hidden';
-        val = jQuery(this).is(":checked") ? '1' : '0';
-        jQuery("#"+hiddenId).attr("value", val);
-    });
+  jQuery("input.defaultCheckbox").on('change', function () {
+      hiddenId = jQuery(this).attr("id") + '_hidden';
+      val = jQuery(this).is(":checked") ? '1' : '0';
+      jQuery("#" + hiddenId).attr("value", val);
+  });
 </script>

--- a/assets/plugins/tinymce4/gsettings/gsettings.row.inc.html
+++ b/assets/plugins/tinymce4/gsettings/gsettings.row.inc.html
@@ -1,9 +1,17 @@
-    <tr class="row1" style="display: [+display+];">
-        <th>[+title+]</th>
-        <td>
-            [+configTpl+]
-            <div>[+message+][+messageVal+]</div>
+<div class="row form-row form-element-input">
+    <label for="[+name+]" class="control-label col-5 col-md-3 col-lg-2">
+        [+title+]
+        <small class="form-text text-muted">[([+name+])]</small>
+    </label>
+    <div class="col-7 col-md-9 col-lg-10">
+        [+configTpl+]
+        <small class="form-text text-muted">
             [+default+]
             [+defaultCheckbox+]
-        </td>
-    </tr>
+            [+message+]
+            [+messageVal+]
+        </small>
+    </div>
+</div>
+
+<div class="split my-1"></div>

--- a/assets/plugins/tinymce4/gsettings/gsettings.rows.inc.php
+++ b/assets/plugins/tinymce4/gsettings/gsettings.rows.inc.php
@@ -1,86 +1,98 @@
 <?php
-
 $params = isset($params) && !empty($params) ? $params : array('base_url'=>'', 'skinsDirectory'=>'', 'skinthemeDirectory'=>'');
 // Hold general settings based on old Modx TinyMCE-Settings
-
 // Settings interface rows configuration
 $settingsRows = array(
     'theme'=>array(
         'title'=>'editor_theme_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                    <select name="[+name+]" class="inputBox">
-                        [+theme_options+]
-                    </select>',
+            <select name="[+name+]" id="[+name+]" class="inputBox" size="1">
+                [+theme_options+]
+            </select>',
         'message'=>'editor_theme_message',
         'messageVal'=>'<b>'. $params['base_url'].'<u>theme</u></b>'
     ),
     'skin'=>array(
         'title'=>'editor_skin_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                    <select name="[+name+]" class="inputBox">
-                        [+skin_options+]
-                    </select>',
+            <select name="[+name+]" id="[+name+]" class="inputBox" size="1">
+                [+skin_options+]
+            </select>',
         'message'=>'editor_skin_message',
         'messageVal'=>'<b>'. $params['base_url'].'<u>'.$params['skinsDirectory'] .'</u></b>'
     ),
     'skintheme'=>array(
         'title'=>'editor_skintheme_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                    <select name="[+name+]" class="inputBox">
-                        [+skintheme_options+]
-                    </select>',
+            <select name="[+name+]" id="[+name+]" class="inputBox" size="1">
+                [+skintheme_options+]
+            </select>',
         'message'=>'editor_skintheme_message',
         'messageVal'=>'<b>'. $params['base_url'].'<u>'.$params['skinthemeDirectory'] .'</u></b>'
     ),
     'template'=>array(
         'title'=>'tpl_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                    <div style="margin-bottom:8px;"><label>[+tpl_docid+] <input type="text" class="inputBox" style="width: 300px;" name="[+name+]_docs" value="[+[+name+]_docs+]" /></label></div>
-                    <div><label>[+tpl_chunkname+] <input type="text" class="inputBox" style="width: 300px;" name="[+name+]_chunks" value="[+[+name+]_chunks+]" /></label></div>',
+            <label>
+                [+tpl_docid+]
+                <input type="text" name="[+name+]_docs" value="[+[+name+]_docs+]" id="[+name+]" class="inputBox" />
+            </label>
+            <label>
+                [+tpl_chunkname+]
+                <input type="text" name="[+name+]_chunks" value="[+[+name+]_chunks+]" id="[+name+]" class="inputBox" />
+            </label>',
         'message'=>'tpl_msg'
     ),
     'entermode'=>array(
         'title'=>'editor_entermode_title',
+        'name'=>'[+name+]',
         'configTpl'=>'[+entermode_options+]',
         'message'=>'editor_entermode_message'
     ),
     'element_format'=>array(
         'title'=>'element_format_title',
+        'name'=>'[+name+]',
         'configTpl'=>'[+element_format_options+]',
         'message'=>'element_format_message'
     ),
     'schema'=>array(
         'title'=>'schema_title',
+        'name'=>'[+name+]',
         'configTpl'=>'[+schema_options+]',
         'message'=>'schema_message'
     ),
-
     'custom_plugins'=>array(
         'title'=>'editor_custom_plugins_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                  <textarea class="inputBox mce" name="[+name+]">[+[+editorKey+]_custom_plugins+]</textarea>',
+            <textarea name="[+name+]" id="[+name+]" class="inputBox mce" >[+[+editorKey+]_custom_plugins+]</textarea>',
         'message'=>'editor_custom_plugins_message',
-        'defaultCheckbox'=>true    
+        'defaultCheckbox'=>true
     ),
     'custom_buttons'=>array(
         'title'=>'editor_custom_buttons_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                  Row 1: <textarea class="inputBox mce" name="[+name+]1">[+[+editorKey+]_custom_buttons1+]</textarea>
-                  <div>[+editor_custom_buttons1_msg+]</div>
-                  Row 2: <textarea class="inputBox mce" name="[+name+]2">[+[+editorKey+]_custom_buttons2+]</textarea>
-                  <div>[+editor_custom_buttons2_msg+]</div>
-                  Row 3: <textarea class="inputBox mce" name="[+name+]3">[+[+editorKey+]_custom_buttons3+]</textarea>
-                  Row 4: <textarea class="inputBox mce" name="[+name+]4">[+[+editorKey+]_custom_buttons4+]</textarea>',
+            #1: <textarea name="[+name+]1" id="[+name+]" class="inputBox mce">[+[+editorKey+]_custom_buttons1+]</textarea>
+            [+editor_custom_buttons1_msg+]
+            #2: <textarea name="[+name+]2" id="[+name+]" class="inputBox mce">[+[+editorKey+]_custom_buttons2+]</textarea>
+            [+editor_custom_buttons2_msg+]
+            #3: <textarea name="[+name+]3" id="[+name+]" class="inputBox mce">[+[+editorKey+]_custom_buttons3+]</textarea>
+            #4: <textarea name="[+name+]4" id="[+name+]" class="inputBox mce">[+[+editorKey+]_custom_buttons4+]</textarea>',
         'message'=>'editor_custom_buttons_message',
         'defaultCheckbox'=>true
     ),
     'css_selectors'=>array(
         'title'=>'editor_css_selectors_title',
+        'name'=>'[+name+]',
         'configTpl'=>'
-                    <textarea class="inputBox mce" name="[+name+]">[+[+editorKey+]_css_selectors+]</textarea>',
+            <textarea name="[+name+]" id="[+name+]" class="inputBox mce">[+[+editorKey+]_css_selectors+]</textarea>',
         'message'=>'editor_css_selectors_message',
         'defaultCheckbox'=>true
     )
 );
-
 ?>

--- a/manager/media/style/default/css/custom.css
+++ b/manager/media/style/default/css/custom.css
@@ -346,7 +346,7 @@ border-bottom: 1px solid #e0e0e0; }
 .darkness #content_body { margin: 0 -1.5rem; }
 .darkness .card .table.data, .darkness .table td[style="background-color:#ffffff;"] { background: #202329 !important; }
 .darkness .table.data, .darkness .grid { background: #282c34 !important; border: none !important }
-.darkness .table.data thead, .darkness .grid thead, .darkness #editorRow_TinyMCE { background: none }
+.darkness .table.data thead, .darkness .grid thead { background: none }
 .darkness .table.data thead th, .darkness .table.data thead td, .darkness .grid th, .darkness .grid thead td { padding: 0.75rem !important; background-color: #202329; border: none; border-bottom: 1px solid #1f5994; color: #777; text-transform: uppercase; font-size: 0.675rem; }
 .darkness .table.data thead .sortable a, .darkness .table.data thead .sortable-text a, .darkness .sortabletable th a { color: #777; }
 .darkness .table th a:hover, .darkness .table thead td a:hover, .darkness .grid th a:hover, .darkness .grid thead td a:hover, .darkness .table .sortable:hover a, .darkness .table .sortable-text:hover a { color: #eee !important; }
@@ -363,11 +363,10 @@ padding: .25rem .5rem; background: none; border: none !important; color: inherit
 .darkness .table.data .actions a:hover .fa::before { color: #eee; }
 .darkness .table.data .actions a:hover .fa::after { background-color: #3b414e; }
 .darkness .table.data .actions a:hover .fa.fa-trash::before { color: #d80030; }
-.darkness table .split, .darkness #editorRow_TinyMCE tr, .darkness table.table.table--edit > tbody > tr, .darkness .sysSettings > tbody > tr { border: none; border-bottom: 1px solid #23262b !important; }
+.darkness table .split, .darkness table.table.table--edit > tbody > tr, .darkness .sysSettings > tbody > tr { border: none; border-bottom: 1px solid #23262b !important; }
 .darkness table .split { margin: 0 -.5rem; }
 .darkness table tr.noborder { border: none !important; }
 .darkness table .comment { color: #999 !important; }
-.darkness #editorRow_TinyMCE > tbody > tr:first-child > th { background: none !important; color: inherit !important; }
 .darkness .section-editor, .darkness #content_body { border-top: 1px solid #414449; }
 .darkness #file_editfile .navbar-editor, .darkness #file_editfile [name="editFile"], .darkness #content_body, .darkness .section-editor { border-bottom: 1px solid #414449; }
 .darkness .section-editor > textarea, .darkness #content_body > div > textarea, .darkness #content_body > .section-editor { margin-top: 0 }
@@ -462,10 +461,6 @@ ul.mmTagList { float: left; margin-top: .25rem !important
 .mce-container, .mce-container-body { box-sizing: border-box !important }
 .mce-container button { border: none; border-radius: 0; background-color: transparent; }
 .mce-window-head .mce-close { padding: 0; }
-#editorRow_TinyMCE { background-color: #fff; }
-#editorRow_TinyMCE tr { border: 1px dotted rgba(0, 0, 0, .05); }
-#editorRow_TinyMCE th { white-space: nowrap }
-#editorRow_TinyMCE th, #editorRow_TinyMCE td { padding: 0.5em; border: none !important }
 div.mce-fullscreen { margin-top:2.6rem;	}
 /* wrap TinyMCE3 toolbar */
 .mceEditor .mceToolbar td { height: 24px; float: left }


### PR DESCRIPTION
Исправил вывод настроек для tinyMCE в разделе "Конфигурация":
- Сделал их удобнее (вывел название [(ключа)], починил label);
- Привел оформление к одному стилю (поправил код, верстку и классы).

До:
![before](https://user-images.githubusercontent.com/12523676/69008184-1b235700-0961-11ea-9a74-5792e5825128.png)

После:
![after](https://user-images.githubusercontent.com/12523676/69008183-1b235700-0961-11ea-82f0-72434d88c75b.png)
