### PR TITLE
[FIX] Restore child docs visibility for non-admin users

### DIFF
--- a/core/tests/Unit/Manager/Page3ChildDocsVisibilityTest.php
+++ b/core/tests/Unit/Manager/Page3ChildDocsVisibilityTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Manager;
+
+use Tests\TestCase;
+
+final class Page3ChildDocsVisibilityTest extends TestCase
+{
+    public function testNonAdminChildVisibilityFiltersStayOnTheChildQuery(): void
+    {
+        $view = (string) file_get_contents(dirname(__DIR__, 4) . '/manager/views/page/3.blade.php');
+
+        self::assertStringContainsString("\$childs = \$childs->where(function (\$q) {", $view);
+        self::assertStringContainsString("\$childs = \$childs->where('site_content.privatemgr', 0);", $view);
+        self::assertStringNotContainsString("\$childs = \$resources->where(function (\$q) {", $view);
+        self::assertStringNotContainsString("\$childs = \$resources->where('site_content.privatemgr', 0);", $view);
+    }
+}

--- a/manager/views/page/3.blade.php
+++ b/manager/views/page/3.blade.php
@@ -112,11 +112,11 @@
 
         if ($_SESSION['mgrRole'] != 1) {
             if (is_array($_SESSION['mgrDocgroups']) && count($_SESSION['mgrDocgroups']) > 0) {
-                $childs = $resources->where(function ($q) {
+                $childs = $childs->where(function ($q) {
                     $q->where('site_content.privatemgr', 0)->orWhereIn('document_groups.document_group', $_SESSION['mgrDocgroups']);
                 });
             } else {
-                $childs = $resources->where('site_content.privatemgr', 0);
+                $childs = $childs->where('site_content.privatemgr', 0);
             }
         }
 


### PR DESCRIPTION
## Summary
- keep the child-document visibility filters on the child query in the “Documents in Folder” tab for non-admin manager users
- stop the non-admin branch from reusing the parent resource query when counting and listing children
- add a focused regression test that blocks future fallback from `$childs` to `$resources`

## Why
Closes #2219.

In the current manager view, the non-admin branch inside `manager/views/page/3.blade.php` swaps back to the parent resource query, so limited users lose the actual child list and only see the folder resource.

## Files
- `manager/views/page/3.blade.php`
- `core/tests/Unit/Manager/Page3ChildDocsVisibilityTest.php`

## Verification
- `./vendor/bin/pest tests/Unit/Manager/Page3ChildDocsVisibilityTest.php`
  - result: `1 passed (4 assertions)`
- `php -l manager/views/page/3.blade.php`
- `php -l core/tests/Unit/Manager/Page3ChildDocsVisibilityTest.php`

## Notes
- Prepared by MiddleDuck on branch `middleDuck/evo-2219-child-docs`.
- The reporter’s follow-up matched the same two-line query-chain fix, and the regression test now protects that branch explicitly.
