### PR TITLE
Add 'document' as content type in case if it's defaulted due to plugin error

### DIFF
--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -136,7 +136,7 @@ if(!isset($_REQUEST['id'])) {
     }
 }
 
-$content['type'] = get_by_key($content, 'type', $defaultContentType, 'is_scalar');
+$content['type'] = get_by_key($content, 'type', $defaultContentType, 'is_scalar') ?: $defaultContentType;
 
 if(isset ($_POST['which_editor'])) {
     $modx->setConfig('which_editor', get_by_key($_POST, 'which_editor', '', 'is_scalar'));


### PR DESCRIPTION
is_scalar is not enough validation as it not checks for empty value.

Way to reproduce the original issue - insert table with i.e. 200 rows to the multiTv input, with 7 text inputs (columns) in multiTV and save.
It will not fail if you create 20 not 200 records it will save successfully, otherwise $content['type'] becomes empty and document loses Published status