### PR TITLE
[FIX] Preserve database name during CLI installation

### DIFF
--- a/core/tests/Unit/Install/CliInstallTest.php
+++ b/core/tests/Unit/Install/CliInstallTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Install;
+
+use Tests\TestCase;
+
+require_once dirname(__DIR__, 4) . '/install/cli-install.php';
+
+final class CliInstallTest extends TestCase
+{
+    private string $configPath;
+    private bool $configExisted = false;
+    private string $originalConfig = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configPath = dirname(__DIR__, 4) . '/core/config/database/connections/default.php';
+        $this->configExisted = file_exists($this->configPath);
+
+        if ($this->configExisted) {
+            $this->originalConfig = (string) file_get_contents($this->configPath);
+            @chmod($this->configPath, 0600);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->configExisted) {
+            @chmod($this->configPath, 0600);
+            file_put_contents($this->configPath, $this->originalConfig);
+        } elseif (file_exists($this->configPath)) {
+            @chmod($this->configPath, 0600);
+            unlink($this->configPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testWriteConfigUsesTheProvidedDatabaseName(): void
+    {
+        $installer = new \InstallEvo([]);
+        $installer->databaseServer = 'host.mysql.tools';
+        $installer->databaseType = 'mysql';
+        $installer->database = 'db_name';
+        $installer->databaseUser = 'db_user';
+        $installer->databasePassword = 'password';
+        $installer->tablePrefix = 'evo_';
+        $installer->database_charset = 'utf8mb4';
+        $installer->database_collation = 'utf8mb4_unicode_520_ci';
+        $installer->dbh = new class {
+            public function getAttribute($attribute): string
+            {
+                return '8.0.36';
+            }
+        };
+
+        $installer->writeConfig();
+
+        $config = (string) file_get_contents($this->configPath);
+
+        self::assertStringContainsString("'database' => env('DB_DATABASE', 'db_name')", $config);
+        self::assertStringNotContainsString('[+database_name+]', $config);
+        self::assertStringContainsString("'username' => env('DB_USERNAME', 'db_user')", $config);
+    }
+}

--- a/install/cli-install.php
+++ b/install/cli-install.php
@@ -3,12 +3,12 @@
 use EvolutionCMS\Facades\Console;
 
 $base_path = dirname(__DIR__) . '/';
-define('MODX_API_MODE', true);
-define('EVO_BASE_PATH', $base_path);
-define('EVO_SITE_URL', '/');
-define('EVO_CORE_PATH', $base_path . 'core/');
-define('IN_INSTALL_MODE', true);
-define('EVO_CLI', true);
+defined('MODX_API_MODE') || define('MODX_API_MODE', true);
+defined('EVO_BASE_PATH') || define('EVO_BASE_PATH', $base_path);
+defined('EVO_SITE_URL') || define('EVO_SITE_URL', '/');
+defined('EVO_CORE_PATH') || define('EVO_CORE_PATH', $base_path . 'core/');
+defined('IN_INSTALL_MODE') || define('IN_INSTALL_MODE', true);
+defined('EVO_CLI') || define('EVO_CLI', true);
 require_once EVO_BASE_PATH . 'install/src/functions.php';
 /**
  * EVO Cli Installer/Updater
@@ -16,8 +16,15 @@ require_once EVO_BASE_PATH . 'install/src/functions.php';
  * php cli-install.php --typeInstall=2 --removeInstall=y
  **/
 
-$install = new InstallEvo($argv);
-$install->start();
+function runCliInstall(array $argv): void
+{
+    $install = new InstallEvo($argv);
+    $install->start();
+}
+
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
+    runCliInstall($argv);
+}
 
 class InstallEvo
 {
@@ -445,7 +452,9 @@ class InstallEvo
         $confph['connection_charset'] = $this->database_charset;
         $confph['connection_collation'] = $this->database_collation;
         $confph['connection_method'] = 'SET CHARACTER SET';
-        $confph['dbase'] = str_replace('', '', $this->database);
+        $confph['database_name'] = $this->databaseType === 'sqlite'
+            ? sqliteDbNameToPath($this->database)
+            : $this->database;
         $confph['table_prefix'] = $this->tablePrefix;
         $confph['lastInstallTime'] = time();
         $confph['database_engine'] = '';
@@ -464,13 +473,15 @@ class InstallEvo
                 }
                 break;
         }
-        $configString = file_get_contents('stubs/files/config/database/connections/default.tpl');
+        $configString = file_get_contents(__DIR__ . '/stubs/files/config/database/connections/default.tpl');
         $configString = parse($configString, $confph);
 
         $filename = EVO_CORE_PATH . 'config/database/connections/default.php';
         $configFileFailed = false;
 
-        @chmod($filename, 0777);
+        if (file_exists($filename)) {
+            @chmod($filename, 0777);
+        }
 
         if (!$handle = fopen($filename, 'w')) {
             $configFileFailed = true;
@@ -827,4 +838,6 @@ class InstallEvo
     }
 }
 
-exit();
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
+    exit();
+}

--- a/install/src/functions.php
+++ b/install/src/functions.php
@@ -853,34 +853,36 @@ function removeFolder($path)
  * @param  mixed  $default
  * @return mixed
  */
-function env($key, $default = null)
-{
-    $value = getenv($key);
+if (!function_exists('env')) {
+    function env($key, $default = null)
+    {
+        $value = getenv($key);
 
-    if ($value === false) {
-        return value($default);
+        if ($value === false) {
+            return value($default);
+        }
+
+        switch (strtolower($value)) {
+            case 'true':
+            case '(true)':
+                return true;
+            case 'false':
+            case '(false)':
+                return false;
+            case 'empty':
+            case '(empty)':
+                return '';
+            case 'null':
+            case '(null)':
+                return;
+        }
+
+        if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
+            return substr($value, 1, -1);
+        }
+
+        return $value;
     }
-
-    switch (strtolower($value)) {
-        case 'true':
-        case '(true)':
-            return true;
-        case 'false':
-        case '(false)':
-            return false;
-        case 'empty':
-        case '(empty)':
-            return '';
-        case 'null':
-        case '(null)':
-            return;
-    }
-
-    if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
-        return substr($value, 1, -1);
-    }
-
-    return $value;
 }
 
 /**
@@ -889,9 +891,11 @@ function env($key, $default = null)
  * @param  mixed  $value
  * @return mixed
  */
-function value($value)
-{
-    return $value instanceof Closure ? $value() : $value;
+if (!function_exists('value')) {
+    function value($value)
+    {
+        return $value instanceof Closure ? $value() : $value;
+    }
 }
 
 function seed($folder = 'install')


### PR DESCRIPTION
## Summary
- fix the CLI installer so the generated connection config uses the provided database name instead of leaving `[+database_name+]`
- load the installer config template from an absolute path so `php install/cli-install.php ...` resolves the stub reliably
- add a focused regression test that verifies `writeConfig()` writes `DB_DATABASE` correctly for CLI installs

## Why
Closes #2216.

The current CLI path populates `dbase`, while the template expects `database_name`, so the generated `core/config/database/connections/default.php` keeps the placeholder and later DB work connects against the wrong database name.

## Files
- `install/cli-install.php`
- `install/src/functions.php`
- `core/tests/Unit/Install/CliInstallTest.php`

## Verification
- `./vendor/bin/pest tests/Unit/Install/CliInstallTest.php`
  - result: `1 passed (3 assertions)`
- `php -l install/cli-install.php`
- `php -l install/src/functions.php`
- `php -l core/tests/Unit/Install/CliInstallTest.php`
- local smoke on `http://127.0.0.1:9544/` returned `200 OK`

## Notes
- I used a clean MiddleDuck task worktree on branch `middleDuck/evo-2216-cli-db-name` pushed to `middleDuckAi/evolution`.
- In this local PHP built-in server setup, `/manager/index.php` still returns `404`, so the visual smoke proof was captured on the front page runtime instead of the manager login.
