### PR TITLE
allow / in the name of a templete alias

### DIFF
--- a/manager/processors/save_template.processor.php
+++ b/manager/processors/save_template.processor.php
@@ -116,7 +116,7 @@ switch ($_POST['mode']) {
 
         if($templatealias == '')
             $templatealias = $templatename;
-        $templatealias = strtolower($modx->stripAlias(trim($templatealias)));
+        $templatealias = strtolower(trim(preg_replace('/[^\.\/%A-Za-z0-9 _-]/', '', $templatealias)));
 
         $docid = $modx->getDatabase()->getValue($modx->getDatabase()->select('id', $modx->getDatabase()->getFullTableName('site_templates'), "id<>'$id' AND templatealias='$templatealias'", '', 1));
 


### PR DESCRIPTION

<img width="716" alt="Screen Shot 2019-11-22 at 11 19 52 AM" src="https://user-images.githubusercontent.com/293377/69454027-1c1a0700-0d1a-11ea-9459-b710f24661c9.png">
when using blade templates I discovered I can't use / to navigate the folder structure of the views folder. this fixes that problem but maybe there is a better way to do this, a helper function that can be used. Please let me know and I can modify and create a new pull request