### PR TITLE
fix views path setting

### DIFF
--- a/core/src/Parser.php
+++ b/core/src/Parser.php
@@ -31,6 +31,9 @@ class Parser
     protected $twig;
 
     protected $twigEnabled = false;
+
+    public $blade;
+
     protected $bladeEnabled = true;
 
     protected $templateData = array();
@@ -104,10 +107,10 @@ class Parser
 
         if (!empty($path)) {
             $this->templatePath = $path;
-            if ($this->twigEnabled) {
+            if ($this->twig) {
                 $this->twig->setLoader(new Twig_Loader_Filesystem(MODX_BASE_PATH . $path));
             }
-            if ($this->bladeEnabled) {
+            if ($this->blade) {
                 $filesystem = new Filesystem;
                 $viewFinder = new FileViewFinder($filesystem, [MODX_BASE_PATH . $path]);
                 $this->blade->setFinder($viewFinder);


### PR DESCRIPTION
Проблема:
не удается задать путь к blade-шаблонам для доклистера.

Причина: 
В методе `setTemplatePath` проверяется свойство `$this->bladeEnabled`, и путь будет задан только в том случае если оно равно `true`. Но вот значение этого свойства меняется только в методе `parseChunk`, в зависимости от того, какой обрабатывается шаблон. Т.е. если вывести не-blade-шаблон, то сразу после этого задать путь не удастся.

Поэтому считаю будет правильнее проверять не свойство `$bladeEnabled`, а свойство `$blade`.