### PR TITLE
Fix rich text selection when editor disabled

### DIFF
--- a/assets/modules/store/installer/instprocessor-fast.php
+++ b/assets/modules/store/installer/instprocessor-fast.php
@@ -1,13 +1,12 @@
 <?php
 /**
- * @deprecated
- * @since 3.5.0
+ * @deprecated 3.5.0
  *
  * Module seems broken, SqlParser public function __construct($host, $user, $password, $db, $prefix='modx_', $adminname,
  * $adminemail, $adminpass, $connection_charset= 'utf8', $managerlanguage='english',
  * $connection_method = 'SET CHARACTER SET', $auto_template_logic = 'parent') {
  * is called here with missing parameters (see line 129)
- * new SqlParser('', '', '', $databaseConfig['charset'], \Lang::getLocale(), $databaseConfig['method'], 'sibling')
+ * new SqlParser('', '', '', $databaseConfig['charset'], \Lang::getLocale(), $databaseConfig['driver'], 'sibling')
  *
  * @todo [remove@3.7] Remove in Evolution CMS 3.7
  */
@@ -126,7 +125,7 @@ include "{$setupPath}/setup.info.php";
 include "sqlParser.class.php";
 
 $databaseConfig = evo()->app['config']['database']['connections']['default'];
-$sqlParser = new SqlParser('', '', '', $databaseConfig['charset'], \Lang::getLocale(), $databaseConfig['method'], 'sibling');
+$sqlParser = new SqlParser();
 $sqlParser->mode = "upd";
 $sqlParser->ignoreDuplicateErrors = true;
 
@@ -147,8 +146,6 @@ if (count($moduleTemplates) > 0) {
 
             // Strip the first comment up top
             $template = preg_replace("/^.*?\/\*\*.*?\*\/\s+/s", '', file_get_contents($filecontent), 1);
-            $template = $template;
-
             // See if the template already exists
             $template = \EvolutionCMS\Models\SiteTemplate::where('templatename', $name)->first();
 

--- a/assets/modules/store/installer/sqlParser.class.php
+++ b/assets/modules/store/installer/sqlParser.class.php
@@ -11,7 +11,7 @@
 // SNUFFKIN/ Alex 2004
 error_reporting(E_ALL & ~E_NOTICE);
 class SqlParser {
-    var $host, $dbname, $prefix, $user, $password, $mysqlErrors;
+    var $host, $dbname, $prefix, $user, $password, $mysqlErrors, $ignoreDuplicateErrors, $autoTemplateLogic;
     var $conn, $installFailed, $sitename, $adminname, $adminemail, $adminpass, $managerlanguage;
     var $mode, $fileManagerPath, $imgPath, $imgUrl;
     var $connection_charset;

--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -839,22 +839,28 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
                                             <hr>
                                             <!-- Content -->
                                             <div class="clearfix">
-                                                <span id="content_header"><?=ManagerTheme::getLexicon('resource_content');?></span>
-                                                <label class="float-right"><?=ManagerTheme::getLexicon('which_editor_title');?>
-                                                    <select id="which_editor" class="form-control form-control-sm" size="1" name="which_editor" onchange="changeRTE();">
-                                                        <option value="none"><?=ManagerTheme::getLexicon('none');?></option>
-                                                        <?php
-                                                        // invoke OnRichTextEditorRegister event
-                                                        $evtOut = $modx->invokeEvent("OnRichTextEditorRegister");
-                                                        if(is_array($evtOut)) {
-                                                            for($i = 0; $i < count($evtOut); $i++) {
-                                                                $editor = $evtOut[$i];
-                                                                echo "\t\t\t", '<option value="', $editor, '"', ($modx->getConfig('which_editor') == $editor ? ' selected="selected"' : ''), '>', $editor, "</option>\n";
-                                                            }
-                                                        }
-                                                        ?>
-                                                    </select>
-                                                </label>
+                                                <span id="content_header"><?= ManagerTheme::getLexicon('resource_content'); ?></span>
+                                                <?php
+                                                if ($modx->getConfig('use_editor') && $content['richtext']) {
+                                                    $evtOut = $modx->invokeEvent("OnRichTextEditorRegister");
+                                                    if (is_array($evtOut) && count($evtOut) > 0) { ?>
+                                                        <label class="float-right"><?= ManagerTheme::getLexicon('which_editor_title'); ?>
+                                                            <select id="which_editor" class="form-control form-control-sm" size="1"
+                                                                    name="which_editor" onchange="changeRTE();">
+                                                                <option value="none"><?= ManagerTheme::getLexicon('none'); ?></option>
+                                                                <?php
+                                                                for ($i = 0; $i < count($evtOut); $i++) {
+                                                                    $editor = $evtOut[$i];
+                                                                    echo "\t\t\t", '<option value="', $editor, '"',
+                                                                    ($modx->getConfig('which_editor') == $editor ?
+                                                                        ' selected="selected"' : ''), '>', $editor, "</option>\n";
+                                                                }
+                                                                ?>
+                                                            </select>
+                                                        </label>
+                                                    <?php
+                                                    }
+                                                } ?>
                                             </div>
                                             <div id="content_body">
                                                 <?php


### PR DESCRIPTION
When
<img width="285" height="398" alt="image" src="https://github.com/user-attachments/assets/60ebd3d2-abb0-4e60-8b55-5c11d4653fff" />
then
<img width="221" height="128" alt="image" src="https://github.com/user-attachments/assets/25163c1c-8c90-463e-b78b-31cbc6179876" />
should not confuse users as editor selection is not persistent - only checkbox is.