### PR TITLE
Поддержка contentType

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -937,7 +937,7 @@ class DocumentParser
 
         // send out content-type and content-disposition headers
         if (IN_PARSER_MODE == "true") {
-            $type = !empty ($this->contentTypes[$this->documentIdentifier]) ? $this->contentTypes[$this->documentIdentifier] : "text/html";
+            $type = !empty ($this->documentObject["contentType"]) ? $this->documentObject["contentType"] : "text/html";
             header('Content-Type: ' . $type . '; charset=' . $this->config['modx_charset']);
             //            if (($this->documentIdentifier == $this->config['error_page']) || $redirect_error)
             //                header('HTTP/1.0 404 Not Found');


### PR DESCRIPTION
$this->contentTypes всегда равен NULL. Кто ввёл эту переменную и зачем разбираться некогда.
Проверку выполняем по нормальному.