### PR TITLE
Execute parser for show 404 page only on notFound and notAllowed exceptions

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -2693,15 +2693,9 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
                 ->then(function ($request) {
                     return $this->router->dispatch($request);
                 });
-        } catch (NotFoundHttpException $exception) {
-            EvolutionCMS()->executeParser();
-            exit();
-        } catch (MethodNotAllowedException $exception) {
-            EvolutionCMS()->executeParser();
-            exit();
-        } catch (\Exception $exception) {
-            EvolutionCMS()->executeParser();
-            exit();
+        } catch (NotFoundHttpException | MethodNotAllowedException $exception) {
+            $this->executeParser();
+            exit;
         }
 
         $response->send();

--- a/core/src/ExceptionHandler.php
+++ b/core/src/ExceptionHandler.php
@@ -28,7 +28,7 @@ class ExceptionHandler
 
     protected function registerHanlders()
     {
-        if (!defined('MODX_CLI') || !MODX_CLI) {
+        if (!defined('MODX_CLI') || MODX_CLI) {
             return;
         }
 

--- a/core/src/ExceptionHandler.php
+++ b/core/src/ExceptionHandler.php
@@ -28,6 +28,10 @@ class ExceptionHandler
 
     protected function registerHanlders()
     {
+        if (!defined('MODX_CLI') || !MODX_CLI) {
+            return;
+        }
+
         register_shutdown_function([$this, 'handleShutdown']);
         set_exception_handler([$this, 'handleException']);
         set_error_handler([$this, 'phpError']);


### PR DESCRIPTION
simple example:
```php
Route::get('/helloworld', function() {
    $undefined = app()->undefined;
});
```
this route should not show 404 page