### PR TITLE
Removed deprecated e_strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
   "require": {
     "php": ">=8.2",
     "ext-pdo": "*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-mysqli": "*",
+    "ext-readline": "*"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/core/functions/processors.php
+++ b/core/functions/processors.php
@@ -32,7 +32,6 @@ if (!function_exists('evalModule')) {
                     break;
                 case E_DEPRECATED :
                 case E_USER_DEPRECATED :
-                case E_STRICT :
                     $error_level = 2;
                     break;
                 default:

--- a/core/lang/az/global.php
+++ b/core/lang/az/global.php
@@ -1321,7 +1321,7 @@ $_lang["yourinfo_username"] = 'Siz daxil olmusunuz:';
 $_lang["a17_error_reporting_title"] = 'PHP səhv aşkarlama səviyyəsi';
 $_lang["a17_error_reporting_msg"] = 'PHP səhvlərinin aşkarlama səviyyəsini təyin edin.';
 $_lang["a17_error_reporting_opt0"] = 'Bütün səhvləri görməzlikdən gəl';
-$_lang["a17_error_reporting_opt1"] = 'Yüngül xəbərdarlıqları nəzərə alma (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Yüngül xəbərdarlıqları nəzərə alma (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'E_NOTICE və E_USER_DEPRECATED istisna olmaqla bütün səhvləri aşkarlayın';
 $_lang["a17_error_reporting_opt99"] = 'E_USER_DEPRECATED istisna olmaqla bütün səhvləri aşkarlayın';
 $_lang["a17_error_reporting_opt199"] = 'Bütün səhvləri aşkarlayın';

--- a/core/lang/be/global.php
+++ b/core/lang/be/global.php
@@ -1306,7 +1306,7 @@ $_lang["yourinfo_username"] = 'Вы ўвайшлі як:';
 $_lang["a17_error_reporting_title"] = 'Узровень выяўлення памылак у PHP';
 $_lang["a17_error_reporting_msg"] = 'Настройце ўзровень выяўлення памылак у PHP.';
 $_lang["a17_error_reporting_opt0"] = 'Ігнараваць усе';
-$_lang["a17_error_reporting_opt1"] = 'Ігнараваць папярэджанні пра дробны ўзровень увагі (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ігнараваць папярэджанні пра дробны ўзровень увагі (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Выявіць усе памылкі, акрамя E_NOTICE і E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Вызначыць усе, акрамя E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Выявіць усе';

--- a/core/lang/bg/global.php
+++ b/core/lang/bg/global.php
@@ -1094,7 +1094,7 @@ $_lang["yourinfo_username"] = 'Влязал си като:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/cs/global.php
+++ b/core/lang/cs/global.php
@@ -1098,7 +1098,7 @@ $_lang["yourinfo_username"] = 'Jste přihlášen jako:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/da/global.php
+++ b/core/lang/da/global.php
@@ -1097,7 +1097,7 @@ $_lang["yourinfo_username"] = 'Du er logget ind som:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/de/global.php
+++ b/core/lang/de/global.php
@@ -1182,7 +1182,7 @@ $_lang["yourinfo_username"] = 'Sie sind angemeldet als:';
 $_lang["a17_error_reporting_title"] = 'PHP-Warnungen/Fehler';
 $_lang["a17_error_reporting_msg"] = 'PHP-Warnungen/Fehler mit dieser Stufe erkennen.';
 $_lang["a17_error_reporting_opt0"] = 'Alle PHP-Warnungen/Fehler ignorieren';
-$_lang["a17_error_reporting_opt1"] = 'Geringfügige PHP-Warnungen ignorieren (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Geringfügige PHP-Warnungen ignorieren (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Alle PHP-Warnungen/Fehler außer E_NOTICE erkennen';
 $_lang["a17_error_reporting_opt99"] = 'Alle PHP-Warnungen/Fehler erkennen';
 

--- a/core/lang/en/global.php
+++ b/core/lang/en/global.php
@@ -1211,7 +1211,7 @@ $_lang["yourinfo_username"] = 'You are logged in as:';
 $_lang["a17_error_reporting_title"] = 'Detection level of PHP errors';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP errors.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore warnings of a slight notice level (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore warnings of a slight notice level (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/es/global.php
+++ b/core/lang/es/global.php
@@ -1184,7 +1184,7 @@ $_lang["yourinfo_username"] = 'Estás ingresado como:';
 $_lang["a17_error_reporting_title"] = 'Nivel de detección de errores de PHP';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP errors.';
 $_lang["a17_error_reporting_opt0"] = 'Ignora todo';
-$_lang["a17_error_reporting_opt1"] = 'Ignore warnings of a slight notice level (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore warnings of a slight notice level (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/fa/global.php
+++ b/core/lang/fa/global.php
@@ -1094,7 +1094,7 @@ $_lang["yourinfo_username"] = 'شناسه ای که با آن وارد شده ا
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/fi/global.php
+++ b/core/lang/fi/global.php
@@ -1093,7 +1093,7 @@ $_lang["yourinfo_username"] = 'Käyttäjänimi:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/fr/global.php
+++ b/core/lang/fr/global.php
@@ -1064,7 +1064,7 @@ $_lang["yourinfo_username"] = 'Connecté sous le nom:';
 $_lang["a17_error_reporting_title"] = 'Niveau de rapport d\'erreurs PHP';
 $_lang["a17_error_reporting_msg"] = 'Fixe le niveau de rapport d\'erreurs PHP.';
 $_lang["a17_error_reporting_opt0"] = 'Tout ignorer';
-$_lang["a17_error_reporting_opt1"] = 'Ignorer les erreurs de faible niveau (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignorer les erreurs de faible niveau (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Détection des toutes les erreurs sauf E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Détection des toutes les erreurs sauf E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Tout détecter';

--- a/core/lang/he/global.php
+++ b/core/lang/he/global.php
@@ -1094,7 +1094,7 @@ $_lang["yourinfo_username"] = 'אתה מחובר כ:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/it/global.php
+++ b/core/lang/it/global.php
@@ -1193,7 +1193,7 @@ $_lang["yourinfo_username"] = 'Siete autenticati come:';
 $_lang["a17_error_reporting_title"] = 'Livello di dettaglio degli errori PHP:';
 $_lang["a17_error_reporting_msg"] = 'Imposta il livello di rilevamento degli errori PHP.';
 $_lang["a17_error_reporting_opt0"] = 'Ignora tutti gli errori';
-$_lang["a17_error_reporting_opt1"] = 'Ignora gli errori di basso livello (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignora gli errori di basso livello (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Rileva tutti gli errori eccetto E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Rileva tutti gli errori eccetto E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Rileva tutti gli errori';

--- a/core/lang/ja/global.php
+++ b/core/lang/ja/global.php
@@ -1220,7 +1220,7 @@ $_lang["yourinfo_username"] = 'ログイン名';
 $_lang["a17_error_reporting_title"] = 'PHPエラーの検出レベル';
 $_lang["a17_error_reporting_msg"] = 'PHPエラーの検出レベルを設定します。';
 $_lang["a17_error_reporting_opt0"] = '全て無視する';
-$_lang["a17_error_reporting_opt1"] = '通知レベルの軽度の警告を無視する(<a href="https://www.google.com/search?hl=ja&q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = '通知レベルの軽度の警告を無視する(<a href="https://www.google.com/search?hl=ja&q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = '~E_NOTICE 以外の全てのエラーを検出';
 $_lang["a17_error_reporting_opt99"] = '~E_NOTICE & ~E_USER_DEPRECATED 以外の全てのエラーを検出';
 $_lang["a17_error_reporting_opt199"] = '全て検出する';

--- a/core/lang/nl/global.php
+++ b/core/lang/nl/global.php
@@ -1170,7 +1170,7 @@ $_lang["yourinfo_username"] = 'U bent aangemeld als:';
 $_lang["a17_error_reporting_title"] = 'Detectie level van de PHP foutmelding';
 $_lang["a17_error_reporting_msg"] = 'Bepaal het level van de PHP foutmelding.';
 $_lang["a17_error_reporting_opt0"] = 'Negeer alle';
-$_lang["a17_error_reporting_opt1"] = 'Negeer de waarschuwing van een melding met laag niveau (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">deprecated</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Negeer de waarschuwing van een melding met laag niveau (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">deprecated</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detecteer alle foutmeldingen behalve E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detecteer alle foutmeldingen behalve E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detecteer alle';

--- a/core/lang/nn/global.php
+++ b/core/lang/nn/global.php
@@ -1061,7 +1061,7 @@ $_lang["yourinfo_username"] = 'Du er inlogget som:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/pl/global.php
+++ b/core/lang/pl/global.php
@@ -1186,7 +1186,7 @@ $_lang["yourinfo_username"] = 'Zalogowany jako:';
 $_lang["a17_error_reporting_title"] = 'Poziom wykrywania błędów PHP';
 $_lang["a17_error_reporting_msg"] = 'Ustaw poziom wykrywania błędów PHP.';
 $_lang["a17_error_reporting_opt0"] = 'Ignoruj wszystko';
-$_lang["a17_error_reporting_opt1"] = 'Ignoruj ostrzeżenia niskiego poziomu (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignoruj ostrzeżenia niskiego poziomu (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Wykrywaj wszystkie błędy poza E_NOTICE';
 $_lang["a17_error_reporting_opt99"] = 'Wykrywaj wszystko';
 

--- a/core/lang/pt/global.php
+++ b/core/lang/pt/global.php
@@ -1094,7 +1094,7 @@ $_lang["yourinfo_username"] = 'Está ligado como:';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/lang/ru/global.php
+++ b/core/lang/ru/global.php
@@ -1208,7 +1208,7 @@ $_lang["yourinfo_username"] = 'Вы авторизованы как:';
 $_lang["a17_error_reporting_title"] = 'Обнаружение уровня ошибки РНР';
 $_lang["a17_error_reporting_msg"] = 'Набор обнаружения уровня ошибок РНР';
 $_lang["a17_error_reporting_opt0"] = 'Игнорировать все';
-$_lang["a17_error_reporting_opt1"] = 'Игнорировать предупреждения о незначительных ошибках(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Игнорировать предупреждения о незначительных ошибках(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Обнаружить все ошибки кроме E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Обнаружить все кроме E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Обнаружить все';

--- a/core/lang/sv/global.php
+++ b/core/lang/sv/global.php
@@ -1095,7 +1095,7 @@ $_lang["yourinfo_username"] = 'Du är inloggad som';
 $_lang["a17_error_reporting_title"] = 'Detection level of the PHP error';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP error.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore the warning of a slight notice level(<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE';
 $_lang["a17_error_reporting_opt99"] = 'Detect all';
 

--- a/core/lang/uk/global.php
+++ b/core/lang/uk/global.php
@@ -1208,7 +1208,7 @@ $_lang["yourinfo_username"] = 'Ви авторизовані як:';
 $_lang["a17_error_reporting_title"] = 'Виявлення рівня помилки РНР';
 $_lang["a17_error_reporting_msg"] = 'Набір виявлення рівня помилок РНР';
 $_lang["a17_error_reporting_opt0"] = 'Ігнорувати все';
-$_lang["a17_error_reporting_opt1"] = 'Ігнорувати попередження про незначні помилки (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ігнорувати попередження про незначні помилки (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Виявити всі помилки крім E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Виявити всі крім E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Виявити всі';

--- a/core/lang/zh/global.php
+++ b/core/lang/zh/global.php
@@ -1095,7 +1095,7 @@ $_lang["yourinfo_username"] = '你的登陆名:';
 $_lang["a17_error_reporting_title"] = 'Detection level of PHP errors';
 $_lang["a17_error_reporting_msg"] = 'Set the detection level of the PHP errors.';
 $_lang["a17_error_reporting_opt0"] = 'Ignore all';
-$_lang["a17_error_reporting_opt1"] = 'Ignore warnings of a slight notice level (<a href="https://www.google.com/search?q=E_DEPRECATED+E_STRICT" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT</a>)';
+$_lang["a17_error_reporting_opt1"] = 'Ignore warnings of a slight notice level (<a href="https://www.google.com/search?q=E_DEPRECATED+E_NOTICE" target="_blank">E_ALL & ~E_NOTICE & ~E_DEPRECATED</a>)';
 $_lang["a17_error_reporting_opt2"] = 'Detect all errors except E_NOTICE and E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt99"] = 'Detect all except E_USER_DEPRECATED';
 $_lang["a17_error_reporting_opt199"] = 'Detect all';

--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -1841,7 +1841,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
             $detected = true;
         } elseif ($this->getConfig('error_reporting') === 2 && ($error & ~E_NOTICE & ~E_USER_DEPRECATED)) {
             $detected = true;
-        } elseif ($this->getConfig('error_reporting') === 1 && ($error & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT)) {
+        } elseif ($this->getConfig('error_reporting') === 1 && ($error & ~E_NOTICE & ~E_DEPRECATED)) {
             $detected = true;
         }
 

--- a/core/src/ExceptionHandler.php
+++ b/core/src/ExceptionHandler.php
@@ -100,7 +100,7 @@ class ExceptionHandler
      */
     public function phpError($nr, $text, $file, $line)
     {
-        if (error_reporting() == 0 || $nr == 0 || error_reporting() !== E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT) {
+        if (error_reporting() == 0 || $nr == 0 || error_reporting() !== E_ALL & ~E_DEPRECATED & ~E_NOTICE) {
             return true;
         }
         if ($this->container->stopOnNotice == false) {
@@ -119,7 +119,6 @@ class ExceptionHandler
                     $isError = false;
                     $msg = 'PHP Minor Problem (this message show logged in only)';
                     break;
-                case E_STRICT:
                 case E_DEPRECATED:
                     if ($this->container->error_reporting <= 1) {
                         return true;
@@ -219,7 +218,6 @@ class ExceptionHandler
             E_USER_ERROR => "USER ERROR",
             E_USER_WARNING => "USER WARNING",
             E_USER_NOTICE => "USER NOTICE",
-            E_STRICT => "STRICT NOTICE",
             E_RECOVERABLE_ERROR => "RECOVERABLE ERROR",
             E_DEPRECATED => "DEPRECATED",
             E_USER_DEPRECATED => "USER DEPRECATED"
@@ -350,7 +348,6 @@ class ExceptionHandler
         switch ($nr) {
             case E_DEPRECATED :
             case E_USER_DEPRECATED :
-            case E_STRICT :
             case E_NOTICE :
             case E_USER_NOTICE :
                 $error_level = 2;

--- a/install/cli-install.php
+++ b/install/cli-install.php
@@ -9,10 +9,11 @@ define('EVO_SITE_URL', '/');
 define('EVO_CORE_PATH', $base_path . 'core/');
 define('IN_INSTALL_MODE', true);
 define('MODX_CLI', true);
-require_once 'src/functions.php';
+require_once EVO_BASE_PATH . 'install/src/functions.php';
 /**
- * EVO Cli Installer
+ * EVO Cli Installer/Updater
  * php cli-install.php --typeInstall=1 --databaseType=pgsql --databaseServer=localhost --database=db_name --databaseUser=serious --databasePassword=serious  --tablePrefix=evo_ --cmsAdmin=admin --cmsAdminEmail=serious2008@gmail.com --cmsPassword=123456 --language=uk --removeInstall=y
+ * php cli-install.php --typeInstall=2 --removeInstall=y
  **/
 
 $install = new InstallEvo($argv);
@@ -187,104 +188,77 @@ class InstallEvo
 
     public function checkDatabaseType()
     {
-        if ($this->databaseType != 'pgsql' && $this->databaseType != 'mysql') {
+        $dbTypes = ['pgsql', 'mysql'];
+        while (!in_array($this->databaseType, $dbTypes)) {
             $this->databaseType = $this->choice(
                 'Please choose your database type:',
-                ['mysql', 'pgsql'],
-                0
+                $dbTypes
             );
-        }
-        if ($this->databaseType != 'pgsql' && $this->databaseType != 'mysql') {
-            $this->checkDatabaseType();
         }
     }
 
     public function checkDatabaseServer()
     {
-        if ($this->databaseServer == '') {
+        while ($this->databaseServer === '') {
             $this->databaseServer = $this->ask('Please enter database server:', 'localhost');
-        }
-        if ($this->databaseServer == '') {
-            $this->checkDatabaseServer();
         }
     }
 
     public function checkDatabase()
     {
-        if ($this->database == '') {
+        while ($this->database === '') {
             $this->database = $this->ask('Please enter database:', '');
-        }
-        if ($this->database == '') {
-            $this->checkDatabase();
         }
     }
 
     public function checkDatabaseUser()
     {
-        if ($this->databaseUser == '') {
+        while ($this->databaseUser === '') {
             $this->databaseUser = $this->ask('Please enter database user:', '');
-        }
-        if ($this->databaseUser == '') {
-            $this->checkDatabaseUser();
         }
     }
 
     public function checkDatabasePassword()
     {
-        if ($this->databasePassword == '') {
+        while ($this->databasePassword === '') {
             $this->databasePassword = $this->ask('Please enter database password:', '');
-        }
-        if ($this->databasePassword == '') {
-            $this->checkDatabasePassword();
         }
     }
 
     public function checkTablePrefix()
     {
-        if ($this->tablePrefix == '') {
+        while ($this->tablePrefix === '') {
             $this->tablePrefix = $this->ask('Please enter table_prefix:', 'evo_');
-        }
-        if ($this->tablePrefix == '') {
-            $this->tablePrefix = 'evo_';
         }
     }
 
     public function checkCmsAdmin()
     {
-        if ($this->cmsAdmin == '') {
+        while ($this->cmsAdmin === '') {
             $this->cmsAdmin = $this->ask('Please enter you login for access to manager:', '');
-        }
-        if ($this->cmsAdmin == '') {
-            $this->checkCmsAdmin();
         }
     }
 
     public function checkCmsAdminEmail()
     {
-        if ($this->cmsAdminEmail == '') {
+        while ($this->cmsAdminEmail === '') {
             $this->cmsAdminEmail = $this->ask('Please enter you email:', '');
-        }
-        if ($this->cmsAdminEmail == '') {
-            $this->checkCmsAdminEmail();
         }
     }
 
     public function checkCmsPassword()
     {
-        if ($this->cmsPassword == '') {
+        while ($this->cmsPassword === '') {
             $this->cmsPassword = $this->ask('Please enter you password for access to manager:', '');
-        }
-        if ($this->database == '') {
-            $this->checkCmsPassword();
         }
     }
 
     public function checkLanguage()
     {
         $langs = [];
-        if ($handle = opendir(EVO_BASE_PATH . 'core/lang')) {
+        if ($handle = opendir(EVO_CORE_PATH . 'lang')) {
             while (false !== ($file = readdir($handle))) {
-                if (is_dir(EVO_BASE_PATH . 'core/lang/' . $file) && $file != '.' && $file != '..') {
+                if (is_dir(EVO_CORE_PATH . 'lang/' . $file) && $file != '.' && $file != '..') {
                     $langs[] = $file;
                 }
             }
@@ -411,9 +385,8 @@ class InstallEvo
 
     public function composerUpdate()
     {
-        $projectRoot = dirname(__DIR__);
-        $composerBin = $projectRoot . '/core/vendor/bin/composer';
-        $workingDir  = $projectRoot . '/core';
+        $composerBin = EVO_CORE_PATH . 'vendor/bin/composer';
+        $workingDir  = EVO_CORE_PATH;
         $cmd = sprintf(
             'php %s update --no-interaction --prefer-dist --working-dir=%s',
             escapeshellarg($composerBin),
@@ -691,7 +664,7 @@ class InstallEvo
         if (is_dir($modulePath) && is_readable($modulePath)) {
             $d = dir($modulePath);
             while (false !== ($tplfile = $d->read())) {
-                if (substr($tplfile, -4) != '.tpl') {
+                if (!str_ends_with($tplfile, '.tpl')) {
                     continue;
                 }
                 $params = parse_docblock($modulePath, $tplfile);

--- a/install/index.php
+++ b/install/index.php
@@ -2,7 +2,7 @@
 /**
  * Evolution CMS Installer
  */
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 $base_path = dirname(__DIR__) . '/';
 
 if (is_file($base_path . 'assets/cache/siteManager.php')) {

--- a/install/src/controllers/options.php
+++ b/install/src/controllers/options.php
@@ -15,7 +15,7 @@ switch($installMode){
         $database_collation = $db_config['collation'];
         $database_connection_charset = $db_config['charset'];
         if (@$conn = mysqli_connect($db_config['host'], $db_config['username'], $db_config['password'], '', isset($db_config['port']) ? $db_config['port'] : null)) {
-            if (@mysqli_query($conn, 'USE ' . $db_config['database'])) {
+            if (@mysqli_query($conn, 'USE `' . mysqli_real_escape_string($conn, $db_config['database']) . '`')) {
                 if (!$rs = mysqli_query($conn, "show session variables like 'collation_database'")) {
                     $rs = mysqli_query($conn, "show session variables like 'collation_server'");
                 }


### PR DESCRIPTION
All e_strict errors was replaced with e_notice in php8.0 and so e_strict raises deprecation warning since 8.4
https://php.watch/versions/8.0/error-display-E_ALL

https://www.php.net/manual/en/errorfunc.constants.php