### PR TITLE
EvolutionCMS() to evo() and related cleanup

### DIFF
--- a/core/functions/laravel.php
+++ b/core/functions/laravel.php
@@ -55,7 +55,7 @@ if (! function_exists('base_path')) {
      */
     function base_path($path = '')
     {
-        return evolutionCMS()->basePath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return evo()->basePath() . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }
 
@@ -68,7 +68,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return evolutionCMS()->publicPath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return evo()->publicPath() . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }
 
@@ -81,7 +81,7 @@ if (! function_exists('resource_path')) {
      */
     function resource_path($path = '')
     {
-        return evolutionCMS()->publicPath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return evo()->publicPath() . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }
 
@@ -134,10 +134,10 @@ if (! function_exists('app')) {
     function app($abstract = null, array $parameters = [])
     {
         if (is_null($abstract)) {
-            return evolutionCMS();
+            return evo();
         }
 
-        return evolutionCMS()->make($abstract, $parameters);
+        return evo()->make($abstract, $parameters);
     }
 }
 

--- a/core/functions/nodes.php
+++ b/core/functions/nodes.php
@@ -10,7 +10,7 @@ if (!function_exists('makeHTML')) {
      */
     function makeHTML($indent, $parent, $expandAll, $hereid = '')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         global $icons, $_style, $_lang, $opened, $opened2, $closed2, $modx_textdir;
 
         $output = '';
@@ -552,7 +552,7 @@ if (!function_exists('getNodeTitle')) {
      */
     function getNodeTitle($nodeNameSource, $row)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         switch ($nodeNameSource) {
             case 'menutitle':
@@ -638,7 +638,7 @@ if (!function_exists('_htmlentities')) {
      */
     function _htmlentities($array)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $array = json_encode($array, JSON_UNESCAPED_UNICODE);
         $array = htmlentities($array, ENT_COMPAT, $modx->getConfig('modx_charset'));

--- a/core/functions/processors.php
+++ b/core/functions/processors.php
@@ -14,7 +14,7 @@ if (!function_exists('evalModule')) {
      */
     function evalModule($moduleCode, $params)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $modx->event->params = &$params; // store params inside event object
         if (is_array($params)) {
             extract($params, EXTR_SKIP);
@@ -109,7 +109,7 @@ if (!function_exists('login')) {
      */
     function login($username, $givenPassword, $dbasePassword)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getPasswordHash()->CheckPassword($givenPassword, $dbasePassword);
     }
@@ -125,7 +125,7 @@ if (!function_exists('loginV1')) {
      */
     function loginV1($internalKey, $givenPassword, $dbasePassword, $username)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $user_algo = $modx->getManagerApi()->getV1UserHashAlgorithm($internalKey);
 
@@ -158,7 +158,7 @@ if (!function_exists('loginMD5')) {
      */
     function loginMD5($internalKey, $givenPassword, $dbasePassword, $username)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         if ($dbasePassword != md5($givenPassword)) {
             return false;
@@ -176,7 +176,7 @@ if (!function_exists('updateNewHash')) {
      */
     function updateNewHash($username, $password)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $field = array();
         $field['password'] = $modx->getPasswordHash()->HashPassword($password);
@@ -191,7 +191,6 @@ if (!function_exists('saveUserGroupAccessPermissons')) {
      */
     function saveUserGroupAccessPermissons()
     {
-        $modx = evolutionCMS();
         global $id, $newid;
         global $use_udperms;
 
@@ -272,7 +271,6 @@ if (!function_exists('getEventIdByName')) {
      */
     function getEventIdByName($name)
     {
-        $modx = evolutionCMS();
         static $eventIds = array();
 
         if (isset($eventIds[$name])) {
@@ -290,7 +288,6 @@ if (!function_exists('saveTemplateAccess')) {
      */
     function saveTemplateAccess($id)
     {
-        $modx = evolutionCMS();
         if ($_POST['tvsDirty'] == 1) {
             $newAssignedTvs = isset($_POST['assignedTv']) ? $_POST['assignedTv'] : '';
 
@@ -327,7 +324,6 @@ if (!function_exists('saveTemplateVarAccess')) {
      */
     function saveTemplateVarAccess($id)
     {
-        $modx = evolutionCMS();
         $templates = isset($_POST['template']) ? $_POST['template'] : []; // get muli-templates based on S.BRENNAN mod
 
         $siteTmlvarTemplates = EvolutionCMS\Models\SiteTmplvarTemplate::where('tmplvarid', '=', $id)->get();
@@ -358,7 +354,6 @@ if (!function_exists('saveVarRoles')) {
      */
     function saveVarRoles($id)
     {
-        $modx = evolutionCMS();
         $roles = isset($_POST['role']) ? $_POST['role'] : [];
 
         $exists = EvolutionCMS\Models\UserRoleVar::where('tmplvarid', '=', $id)->get();
@@ -383,7 +378,7 @@ if (!function_exists('saveVarRoles')) {
 if (!function_exists('saveDocumentAccessPermissons')) {
     function saveDocumentAccessPermissons($id)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $docgroups = isset($_POST['docgroups']) ? $_POST['docgroups'] : '';
 
@@ -414,7 +409,7 @@ if (!function_exists('sendMailMessageForUser')) {
      */
     function sendMailMessageForUser($email, $uid, $pwd, $ufn, $message, $url)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         global $_lang;
         global $emailsubject, $emailsender;
         $message = sprintf($message, $uid, $pwd); // use old method

--- a/core/functions/tv.php
+++ b/core/functions/tv.php
@@ -11,7 +11,7 @@ if (!function_exists('ProcessTVCommand')) {
      */
     function ProcessTVCommand($value, $name = '', $docid = '', $src = 'docform', $tvsArray = array())
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $docid = (int)$docid;
         if (!$docid) {
             $docid = $modx->documentIdentifier;
@@ -186,7 +186,7 @@ if (!function_exists('parseTvValues')) {
             return $param;
         }
 
-        $modx = evolutionCMS();
+        $modx = evo();
         if (is_array($modx->documentObject)) {
             $tvsArray = array_merge($tvsArray, $modx->documentObject);
         }
@@ -224,7 +224,7 @@ if (!function_exists('getTVDisplayFormat')) {
     function getTVDisplayFormat($name, $value, $format, $paramstring = '', $tvtype = '', $docid = '', $sep = '')
     {
 
-        $modx = evolutionCMS();
+        $modx = evo();
         $o = '';
 
         // process any TV commands in value
@@ -593,7 +593,7 @@ if (!function_exists('parseInput')) {
      */
     function parseInput($src, $delim = '||', $type = 'string', $columns = true)
     { // type can be: string, array
-        $modx = evolutionCMS();
+        $modx = evo();
         if ($modx->getDatabase()->isResult($src)) {
             // must be a recordset
             $rows = array();
@@ -667,7 +667,7 @@ if (!function_exists('renderFormElement')) {
         $content = null
     )
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if ($content === null) {
             global $content;
         }
@@ -974,7 +974,7 @@ if (!function_exists('ParseIntputOptions')) {
      */
     function ParseIntputOptions($v)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (is_array($v)) {
             return $v;
         }

--- a/core/src/AbstractLaravel.php
+++ b/core/src/AbstractLaravel.php
@@ -459,11 +459,12 @@ abstract class AbstractLaravel extends Container implements ApplicationContract
      * Resolve the given type from the container.
      *
      * (Overriding Container::make)
+     * @template TClass of object
      *
-     * @param string $abstract
+     * @param string|class-string<TClass> $abstract
      * @param array $parameters
-     * @return mixed
-     */
+     * @return ($abstract is class-string<TClass> ? \Closure(): TClass : \Closure(): mixed)
+    */
     public function make($abstract, array $parameters = [])
     {
         $abstract = $this->getAlias($abstract);

--- a/core/src/Console/ClearCacheFullCommand.php
+++ b/core/src/Console/ClearCacheFullCommand.php
@@ -33,7 +33,7 @@ class ClearCacheFullCommand extends Command
             @unlink($packagesPath);
         }
 
-        EvolutionCMS()->clearCache('full');
+        evo()->clearCache('full');
         $this->info('Cache clear');
     }
 }

--- a/core/src/Console/Packages/ExtrasCommand.php
+++ b/core/src/Console/Packages/ExtrasCommand.php
@@ -90,7 +90,7 @@ class ExtrasCommand extends Command
     public function __construct()
     {
         parent::__construct();
-        $this->evo = EvolutionCMS();
+        $this->evo = evo();
         $this->load_dir = $this->evo->getConfig('rb_base_dir');
     }
 

--- a/core/src/Console/Packages/PackageCommand.php
+++ b/core/src/Console/Packages/PackageCommand.php
@@ -55,7 +55,7 @@ class PackageCommand extends Command
     public function __construct()
     {
         parent::__construct();
-        $this->evo = EvolutionCMS();
+        $this->evo = evo();
         $this->load_dir = $this->evo->getConfig('rb_base_dir');
     }
 

--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -47,7 +47,7 @@ class SiteUpdateCommand extends Command
 
     public function startUpdate()
     {
-        $evo = EvolutionCMS();
+        $evo = evo();
         $updateRepository = $evo->getConfig('UpgradeRepository');
         if ($updateRepository == '') {
             $updateRepository = 'evolution-cms/evolution';
@@ -120,8 +120,8 @@ class SiteUpdateCommand extends Command
                 closedir($handle);
             }
 
-            SELF::moveFiles($temp_dir . '/' . $dir, MODX_BASE_PATH);
-            SELF::rmdirs($temp_dir);
+            self::moveFiles($temp_dir . '/' . $dir, MODX_BASE_PATH);
+            self::rmdirs($temp_dir);
 
             $ch = curl_init();
             $url = 'https://api.github.com/repos/' . $updateRepository . '/releases';
@@ -160,7 +160,7 @@ class SiteUpdateCommand extends Command
                     $file = str_replace('{core}', EVO_CORE_PATH, $file);
                     if (file_exists($file)) {
                         if (is_dir($file)) {
-                            SELF::rmdirs($file);
+                            self::rmdirs($file);
                         } else {
                             unlink($file);
                         }

--- a/core/src/Controllers/Users/DeleteUser.php
+++ b/core/src/Controllers/Users/DeleteUser.php
@@ -30,7 +30,7 @@ class DeleteUser extends AbstractController implements ManagerTheme\PageControll
     public function process() : bool
     {
         if($_GET['id'] == evo()->getLoginUserID()){
-            EvolutionCMS()->webAlertAndQuit(Lang::get('global.delete_yourself'));
+            evo()->webAlertAndQuit(Lang::get('global.delete_yourself'));
         }
         $user = Models\UserAttribute::query()->where('internalKey', $_GET['id'])->first();
         if($user->role == 1){

--- a/core/src/Database.php
+++ b/core/src/Database.php
@@ -26,7 +26,7 @@ class Database extends Manager
 
     public $config;
 
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         parent::__construct($container);
         $this->prepareNativeConfig();
@@ -84,7 +84,7 @@ class Database extends Manager
             return $out;
         } catch (Exception $exception) {
             if ($watchError === true) {
-                evolutionCMS()->getService('ExceptionHandler')->messageQuit($exception->getMessage());
+                evo()->getService('ExceptionHandler')->messageQuit($exception->getMessage());
             }
         }
     }
@@ -473,7 +473,7 @@ class Database extends Manager
 
         $out = false;
         if (!$from) {
-            evolutionCMS()->getService('ExceptionHandler')->messageQuit("Empty \$from parameters in DBAPI::delete().");
+            evo()->getService('ExceptionHandler')->messageQuit("Empty \$from parameters in DBAPI::delete().");
         } else {
             $from = $this->replaceFullTableName($from);
             $where = trim($where);
@@ -588,7 +588,7 @@ class Database extends Manager
     {
         $out = false;
         if (!$intotable) {
-            evolutionCMS()->getService('ExceptionHandler')->messageQuit("Empty \$intotable parameters in DBAPI::insert().");
+            evo()->getService('ExceptionHandler')->messageQuit("Empty \$intotable parameters in DBAPI::insert().");
         } else {
             $intotable = $this->replaceFullTableName($intotable);
             if (!is_array($fields)) {
@@ -621,7 +621,7 @@ class Database extends Manager
                 }
             }
             if (($lid = $this->getInsertId()) === false) {
-                evolutionCMS()->getService('ExceptionHandler')->messageQuit("Couldn't get last insert key!");
+                evo()->getService('ExceptionHandler')->messageQuit("Couldn't get last insert key!");
             }
 
             $out = $lid;
@@ -649,7 +649,7 @@ class Database extends Manager
     {
         $out = false;
         if (!$table) {
-            evolutionCMS()->getService('ExceptionHandler')->messageQuit('Empty ' . $table . ' parameter in DBAPI::update().');
+            evo()->getService('ExceptionHandler')->messageQuit('Empty ' . $table . ' parameter in DBAPI::update().');
         } else {
             $table = $this->replaceFullTableName($table);
             if (is_array($fields)) {
@@ -688,8 +688,9 @@ class Database extends Manager
     public function getTableMetaData($table)
     {
         $metadata = [];
+        $driver = evo()->getDatabase()->getConfig('driver');
         if (!empty($table) && is_scalar($table)) {
-            switch (EvolutionCMS()->getDatabase()->getConfig('driver')) {
+            switch ($driver) {
                 case 'pgsql':
                     $sql = " SELECT * FROM information_schema.columns WHERE table_name = '" . $table . "';";
                     break;
@@ -699,7 +700,7 @@ class Database extends Manager
             }
             if ($ds = $this->query($sql)) {
                 while ($row = $this->getRow($ds)) {
-                    switch (EvolutionCMS()->getDatabase()->getConfig('driver')) {
+                    switch ($driver) {
                         case 'pgsql':
                             $fieldName = $row['column_name'];
                             break;

--- a/core/src/ExceptionHandler.php
+++ b/core/src/ExceptionHandler.php
@@ -154,7 +154,7 @@ class ExceptionHandler
      * @param string $text
      * @param string $line
      * @param string $output
-     * @return bool
+     * @return void|bool
      */
     public function messageQuit(
         $msg = 'unspecified error',
@@ -182,7 +182,9 @@ class ExceptionHandler
         $table = array();
 
         if (isset($_SERVER['HTTP_HOST'])) {
-            $request_uri = "http://" . $_SERVER['HTTP_HOST'] . ($_SERVER["SERVER_PORT"] == 80 ? "" : (":" . $_SERVER["SERVER_PORT"])) . $_SERVER['REQUEST_URI'];
+            $request_uri = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] .
+                (in_array((int)$_SERVER['SERVER_PORT'], [80, (int)HTTPS_PORT]) ? '' : (':' . $_SERVER['SERVER_PORT'])) .
+                $_SERVER['REQUEST_URI'];
             $request_uri = $this->container->getPhpCompat()->htmlspecialchars($request_uri, ENT_QUOTES,
                 $this->container->getConfig('modx_charset'));
         } else {

--- a/core/src/Legacy/Cache.php
+++ b/core/src/Legacy/Cache.php
@@ -30,8 +30,7 @@ class Cache
      */
     public function __construct()
     {
-        $modx = evolutionCMS();
-        $this->request_time = $_SERVER['REQUEST_TIME'] + $modx->getConfig('server_offset_time');
+        $this->request_time = $_SERVER['REQUEST_TIME'] + evo()->getConfig('server_offset_time');
     }
 
     /**
@@ -180,7 +179,7 @@ class Cache
         $content .= '$recent_update=\'' . $this->request_time . '\';' . "\n";
         $content .= '$cacheRefreshTime=\'' . $cacheRefreshTime . '\';' . "\n";
 
-        $filename = evolutionCMS()->getSitePublishingFilePath();
+        $filename = evo()->getSitePublishingFilePath();
         if (!$handle = fopen($filename, 'w')) {
             exit("Cannot open file ({$filename}");
         }
@@ -198,8 +197,6 @@ class Cache
      */
     public function getCacheRefreshTime()
     {
-        $modx = evolutionCMS();
-
         // update publish time file
         $timesArr = array();
 

--- a/core/src/Legacy/DeprecatedCore.php
+++ b/core/src/Legacy/DeprecatedCore.php
@@ -11,7 +11,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
     */
     public function dbConnect()
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $modx->getDatabase()->connect();
         $modx->rs = $modx->getDatabase()->conn;
     }
@@ -20,11 +20,11 @@ class DeprecatedCore implements DeprecatedCoreInterface
      * @deprecated
      *
      * @param $sql
-     * @return bool|mysqli_result|resource
+     * @return bool|\mysqli_result|resource
      */
     public function dbQuery($sql)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getDatabase()->query($sql);
     }
@@ -37,7 +37,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function recordCount($rs)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getDatabase()->getRecordCount($rs);
     }
@@ -51,7 +51,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function fetchRow($rs, $mode = 'assoc')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getDatabase()->getRow($rs, $mode);
     }
@@ -64,7 +64,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function affectedRows($rs)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getDatabase()->getAffectedRows($rs);
     }
@@ -77,7 +77,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function insertId($rs)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getDatabase()->getInsertId($rs);
     }
@@ -89,7 +89,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function dbClose()
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $modx->getDatabase()->disconnect();
     }
 
@@ -179,7 +179,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function putChunk($chunkName)
     { // alias name >.<
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getChunk($chunkName);
     }
@@ -191,7 +191,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function getDocGroups()
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->getUserDocGroups();
     }
@@ -205,7 +205,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function changePassword($o, $n)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         return $modx->changeWebUserPassword($o, $n);
     }
@@ -217,7 +217,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function userLoggedIn()
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $userdetails = array();
         if ($modx->isFrontend() && isset ($_SESSION['webValidated'])) {
             // web user
@@ -254,7 +254,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
     public function getFormVars($method = "", $prefix = "", $trim = "", $REQUEST_METHOD)
     {
         //  function to retrieve form results into an associative array
-        $modx = evolutionCMS();
+        $modx = evo();
         $results = array();
         $method = strtoupper($method);
         if ($method == "") {
@@ -295,7 +295,7 @@ class DeprecatedCore implements DeprecatedCoreInterface
      */
     public function webAlert($msg, $url = "")
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $msg = addslashes($modx->getDatabase()->escape($msg));
         if (substr(strtolower($url), 0, 11) == "javascript:") {
             $act = "__WebAlert();";

--- a/core/src/Legacy/Modifiers.php
+++ b/core/src/Legacy/Modifiers.php
@@ -63,7 +63,7 @@ class Modifiers implements ModifiersInterface
      */
     public function __construct()
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (function_exists('mb_internal_encoding')) {
             mb_internal_encoding($modx->getConfig('modx_charset'));
         }
@@ -78,7 +78,7 @@ class Modifiers implements ModifiersInterface
      */
     public function phxFilter($key, $value, $modifiers)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (substr($modifiers, 0, 3) !== 'id(') {
             $value = $this->parseDocumentSource($value);
         }
@@ -191,7 +191,7 @@ class Modifiers implements ModifiersInterface
 
     public function splitEachModifiers($modifiers)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $cmd = '';
         $bt = '';
@@ -263,7 +263,6 @@ class Modifiers implements ModifiersInterface
 
     public function parsePhx($key, $value, $modifiers)
     {
-        $modx = evolutionCMS();
         $lastKey = '';
         $cacheKey = md5('parsePhx#' . $key . '#' . $value . '#' . print_r($modifiers, true));
         if (isset($this->tmpCache[$cacheKey])) {
@@ -282,7 +281,7 @@ class Modifiers implements ModifiersInterface
             $modifiers[] = array('cmd' => 'else', 'opt' => '0');
         }
 
-        foreach ($modifiers as $i => $a) {
+        foreach ($modifiers as $a) {
             $value = $this->Filter($key, $value, $a['cmd'], $a['opt']);
         }
         $this->tmpCache[$cacheKey] = $value;
@@ -293,7 +292,7 @@ class Modifiers implements ModifiersInterface
     // Parser: modifier detection and eXtended processing if needed
     public function Filter($key, $value, $cmd, $opt = '')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         if ($key === 'documentObject') {
             $value = $modx->documentIdentifier;
@@ -344,7 +343,7 @@ class Modifiers implements ModifiersInterface
 
     public function getValueFromPreset($key, $value, $cmd, $opt)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         if ($this->isEmpty($cmd, $value)) {
             return '';
@@ -856,7 +855,7 @@ class Modifiers implements ModifiersInterface
                         // https://www.php.net/manual/en/class.intldateformatter.php
                         // https://www.php.net/manual/en/datetime.createfromformat.php
                         $formatter = new IntlDateFormatter(
-                            evolutionCMS()->getConfig('manager_language'),
+                            evo()->getConfig('manager_language'),
                             IntlDateFormatter::MEDIUM,
                             IntlDateFormatter::MEDIUM,
                             null,
@@ -1306,7 +1305,7 @@ class Modifiers implements ModifiersInterface
 
     public function includeMdfFile($cmd)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $key = $this->key;
         $value = $this->value;
         $opt = $this->opt;
@@ -1316,7 +1315,7 @@ class Modifiers implements ModifiersInterface
 
     public function getValueFromElement($key, $value, $cmd, $opt)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (isset($modx->snippetCache[$this->elmName])) {
             $php = $modx->snippetCache[$this->elmName];
         } else {
@@ -1412,7 +1411,7 @@ class Modifiers implements ModifiersInterface
 
     public function parseDocumentSource($content = '')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         if (strpos($content, '[') === false && strpos($content, '{') === false) {
             return $content;
@@ -1455,7 +1454,7 @@ class Modifiers implements ModifiersInterface
 
     public function getDocumentObject($target = '', $field = 'pagetitle')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $target = trim($target);
         if (empty($target)) {
@@ -1510,7 +1509,7 @@ class Modifiers implements ModifiersInterface
     //mbstring
     public function substr($str, $s, $l = null)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (is_null($l)) {
             $l = $this->strlen($str);
         }
@@ -1527,7 +1526,7 @@ class Modifiers implements ModifiersInterface
 
     public function strpos($haystack, $needle, $offset = 0)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (function_exists('mb_strpos')) {
             return mb_strpos($haystack, $needle, $offset, $modx->getConfig('modx_charset'));
         }
@@ -1537,7 +1536,7 @@ class Modifiers implements ModifiersInterface
 
     public function strlen($str)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (function_exists('mb_strlen')) {
             return mb_strlen(str_replace("\r\n", "\n", $str), $modx->getConfig('modx_charset'));
         }
@@ -1612,7 +1611,7 @@ class Modifiers implements ModifiersInterface
 
     public function strip_tags($value, $params = '')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         if (stripos($params, 'style') === false && stripos($value, '</style>') !== false) {
             $value = preg_replace('@<style.*?>.*?</style>@is', '', $value);

--- a/core/src/Legacy/ModuleCategoriesManager.php
+++ b/core/src/Legacy/ModuleCategoriesManager.php
@@ -46,7 +46,7 @@ class ModuleCategoriesManager extends Categories
      */
     public function get($key)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         if (isset($this->params[$key])) {
             return $this->params[$key];

--- a/core/src/Legacy/Permissions.php
+++ b/core/src/Legacy/Permissions.php
@@ -31,7 +31,7 @@ class Permissions
     {
 
         global $udperms_allowroot;
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $document = $this->document;
         $role = $this->role;

--- a/core/src/Legacy/PhpCompat.php
+++ b/core/src/Legacy/PhpCompat.php
@@ -50,6 +50,6 @@ class PhpCompat implements PhpCompatInterface
 
     public function entities($data)
     {
-        return entities($data, evolutionCMS()->getConfig('modx_charset', 'UTF-8'));
+        return entities($data, evo()->getConfig('modx_charset', 'UTF-8'));
     }
 }

--- a/core/src/Legacy/Phx.php
+++ b/core/src/Legacy/Phx.php
@@ -47,7 +47,7 @@ class Phx
     {
         $modx = get_by_key($args, 0);
         if (! $modx instanceof Core) {
-            $modx = evolutionCMS();
+            $modx = evo();
         }
 
         $this->modx = $modx;

--- a/core/src/Legacy/mgrResources.php
+++ b/core/src/Legacy/mgrResources.php
@@ -78,7 +78,7 @@ class mgrResources
     public function queryItemsFromDB()
     {
         foreach ($this->types as $resourceTable => $type) {
-            if (evolutionCMS()->hasAnyPermissions($type['permissions'])) {
+            if (evo()->hasAnyPermissions($type['permissions'])) {
                 $nameField = isset($type['name']) ? $type['name'] : 'name';
                 $this->items[$resourceTable] = $this->queryResources($resourceTable, $nameField);
             }
@@ -92,7 +92,7 @@ class mgrResources
      */
     public function queryResources($resourceTable, $nameField = 'name')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         global $_lang;
 
         $allowed = array(

--- a/core/src/Mail.php
+++ b/core/src/Mail.php
@@ -28,7 +28,7 @@ class Mail extends PHPMailer
     public function init($modx = null)
     {
         if ($modx === null) {
-            $modx = evolutionCMS();
+            $modx = evo();
         }
         $this->modx = $modx;
         $this->PluginDir = MODX_MANAGER_PATH . 'includes/controls/phpmailer/';

--- a/core/src/Models/ActiveUser.php
+++ b/core/src/Models/ActiveUser.php
@@ -39,7 +39,7 @@ class ActiveUser extends Eloquent\Model
     public function scopeLocked(Eloquent\Builder $builder, $action, $id = null, $userId = null)
     {
         if ($userId === null) {
-            $userId = evolutionCMS()->getLoginUserID();
+            $userId = evo()->getLoginUserID();
         }
 
         $builder = $builder->where('action', '=', (int)$action)

--- a/core/src/Models/SiteContent.php
+++ b/core/src/Models/SiteContent.php
@@ -306,7 +306,7 @@ class SiteContent extends Eloquent\Model
      */
     public function getNodeNameAttribute()
     {
-        $key = evolutionCMS()->getConfig('resource_tree_node_name', 'pagetitle');
+        $key = evo()->getConfig('resource_tree_node_name', 'pagetitle');
         if (mb_strtolower($key) === 'nodename') {
             $key = 'pagetitle';
         }
@@ -364,7 +364,7 @@ class SiteContent extends Eloquent\Model
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(7);
+        return evo()->getLockedElements(7);
     }
 
     /**
@@ -2117,7 +2117,7 @@ class SiteContent extends Eloquent\Model
 
     public function scopeTvFilter($query, $filters = '', $outerSep = ';', $innerSep = ':')
     {
-        $prefix = EvolutionCMS()->getDatabase()->getConfig('prefix');
+        $prefix = evo()->getDatabase()->getConfig('prefix');
         $filters = explode($outerSep, trim($filters));
         foreach ($filters as $filter) {
             if (empty($filter)) break;
@@ -2174,7 +2174,7 @@ class SiteContent extends Eloquent\Model
 
     public function scopeTvOrderBy($query, $orderBy = '', $sep = ':')
     {
-        $prefix = EvolutionCMS()->getDatabase()->getConfig('prefix');
+        $prefix = evo()->getDatabase()->getConfig('prefix');
         $orderBy = explode(',', trim($orderBy));
         foreach ($orderBy as $parts) {
             if (empty(trim($parts))) return;

--- a/core/src/Models/SiteHtmlsnippet.php
+++ b/core/src/Models/SiteHtmlsnippet.php
@@ -105,13 +105,13 @@ class SiteHtmlsnippet extends Eloquent\Model
 
     public function scopeLockedView(Eloquent\Builder $builder)
     {
-        return evolutionCMS()->getLoginUserID('mgr') !== 1 ?
+        return evo()->getLoginUserID('mgr') !== 1 ?
             $builder->where('locked', '=', 0) : $builder;
     }
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(3);
+        return evo()->getLockedElements(3);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Models/SiteModule.php
+++ b/core/src/Models/SiteModule.php
@@ -119,17 +119,17 @@ class SiteModule extends Eloquent\Model
 
     public function scopeLockedView(Eloquent\Builder $builder)
     {
-        return evolutionCMS()->getLoginUserID('mgr') !== 1 ?
+        return evo()->getLoginUserID('mgr') !== 1 ?
             $builder->where('locked', '=', 0) : $builder;
     }
 
     public function scopeWithoutProtected(Eloquent\Builder $builder)
     {
-        if ($_SESSION['mgrRole'] != 1 && evolutionCMS()->getConfig('use_udperms')) {
+        if ($_SESSION['mgrRole'] != 1 && evo()->getConfig('use_udperms')) {
             $builder->leftJoin('site_module_access', 'site_module_access.module', '=', 'site_modules.id')
                 ->leftJoin('member_groups', 'member_groups.user_group', '=', 'site_module_access.usergroup')
                 ->whereNull('site_module_access.usergroup')
-                ->orWhere('member_groups.member', '=', (int)evolutionCMS()->getLoginUserID('mgr'));
+                ->orWhere('member_groups.member', '=', (int)evo()->getLoginUserID('mgr'));
         }
 
         return $builder;
@@ -137,7 +137,7 @@ class SiteModule extends Eloquent\Model
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(6);
+        return evo()->getLockedElements(6);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Models/SitePlugin.php
+++ b/core/src/Models/SitePlugin.php
@@ -120,7 +120,7 @@ class SitePlugin extends Eloquent\Model
 
     public function scopeLockedView(Eloquent\Builder $builder)
     {
-        return evolutionCMS()->getLoginUserID('mgr') !== 1 ?
+        return evo()->getLoginUserID('mgr') !== 1 ?
             $builder->where('locked', '=', 0) : $builder;
     }
 
@@ -140,7 +140,7 @@ class SitePlugin extends Eloquent\Model
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(5);
+        return evo()->getLockedElements(5);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Models/SiteSnippet.php
+++ b/core/src/Models/SiteSnippet.php
@@ -112,13 +112,13 @@ class SiteSnippet extends Eloquent\Model
 
     public function scopeLockedView(Eloquent\Builder $builder)
     {
-        return evolutionCMS()->getLoginUserID('mgr') !== 1 ?
+        return evo()->getLoginUserID('mgr') !== 1 ?
             $builder->where('locked', '=', 0) : $builder;
     }
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(4);
+        return evo()->getLockedElements(4);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Models/SiteTemplate.php
+++ b/core/src/Models/SiteTemplate.php
@@ -133,13 +133,13 @@ class SiteTemplate extends Eloquent\Model
 
     public function scopeLockedView(Eloquent\Builder $builder)
     {
-        return evolutionCMS()->getLoginUserID('mgr') !== 1 ?
+        return evo()->getLoginUserID('mgr') !== 1 ?
             $builder->where('locked', '=', 0) : $builder;
     }
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(1);
+        return evo()->getLockedElements(1);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Models/SiteTmplvar.php
+++ b/core/src/Models/SiteTmplvar.php
@@ -141,13 +141,13 @@ class SiteTmplvar extends Eloquent\Model
 
     public function scopeLockedView(Eloquent\Builder $builder)
     {
-        return evolutionCMS()->getLoginUserID('mgr') !== 1 ?
+        return evo()->getLoginUserID('mgr') !== 1 ?
             $builder->where('locked', '=', 0) : $builder;
     }
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(2);
+        return evo()->getLockedElements(2);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Models/UserRole.php
+++ b/core/src/Models/UserRole.php
@@ -130,7 +130,7 @@ class UserRole extends Eloquent\Model
 
     public static function getLockedElements()
     {
-        return evolutionCMS()->getLockedElements(8);
+        return evo()->getLockedElements(8);
     }
 
     public function getIsAlreadyEditAttribute()

--- a/core/src/Observers/SiteContentObserver.php
+++ b/core/src/Observers/SiteContentObserver.php
@@ -6,7 +6,7 @@ class SiteContentObserver
 {
     public function saving(SiteContent $model) : bool
     {
-        $model->editedby = evolutionCMS()->getLoginUserID('mgr');
+        $model->editedby = evo()->getLoginUserID('mgr');
         $model->pagetitle = trim($model->pagetitle);
 
         return !empty($model->pagetitle);

--- a/core/src/Providers/BladeServiceProvider.php
+++ b/core/src/Providers/BladeServiceProvider.php
@@ -14,11 +14,11 @@ class BladeServiceProvider extends BaseServiceProvider
             }
         }
         Blade::if('auth', function () {
-            return EvolutionCMS()->getLoginUserID() !== false;
+            return evo()->getLoginUserID() !== false;
         });
 
         Blade::if('guest', function () {
-            return EvolutionCMS()->getLoginUserID() === false;
+            return evo()->getLoginUserID() === false;
         });
     }
 }

--- a/core/src/Providers/TracyServiceProvider.php
+++ b/core/src/Providers/TracyServiceProvider.php
@@ -43,7 +43,7 @@ class TracyServiceProvider extends ServiceProvider
 
     protected function logPath(): string
     {
-        return evolutionCMS()->storagePath() . '/logs';
+        return evo()->storagePath() . '/logs';
     }
 
     protected function isTracyHandler(): bool

--- a/core/src/Services/AuthServices.php
+++ b/core/src/Services/AuthServices.php
@@ -109,7 +109,7 @@ class AuthServices
                 $matchPassword = false;
 
                 // check user password - local authentication
-                $hashType = EvolutionCMS()->getManagerApi()->getHashType($this->user->password);
+                $hashType = evo()->getManagerApi()->getHashType($this->user->password);
 
                 if ($hashType == 'phpass') {
                     $matchPassword = login($this->user->username, $value, $this->user->password);

--- a/core/src/Services/ConfigService.php
+++ b/core/src/Services/ConfigService.php
@@ -5,11 +5,11 @@ class ConfigService
 {
     public function get($config = '', $default = null)
     {
-        return EvolutionCMS()->getConfig($config, $default);
+        return evo()->getConfig($config, $default);
     }
     public function set($name, $value)
     {
-        EvolutionCMS()->setConfig($name, $value);
+        evo()->setConfig($name, $value);
     }
 
 }

--- a/core/src/Support/Captcha.php
+++ b/core/src/Support/Captcha.php
@@ -66,7 +66,7 @@ class Captcha implements CaptchaInterface
     }
 
     public function makeText() {
-        $modx = evolutionCMS();
+        $modx = evo();
         // set default words
         $words="MODX,Access,Better,BitCode,Chunk,Cache,Desc,Design,Excell,Enjoy,URLs,TechView,Gerald,Griff,Humphrey,Holiday,Intel,Integration,Joystick,Join(),Oscope,Genetic,Light,Likeness,Marit,Maaike,Niche,Netherlands,Ordinance,Oscillo,Parser,Phusion,Query,Question,Regalia,Righteous,Snippet,Sentinel,Template,Thespian,Unity,Enterprise,Verily,Veri,Website,WideWeb,Yap,Yellow,Zebra,Zygote";
         $words = $modx->getConfig('captcha_words', $words);

--- a/core/src/Support/DataGrid.php
+++ b/core/src/Support/DataGrid.php
@@ -102,7 +102,6 @@ class DataGrid implements DataGridInterface
 
     public function render()
     {
-        $modx = evolutionCMS();
         $columnHeaderStyle = ($this->columnHeaderStyle) ? "style='" . $this->columnHeaderStyle . "'" : '';
         $columnHeaderClass = ($this->columnHeaderClass) ? "class='" . $this->columnHeaderClass . "'" : "";
         $cssStyle = ($this->cssStyle) ? "style='" . $this->cssStyle . "'" : '';
@@ -320,7 +319,7 @@ class DataGrid implements DataGridInterface
                     $value = strtotime($value);
                 }
 
-                $value = EvolutionCMS()->toDateFormat($value);
+                $value = evo()->toDateFormat($value);
                 break;
 
             case "boolean":

--- a/core/src/Support/DataSetPager.php
+++ b/core/src/Support/DataSetPager.php
@@ -103,7 +103,7 @@ class DataSetPager implements DataSetPagerInterface
 
     public function render()
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         global $_PAGE;
 
         $isDataset = $this->ds instanceof \Illuminate\Database\Eloquent\Builder;

--- a/core/src/Support/DocBlock.php
+++ b/core/src/Support/DocBlock.php
@@ -183,7 +183,7 @@ class DocBlock
         foreach ($parsed as $key => $val) {
             if (is_array($val)) {
                 foreach ($val as $key2 => $val2) {
-                    $val2 = evolutionCMS()->parseText($val2, $ph);
+                    $val2 = evo()->parseText($val2, $ph);
                     if (preg_match($regexUrl, $val2, $url)) {
                         $val2 = preg_replace($regexUrl, "<a href=\"{$url[0]}\" target=\"_blank\">{$url[0]}</a> ", $val2);
                     }
@@ -193,7 +193,7 @@ class DocBlock
                     $parsed[$key][$key2] = $val2;
                 }
             } else {
-                $val = evolutionCMS()->parseText($val, $ph);
+                $val = evo()->parseText($val, $ph);
                 if (preg_match($regexUrl, $val, $url)) {
                     $val = preg_replace($regexUrl, "<a href=\"{$url[0]}\" target=\"_blank\">{$url[0]}</a> ", $val);
                 }

--- a/core/src/Support/MakeTable.php
+++ b/core/src/Support/MakeTable.php
@@ -559,7 +559,7 @@ class MakeTable implements MakeTableInterface
      */
     public function createPageLink($link = '', $pageNum = 1, $displayText = '', $currentPage = false, $qs = '')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $orderBy = !empty($_GET['orderby']) ? '&orderby=' . $_GET['orderby'] : '';
         $orderDir = !empty($_GET['orderdir']) ? '&orderdir=' . $_GET['orderdir'] : '';
         if (!empty($qs)) {
@@ -634,7 +634,7 @@ class MakeTable implements MakeTableInterface
      */
     public function prepareOrderByLink($key, $text, $qs = '')
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         if (!empty($_GET['orderdir'])) {
             $orderDir = strtolower($_GET['orderdir']) == 'desc' ? '&orderdir=asc' : '&orderdir=desc';
         } else {

--- a/core/src/Support/Menu.php
+++ b/core/src/Support/Menu.php
@@ -71,7 +71,7 @@ class Menu implements MenuInterface
      */
     public function drawSub($parentid, $level)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
 
         $output = '';
 

--- a/core/src/Support/MysqlDumper.php
+++ b/core/src/Support/MysqlDumper.php
@@ -75,7 +75,7 @@ class MysqlDumper implements MysqlDumperInterface
      */
     public function createDump($callBack)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $createtable = array();
         $dataBaseConfig = $modx->db->getConfig();
 
@@ -246,7 +246,7 @@ class MysqlDumper implements MysqlDumperInterface
      */
     public function result2Array($numinarray = 0, $resource)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $array = array();
         while ($row = $modx->getDatabase()->getRow($resource, 'num')) {
             $array[] = $row[$numinarray];
@@ -270,7 +270,7 @@ class MysqlDumper implements MysqlDumperInterface
      */
     public function loadObjectList($key = '', $resource)
     {
-        $modx = evolutionCMS();
+        $modx = evo();
         $array = array();
         while ($row = $modx->getDatabase()->getRow($resource, 'object')) {
             if ($key) {

--- a/core/src/Tracy/Debugger.php
+++ b/core/src/Tracy/Debugger.php
@@ -13,12 +13,13 @@ class Debugger extends BaseDebugger
 
     public static function errorHandler(int $severity, string $message, string $file, int $line, ?array $context = []): bool
     {
-        if (!empty(evolutionCMS()->currentSnippet)) {
-            $file = 'Snippet: ' . evolutionCMS()->currentSnippet;
+        $evo = evo();
+        if (!empty($evo->currentSnippet)) {
+            $file = "Snippet: $evo->currentSnippet";
         }
 
-        if (!empty(evolutionCMS()->event->activePlugin)) {
-            $file = 'Plugin ' . evolutionCMS()->event->name . '[' . evolutionCMS()->event->activePlugin.']';
+        if (!empty($evo->event->activePlugin)) {
+            $file = "Plugin: {$evo->event->name}[{$evo->event->activePlugin}]";
         }
 
         return parent::errorHandler($severity, $message, $file, $line, $context);

--- a/core/src/Traits/Helpers.php
+++ b/core/src/Traits/Helpers.php
@@ -21,7 +21,7 @@ trait Helpers
     public function now() : Carbon
     {
         return Carbon::now()->addSeconds(
-            evolutionCMS()->getConfig('server_offset_time')
+            evo()->getConfig('server_offset_time')
         );
     }
 

--- a/core/src/Traits/Models/TimeMutator.php
+++ b/core/src/Traits/Models/TimeMutator.php
@@ -11,9 +11,9 @@ trait TimeMutator
         }
 
         $out = $this->asDateTime($value)
-            ->addSeconds(evolutionCMS()->getConfig('server_offset_time'));
+            ->addSeconds(evo()->getConfig('server_offset_time'));
 
-        $out::setToStringFormat(evolutionCMS()->normalizeFormat());
+        $out::setToStringFormat(evo()->normalizeFormat());
 
         return $out;
     }

--- a/manager/captcha.php
+++ b/manager/captcha.php
@@ -24,7 +24,7 @@ if (!empty($config['root']) && file_exists($config['root']. '/index.php')) {
     exit;
 }
 
-$modx = EvolutionCMS();
+$modx = evo();
 
 $modx->documentMethod = 'id';
 $modx->documentIdentifier = isset($_REQUEST['id']) ? (int)$_REQUEST['id'] : 1;

--- a/manager/index.php
+++ b/manager/index.php
@@ -134,7 +134,7 @@ if (!isset($_SERVER['DOCUMENT_ROOT']) || empty($_SERVER['DOCUMENT_ROOT'])) {
 }
 
 // initiate the content manager class
-$modx = evolutionCMS();
+$modx = evo();
 $modx->mstart = $mstart;
 $modx->sid = session_id();
 


### PR DESCRIPTION
I think it's better to have unified name before longer version may spread between new plugins and snippets written specifically for Evolution