### PR TITLE
Update autoload.php

### DIFF
--- a/manager/media/browser/mcpuk/core/autoload.php
+++ b/manager/media/browser/mcpuk/core/autoload.php
@@ -22,7 +22,7 @@
 define('IN_MANAGER_MODE', true);
 define('MODX_API_MODE', true);
 include_once(__DIR__."/../../../../../index.php");
-$mpdx = EvolutionCMS();
+$modx = EvolutionCMS();
 
 if(!isset($_SESSION['mgrValidated'])) {
         die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
@@ -146,3 +146,4 @@ new SessionSaveHandler();
 
 
 // PUT YOUR ADDITIONAL CODE HERE
+


### PR DESCRIPTION
У файлі manager/media/browser/mcpuk/core/autoload.php на рядку 25 допущено друкарську помилку в назві змінної: $mpdx = EvolutionCMS();. Через це у файл browse.php потрапляє неініціалізована змінна $modx, яка за замовчуванням є null.