### PR TITLE
php-xml library is required

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -39,6 +39,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-mbstring": "*",
+    "ext-xml": "*",
     "ext-SimpleXML": "*",
     "guzzlehttp/guzzle": "^7.0.1",
     "illuminate/cache": "10.*",


### PR DESCRIPTION
The php-xml library is required for the packages specified in /core/composer.json