### PR TITLE
Update TemplateProcessor.php

### DIFF
--- a/core/src/TemplateProcessor.php
+++ b/core/src/TemplateProcessor.php
@@ -41,7 +41,7 @@ class TemplateProcessor
                 $template = 'tpl-' . $doc['template'];
                 break;
             case $this->core['view']->exists($templateAlias):
-                $namespace = trim($this->core->getConfig('ControllerNamespace'));
+                $namespace = trim($this->core->getConfig('ControllerNamespace') ?? '');
                 if (!empty($namespace)) {
                     $baseClassName = $namespace . 'BaseController';
                     if (class_exists($baseClassName)) { //Проверяем есть ли Base класс


### PR DESCRIPTION
У нових версіях PHP (наприклад, PHP 8 і вище) передача значення null у функцію, яка очікує рядок, більше не вважається допустимою практикою. Якщо раніше PHP міг автоматично перетворювати null на порожній рядок, то тепер це викликає попередження про застарілу поведінку (deprecated).