### PR TITLE
Update document.parser.class.inc.php

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -4125,7 +4125,7 @@ class DocumentParser
 
         if($this->isBackend()) {
             if($_SESSION['mgrRole']==1) {
-                return '';
+                return '1=1';
             }
             return $docgrp
                 ? 'sc.privatemgr=0 OR dg.document_group IN (' . $docgrp . ')'


### PR DESCRIPTION
if docAccessConditions() used in sql query only
like this
 'AND (' . $this->docAccessConditions() . ')' 

better return '1=1' for correct sql syntax