### PR TITLE
Update phpcompat.class.inc.php

### DIFF
--- a/manager/includes/extenders/phpcompat.class.inc.php
+++ b/manager/includes/extenders/phpcompat.class.inc.php
@@ -15,9 +15,7 @@ class PHPCOMPAT
     {
         $modx = evolutionCMS();
 
-        if ($str == '') {
-            return '';
-        }
+        if (is_array($str) || $str == '') return '';
 
         if ($encode == '') {
             $encode = $modx->config['modx_charset'];


### PR DESCRIPTION
fix htmlspecialchars() expects parameter 1 to be string, array given

fix for this in events :
site.url/index.php?s=index/think%07pp/invokefunction&function=call_user_func_array&vars%5B0%5D=assert&vars%5B1%5D%5B%5D=phpinfo()