### PR TITLE
Update DocLister.abstract.php

### DIFF
--- a/assets/snippets/DocLister/core/DocLister.abstract.php
+++ b/assets/snippets/DocLister/core/DocLister.abstract.php
@@ -1464,7 +1464,7 @@ abstract class DocLister
         }
         $offset += $this->getCFGDef('start', 0);
         $total = $this->getCFGDef('total', 0);
-        if ($limit < ($total - $limit)) {
+        if ((int)$limit < ((int)$total - (int)$limit)) {
             $limit = $total - $offset;
         }
 


### PR DESCRIPTION
Начиная с версии 7.3 PHP, на данной строке возникает ошибка ("Error : A non-numeric value encountered"), если в сниппет передано ("display"  => "all").
Данный фикс решает эту проблему.