### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.3-fpm
 # Copy composer.lock and composer.json
 COPY composer.json /var/www/
 # Set working directory
@@ -10,12 +10,16 @@ RUN apt-get update && apt-get install -y \
     libjpeg62-turbo-dev \
     libfreetype6-dev \
     locales \
-    zip \
     jpegoptim optipng pngquant gifsicle \
     vim \
     unzip \
     git \
-    curl
+    curl \
+    zip \
+    libzip-dev \
+    && docker-php-ext-configure zip --with-libzip \
+    && docker-php-ext-install zip
+
 # Clear cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Install extensions


### PR DESCRIPTION
evo requires a PHP version of at least 7.3 for its work, so you need to update the Dockefile