### PR TITLE
Double "-" will be lost when editing a url.

### DIFF
--- a/manager/includes/tmplvars.inc.php
+++ b/manager/includes/tmplvars.inc.php
@@ -108,10 +108,10 @@ function renderFormElement($field_type, $field_id, $default_text = '', $field_el
 				);
 				$field_html = '<table border="0" cellspacing="0" cellpadding="0"><tr><td><select id="tv' . $field_id . '_prefix" name="tv' . $field_id . '_prefix" onchange="documentDirty=true;">';
 				foreach($urls as $k => $v) {
-					if(strpos($field_value, $v) === false) {
+					if(strpos($field_value, $v) !== 0) {
 						$field_html .= '<option value="' . $v . '">' . $k . '</option>';
-					} else {
-						$field_value = str_replace($v, '', $field_value);
+					} elseif (!empty($k)) {
+						$field_value = preg_replace("~^{$v}~", '', $field_value);
 						$field_html .= '<option value="' . $v . '" selected="selected">' . $k . '</option>';
 					}
 				}


### PR DESCRIPTION
When editing field with type URL, when data is loaded from DB, a double "- " was cut from the url.
In addition, the schema prefix was searched for throughout the url, not at the begin.

Therefore, the url containing for example 'http://' in the middle was also loaded with an error.

For example, instead of 
«http://url.com/?link--redirect=http://url2.com/»
received
«http://» + «url.com/?linkredirect=url2.com/»


