### PR TITLE
[FIX] Use explicit nullable tab indices

### DIFF
--- a/core/src/Controllers/Resources.php
+++ b/core/src/Controllers/Resources.php
@@ -48,7 +48,7 @@ class Resources extends AbstractResources implements ManagerTheme\PageController
         return array_merge(compact('tabs'), parent::getParameters($params), compact('activeTab'));
     }
 
-    protected function makeTab($tabClass, int $index = null) :? ManagerTheme\TabControllerInterface
+    protected function makeTab($tabClass, ?int $index = null) :? ManagerTheme\TabControllerInterface
     {
         $tabController = null;
         if (class_exists($tabClass) &&

--- a/core/src/Controllers/UserRoles/RoleManagment.php
+++ b/core/src/Controllers/UserRoles/RoleManagment.php
@@ -46,7 +46,7 @@ class RoleManagment extends AbstractResources implements ManagerTheme\PageContro
         return array_merge(compact('tabs'), parent::getParameters($params), compact('activeTab'));
     }
 
-    protected function makeTab($tabClass, int $index = null) :? ManagerTheme\TabControllerInterface
+    protected function makeTab($tabClass, ?int $index = null) :? ManagerTheme\TabControllerInterface
     {
 
         $tabController = null;

--- a/core/tests/Unit/Controllers/ControllerNullableSignatureTest.php
+++ b/core/tests/Unit/Controllers/ControllerNullableSignatureTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+test('resources controller autoload has no implicit nullable deprecation', function () {
+    $result = runControllerAutoloadCheck('EvolutionCMS\\Controllers\\Resources');
+
+    expect($result['exitCode'])->toBe(0)
+        ->and($result['output'])->toContain('ok');
+});
+
+test('role management controller autoload has no implicit nullable deprecation', function () {
+    $result = runControllerAutoloadCheck('EvolutionCMS\\Controllers\\UserRoles\\RoleManagment');
+
+    expect($result['exitCode'])->toBe(0)
+        ->and($result['output'])->toContain('ok');
+});
+
+function runControllerAutoloadCheck(string $className): array
+{
+    $autoloadPath = dirname(__DIR__, 3) . '/vendor/autoload.php';
+    $script = <<<'PHP'
+set_error_handler(function (int $severity, string $message, string $file, int $line) {
+    if (in_array($severity, [E_DEPRECATED, E_USER_DEPRECATED], true)) {
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    }
+
+    return false;
+});
+
+require $argv[1];
+
+if (!class_exists($argv[2])) {
+    fwrite(STDERR, "class-not-found\n");
+    exit(2);
+}
+
+echo "ok\n";
+PHP;
+
+    $process = new Process([PHP_BINARY, '-d', 'display_errors=1', '-r', $script, $autoloadPath, $className]);
+    $process->run();
+
+    return [
+        'exitCode' => $process->getExitCode(),
+        'output' => $process->getOutput(),
+        'errorOutput' => $process->getErrorOutput(),
+    ];
+}


### PR DESCRIPTION
## Problem
Issue #2187 reports a PHP 8.4 deprecation when loading the Elements tabs because controller methods use `int $index = null` instead of an explicit nullable type.

## What changed
- change `Resources::makeTab()` to use `?int $index = null`
- change `UserRoles\RoleManagment::makeTab()` to use the same explicit nullable signature
- add a regression test that autoloads both controllers under a deprecation-to-exception handler

## Why this approach
The warning is triggered at class load time, so the safest fix is to make the nullable contract explicit at the method signature. Updating the matching role-management controller at the same time avoids the same PHP 8.4 warning on a neighboring manager screen.

## Verification
- `./vendor/bin/pest tests/Unit/Controllers/ControllerNullableSignatureTest.php`
- `php -l core/src/Controllers/Resources.php`
- `php -l core/src/Controllers/UserRoles/RoleManagment.php`
- `php -l core/tests/Unit/Controllers/ControllerNullableSignatureTest.php`

## Links
- Closes #2187

Prepared by MiddleDuck.