### PR TITLE
Change table format for logs list so pagination become usable.

### DIFF
--- a/manager/actions/eventlog.dynamic.php
+++ b/manager/actions/eventlog.dynamic.php
@@ -139,7 +139,7 @@ echo $cm->render();
 					$grd->pageClass = 'page-item';
 					$grd->selPageClass = 'page-item active';
 					$grd->noRecordMsg = $_lang['no_records_found'];
-					$grd->cssClass = "table data nowrap eventlog";
+					$grd->cssClass = "table data eventlog"; // nowrap
 					$grd->columnHeaderClass = "tableHeader";
 					$grd->itemClass = "tableItem";
 					$grd->altItemClass = "tableAltItem";


### PR DESCRIPTION
With many events in logs list pagination become unusable.
Remove "nowrap" class from the table fix this.

modified:   manager/actions/eventlog.dynamic.php