### PR TITLE
middleware priority, aliases, fixed bindings

### DIFF
--- a/core/config/app.php
+++ b/core/config/app.php
@@ -127,7 +127,7 @@ return [
         |
         */
 
-        'stack' => [
+        'global' => [
             Illuminate\Session\Middleware\StartSession::class,
             Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/core/config/app.php
+++ b/core/config/app.php
@@ -114,18 +114,40 @@ return [
         'DocumentManager' => EvolutionCMS\DocumentManager\Facades\DocumentManager::class,
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | The application's global HTTP middleware stack
-    |--------------------------------------------------------------------------
-    |
-    | These core middleware are run during every request to your application.
-    | You should not edit this list,
-    | for custom middleware see file core/custom/config/middleware.php.
-    |
-    */
-
     'middleware' => [
-        Illuminate\Session\Middleware\StartSession::class,
+
+        /*
+        |--------------------------------------------------------------------------
+        | The application's global HTTP middleware stack
+        |--------------------------------------------------------------------------
+        |
+        | These core middleware are run during every request to your application.
+        | You should not edit this list,
+        | for custom middleware see file core/custom/config/middleware.php.
+        |
+        */
+
+        'stack' => [
+            Illuminate\Session\Middleware\StartSession::class,
+            Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Route middleware
+        |--------------------------------------------------------------------------
+        |
+        | These middleware may be assigned to groups or used individually.
+        | You should not edit this list,
+        | for custom aliases see file core/custom/config/middleware.php.
+        |
+        */
+
+        'aliases' => [
+            'csrf' => EvolutionCMS\App\Middleware\VerifyCsrfToken::class,
+            'authtoken' => EvolutionCMS\App\Middleware\CheckAuthToken::class,
+            'managerauth' => EvolutionCMS\App\Middleware\CheckManagerAuth::class,
+            'bindings' => Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
     ],
 ];

--- a/core/config/app.php
+++ b/core/config/app.php
@@ -144,9 +144,9 @@ return [
         */
 
         'aliases' => [
-            'csrf' => EvolutionCMS\App\Middleware\VerifyCsrfToken::class,
-            'authtoken' => EvolutionCMS\App\Middleware\CheckAuthToken::class,
-            'managerauth' => EvolutionCMS\App\Middleware\CheckManagerAuth::class,
+            'csrf' => EvolutionCMS\Middleware\VerifyCsrfToken::class,
+            'authtoken' => EvolutionCMS\Middleware\CheckAuthToken::class,
+            'managerauth' => EvolutionCMS\Middleware\CheckManagerAuth::class,
             'bindings' => Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ],

--- a/core/custom/config/middleware.php.sample
+++ b/core/custom/config/middleware.php.sample
@@ -13,4 +13,32 @@ return [
         // EvolutionCMS\Middleware\Example::class,
         // ...
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware may be assigned to groups or used individually.
+    |
+    */
+
+    'aliases' => [
+        // 'example' => EvolutionCMS\Middleware\Example::class,
+        // ...
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | The priority-sorted list of middleware
+    |--------------------------------------------------------------------------
+    |
+    | This forces middleware to always be in the given order.
+    |
+    */
+
+    'priority' => [
+        // EvolutionCMS\Middleware\Example::class,
+        // ...
+    ],
 ];

--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -2674,7 +2674,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
     public function setRouterMiddleware()
     {
         $middleware = array_merge(
-            config('app.middleware.stack', []),
+            config('app.middleware.global', []),
             config('middleware.global', [])
         );
 

--- a/core/src/Providers/RoutingServiceProvider.php
+++ b/core/src/Providers/RoutingServiceProvider.php
@@ -3,6 +3,7 @@
 namespace EvolutionCMS\Providers;
 
 use EvolutionCMS\Extensions\Router;
+use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\RoutingServiceProvider as IlluminateRoutingServiceProvider;
 use Illuminate\Support\Facades\Route;
 
@@ -16,7 +17,7 @@ class RoutingServiceProvider extends IlluminateRoutingServiceProvider
         parent::register();
 
         if (is_readable(EVO_CORE_PATH . 'custom/routes.php')) {
-            include EVO_CORE_PATH . 'custom/routes.php';
+            Route::middleware('web')->group(EVO_CORE_PATH . 'custom/routes.php');
         }
 
         Route::fallbackToParser();
@@ -31,5 +32,7 @@ class RoutingServiceProvider extends IlluminateRoutingServiceProvider
         $this->app->singleton('router', function ($app) {
             return new Router($app['events'], $app);
         });
+
+        $this->app->alias('router', Registrar::class);
     }
 }


### PR DESCRIPTION
Added support for middleware custom priority order, aliases for assigning to routes.
Fixed models to routes binding.

```php
Route::get('/documents/{document}', function(SiteContent $document) {
    return $document->pagetitle;
});
```