### PR TITLE
[ADD] Add command to list the code marked as deprecated and for removal by semantic version.

### DIFF
--- a/core/src/Console/Lists/DeprecatedCommand.php
+++ b/core/src/Console/Lists/DeprecatedCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace EvolutionCMS\Console\Lists;
+
+use Illuminate\Console\Command;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class DeprecatedCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'deprecated:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all @deprecated and optional @todo KEYWORD@version tags with exact file:line';
+
+    /**
+     * The command signature (modern Laravel style).
+     */
+    protected $signature = 'deprecated:list
+        {--min= : Minimum version (inclusive)}
+        {--max= : Maximum version (inclusive)}
+        {--todo= : Also search for @todo KEYWORD@version (example: --todo=remove)}
+        {--dir= : Start directory (default: current working directory)}
+        {--ext=php,js,html,htaccess : Comma-separated file extensions}';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $minVer      = $this->option('min') ?: null;
+        $maxVer      = $this->option('max') ?: null;
+        $todoKeyword = $this->option('todo') ?: null;
+        $startDir    = $this->option('dir') ?: getcwd();
+        $extList     = $this->option('ext');
+        $extensions  = array_map('trim', explode(',', strtolower($extList)));
+
+        $excludeDirs = ['vendor', 'node_modules', '.git', 'tmp', 'storage'];
+
+        $results = $this->scan($startDir, $extensions, $excludeDirs, $minVer, $maxVer, $todoKeyword);
+
+        if (empty($results)) {
+            $this->info('No matching @deprecated or @todo tags found.');
+            return;
+        }
+
+        foreach ($results as $line) {
+            $this->line($line);
+        }
+    }
+
+    /**
+     * Core scanner (same logic as deprecate.php).
+     */
+    private function scan(
+        string $startDir,
+        array $extensions,
+        array $excludeDirs,
+        ?string $minVer,
+        ?string $maxVer,
+        ?string $todoKeyword
+    ): array {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($startDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        $results = [];
+
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo->isFile()) {
+                continue;
+            }
+
+            $path = $fileInfo->getPathname();
+            $ext  = strtolower($fileInfo->getExtension());
+
+            if (!in_array($ext, $extensions, true)) {
+                continue;
+            }
+
+            $relative = str_replace($startDir . DIRECTORY_SEPARATOR, '', $path);
+            foreach ($excludeDirs as $ex) {
+                if (stripos($relative, DIRECTORY_SEPARATOR . $ex . DIRECTORY_SEPARATOR) !== false) {
+                    continue 2;
+                }
+            }
+
+            $handle = @fopen($path, 'rb');
+            if ($handle === false) {
+                continue;
+            }
+
+            $lineNum = 0;
+            while (($line = fgets($handle)) !== false) {
+                $lineNum++;
+
+                $hasDeprecated = stripos($line, '@deprecated') !== false;
+                $hasTodoMatch  = $todoKeyword !== null
+                    && stripos($line, '@todo') !== false
+                    && stripos($line, $todoKeyword) !== false;
+
+                if ($hasDeprecated || $hasTodoMatch) {
+                    $ver = $this->extractVersion($line, $todoKeyword);
+                    if ($this->versionInRange($ver, $minVer, $maxVer)) {
+                        $realPath = realpath($path) ?: $path;
+                        $results[] = $realPath . ':' . $lineNum;
+                    }
+                }
+            }
+            fclose($handle);
+        }
+
+        sort($results);
+        return $results;
+    }
+
+    private function extractVersion(string $line, ?string $todoKeyword = null): ?string
+    {
+        if (preg_match('/@deprecated\b.*?(\d+\.\d+(?:\.\d+)?(?:-[^ \s]+)?)/i', $line, $m)) {
+            return $m[1];
+        }
+
+        if ($todoKeyword !== null) {
+            $kw = preg_quote($todoKeyword, '/');
+            if (preg_match('/@todo\b.*?' . $kw . '.*?@?(\d+\.\d+(?:\.\d+)?(?:-[^ \s]+)?)/i', $line, $m)) {
+                return $m[1];
+            }
+        }
+
+        if (preg_match('/@todo\b.*?(\d+\.\d+(?:\.\d+)?(?:-[^ \s]+)?)/i', $line, $m)) {
+            return $m[1];
+        }
+
+        return null;
+    }
+
+    private function versionInRange(?string $ver, ?string $min, ?string $max): bool
+    {
+        if ($ver === null) {
+            return $min === null && $max === null;
+        }
+        if ($min !== null && version_compare($ver, $min, '<')) {
+            return false;
+        }
+        if ($max !== null && version_compare($ver, $max, '>')) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/core/src/Providers/ArtisanServiceProvider.php
+++ b/core/src/Providers/ArtisanServiceProvider.php
@@ -88,6 +88,7 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected $devCommands = [
         'VendorPublish' => 'command.vendor.publish',
+        'ListsDeprecated' => 'command.lists.deprecated',
         'MigrateMake' => 'command.migrate.make',
     ];
 
@@ -342,6 +343,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.view.clear', function ($app) {
             return new ViewClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerListsDeprecatedCommand()
+    {
+        $this->app->singleton('command.lists.deprecated', function () {
+            return new Lists\DeprecatedCommand;
         });
     }
 

--- a/core/vendor/composer/autoload_classmap.php
+++ b/core/vendor/composer/autoload_classmap.php
@@ -1091,6 +1091,7 @@ return array(
     'EvolutionCMS\\Console' => $baseDir . '/src/Console.php',
     'EvolutionCMS\\Console\\ClearCacheFullCommand' => $baseDir . '/src/Console/ClearCacheFullCommand.php',
     'EvolutionCMS\\Console\\ClearCompiledCommand' => $baseDir . '/src/Console/ClearCompiledCommand.php',
+    'EvolutionCMS\\Console\\Lists\\DeprecatedCommand' => $baseDir . '/src/Console/Lists/DeprecatedCommand.php',
     'EvolutionCMS\\Console\\Lists\\DocCommand' => $baseDir . '/src/Console/Lists/DocCommand.php',
     'EvolutionCMS\\Console\\Lists\\TemplateCommand' => $baseDir . '/src/Console/Lists/TemplateCommand.php',
     'EvolutionCMS\\Console\\Lists\\TvCommand' => $baseDir . '/src/Console/Lists/TvCommand.php',

--- a/core/vendor/composer/autoload_static.php
+++ b/core/vendor/composer/autoload_static.php
@@ -1768,6 +1768,7 @@ class ComposerStaticInitfdccd243149f99737a399aeb0b60fe7d
         'EvolutionCMS\\Console' => __DIR__ . '/../..' . '/src/Console.php',
         'EvolutionCMS\\Console\\ClearCacheFullCommand' => __DIR__ . '/../..' . '/src/Console/ClearCacheFullCommand.php',
         'EvolutionCMS\\Console\\ClearCompiledCommand' => __DIR__ . '/../..' . '/src/Console/ClearCompiledCommand.php',
+        'EvolutionCMS\\Console\\Lists\\DeprecatedCommand' => __DIR__ . '/../..' . '/src/Console/Lists/DeprecatedCommand.php',
         'EvolutionCMS\\Console\\Lists\\DocCommand' => __DIR__ . '/../..' . '/src/Console/Lists/DocCommand.php',
         'EvolutionCMS\\Console\\Lists\\TemplateCommand' => __DIR__ . '/../..' . '/src/Console/Lists/TemplateCommand.php',
         'EvolutionCMS\\Console\\Lists\\TvCommand' => __DIR__ . '/../..' . '/src/Console/Lists/TvCommand.php',

--- a/core/vendor/composer/installed.php
+++ b/core/vendor/composer/installed.php
@@ -1,8 +1,8 @@
 <?php return array(
     'root' => array(
         'name' => 'evolution-cms/evolution',
-        'pretty_version' => '3.5.3',
-        'version' => '3.5.3.0',
+        'pretty_version' => '3.5.4',
+        'version' => '3.5.4.0',
         'reference' => null,
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
@@ -173,8 +173,8 @@
             'dev_requirement' => false,
         ),
         'evolution-cms/evolution' => array(
-            'pretty_version' => '3.5.3',
-            'version' => '3.5.3.0',
+            'pretty_version' => '3.5.4',
+            'version' => '3.5.4.0',
             'reference' => null,
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',


### PR DESCRIPTION
```
PS C:\projects\evolution> php .\core\artisan deprecated:list --min 1.2
C:\projects\evolution\core\functions\helper.php:154
C:\projects\evolution\core\src\Console\Lists\DeprecatedCommand.php:130
```

```
PS C:\projects\evolution> php .\core\artisan deprecated:list --max 1.5 --todo remove
No matching @deprecated or @todo tags found.
```

```
php core/artisan deprecated:list
        {--min= : Minimum version (inclusive)}
        {--max= : Maximum version (inclusive)}
        {--todo= : Also search for @todo KEYWORD@version (example: --todo=remove)}
        {--dir= : Start directory (default: current working directory)}
        {--ext=php,js,html,htaccess : Comma-separated file extensions}
```