### PR TITLE
php-xml library is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
   "require": {
     "php": ">=8.2",
     "ext-pdo": "*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-xml": "*"
   },
   "minimum-stability": "dev",
   "prefer-stable": true


### PR DESCRIPTION
The php-xml library is required for the packages specified in /core/composer.json