### PR TITLE
Поправил вывод списков в разделе "Конфигурация"

### DIFF
--- a/manager/media/style/default/css/custom.css
+++ b/manager/media/style/default/css/custom.css
@@ -34,6 +34,7 @@ select[name=usergroup], select[name=docgroup] { margin: 0 0.5em; }
 select[name=docgroup] + input[type=submit] { float: none; margin: 0; }
 #settingsPane #filemanager_path, #settingsPane #rb_base_dir, #settingsPane input[name=txt_custom_contenttype] { border-top-right-radius: 0; border-bottom-right-radius: 0 }
 #settingsPane #filemanager_path + input[name=reset_filemanager_path], #settingsPane #rb_base_dir + input[name=reset_rb_base_dir], #settingsPane input[name=txt_custom_contenttype] + input[type=button], input[name=photo] + input[type=button], #range input#pids + input[name=fsubmit], input[name="ta"].inputBox + input[type=button], input[name="ta"].inputBox + .CodeMirror + input[type=button], #documentPane input[name^=tv]:not([class*=mtv]) + input[type=button] { z-index: 5; float: right; margin-top: -2.30769em; width: auto !important; border-top-left-radius: 0; border-bottom-left-radius: 0 }
+#settingsPane select[size="1"] { width: 50%; }
 #range::after { content: ""; display: table; width: 100% }
 /* [ Editor ] */
 .navbar.navbar-editor {

--- a/manager/views/page/system_settings/file_browser.blade.php
+++ b/manager/views/page/system_settings/file_browser.blade.php
@@ -30,7 +30,7 @@
                 'label' => ManagerTheme::getLexicon('which_browser_default_title'),
                 'small' => '[(which_browser)]',
                 'value' => $settings['which_browser'],
-                'attributes' => 'size="1" onChange="documentDirty=true;"',
+                'attributes' => 'onChange="documentDirty=true;" size="1"',
                 'options' => $fileBrowsers,
                 'as' => 'values',
                 'comment' => ManagerTheme::getLexicon('which_browser_default_msg')

--- a/manager/views/page/system_settings/general.blade.php
+++ b/manager/views/page/system_settings/general.blade.php
@@ -128,7 +128,7 @@
                     'name' => 'default_template',
                     'value' => $settings['default_template'],
                     'options' => $templates['items'],
-                    'attributes' => 'size="1" onchange="documentDirty=true;wrap=document.getElementById(\'template_reset_options_wrapper\');if(this.options[this.selectedIndex].value!=' . $settings['default_template'] . '){wrap.style.display=\'block\';}else{wrap.style.display=\'none\';}"'
+                    'attributes' => 'onchange="documentDirty=true;wrap=document.getElementById(\'template_reset_options_wrapper\');if(this.options[this.selectedIndex].value!=' . $settings['default_template'] . '){wrap.style.display=\'block\';}else{wrap.style.display=\'none\';}" size="1"'
                     ]) .
                     '<div id="template_reset_options_wrapper" style="display:none;">' .
                         ManagerTheme::view('form.radio', [


### PR DESCRIPTION
Поправил вывод списков в разделе "Конфигурация", списки теперь шириной в 50% вместо auto.
По-моему, с единым размером выглядит чутка приятнее.

До:
![before](https://user-images.githubusercontent.com/12523676/69164417-6a0bf080-0b09-11ea-85a1-ddfa6bc915ed.png)

После:
![after](https://user-images.githubusercontent.com/12523676/69164416-69735a00-0b09-11ea-9822-33a8b5ed4e55.png)

Эти правки ни на что не влияют и я пойму, если они будут отклонены :)
