### PR TITLE
fix mistake in getChildIds core function

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -3064,7 +3064,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
                 'id,alias,isfolder,parent'
                 , $this->getDatabase()->getFullTableName('site_content')
                 , sprintf(
-                    "parent IN (%d) AND deleted = '0'"
+                    "parent IN (%s) AND deleted = '0'"
                     , $id
                 )
             );


### PR DESCRIPTION
getChildIds  function din't work properly for multiple ids because of mistake in sprintf.

`sprintf("%d", "2,3,4")`

  returns "2".