### PR TITLE
Fix css for the fontawesome icons in manager

### DIFF
--- a/manager/media/style/default/css/mainmenu.css
+++ b/manager/media/style/default/css/mainmenu.css
@@ -39,6 +39,8 @@
 #mainMenu .nav > li > ul > li > span:first-child { padding: 0 1rem; text-align: center; font-size: 0.875em; color: #aaa; }
 #mainMenu .nav > li > ul > li.dropdown-back > span { text-align: left; font-size: inherit; color: inherit }
 #mainMenu .nav > li > ul > li.dropdown-back > span * { pointer-events: none }
+#mainMenu .nav > li > ul > li .fab,
+#mainMenu .nav > li > ul > li .fas,
 #mainMenu .nav > li > ul > li .fa { width: 1.3em; margin-right: 0.5em; font-size: .875rem; line-height: .8rem; text-align: center; vertical-align: baseline }
 #mainMenu .nav > li > ul > li.selected a:first-child::before, #main .evo-tab-row .tab.changed::before { content: ''; position: absolute; right: 0.25em; top: 0.25em; width: 0.5em; height: 0.5em; background-color: #ffc107; -webkit-border-radius: 50%; border-radius: 50%; pointer-events: none }
 #mainMenu .nav > li > ul > li.dropdown-toggle > a > .toggle { position: absolute; top: 0; right: 0; height: 100%; width: 2rem; margin: 0; line-height: 2rem; text-align: center; }


### PR DESCRIPTION
In dropdowns (list of modules) icons with class .fas or .fab are shown without margins.
This will fix it.

modified:   manager/media/style/default/css/mainmenu.css