### PR TITLE
[FIX] Use selected tree context for menu sort

### DIFF
--- a/core/tests/Unit/TreeSortButtonContextTest.php
+++ b/core/tests/Unit/TreeSortButtonContextTest.php
@@ -1,0 +1,21 @@
+<?php
+
+test('tree sort button uses contextual JS handler instead of hardcoded root id', function () {
+    $template = file_get_contents(dirname(__DIR__, 3) . '/manager/views/frame/tree.blade.php');
+
+    expect($template)->toContain("onclick=\"modx.tree.openSortMenuIndex();\"")
+        ->and($template)->not->toContain('?a=56&id=0');
+});
+
+test('both manager themes resolve sort menu index target from current tree context', function () {
+    $defaultThemeJs = file_get_contents(dirname(__DIR__, 3) . '/manager/media/style/default/js/modx.js');
+    $liquidThemeJs = file_get_contents(dirname(__DIR__, 3) . '/manager/media/style/liquid/js/modx.js');
+
+    foreach ([$defaultThemeJs, $liquidThemeJs] as $themeJs) {
+        expect($themeJs)->toContain('getSortMenuIndexTarget: function ()')
+            ->and($themeJs)->toContain("d.querySelector('#tree .current')")
+            ->and($themeJs)->toContain("d.querySelector('.treeRoot .node')")
+            ->and($themeJs)->toContain("openSortMenuIndex: function ()")
+            ->and($themeJs)->not->toContain("?a=56&id=0");
+    }
+});

--- a/manager/media/style/default/js/modx.js
+++ b/manager/media/style/default/js/modx.js
@@ -1463,6 +1463,32 @@
                 el = d.querySelector('#node' + a + '>.node');
                 if (el) el.classList.add('selected');
             },
+            getSortMenuIndexTarget: function () {
+                var node = d.querySelector('#tree .current')
+                    || d.querySelector('.treeRoot .selected')
+                    || d.querySelector('.treeRoot .node')
+                    || d.querySelector('#node0 > .node');
+                var trigger = d.getElementById('treeMenu_sortingindex');
+                var fallbackTitle = trigger ? trigger.getAttribute('title') : 'Sort menu index';
+
+                if (!node) {
+                    return { id: 0, title: fallbackTitle };
+                }
+
+                var id = node.dataset.id || node.parentNode.id.replace('node', '');
+                var title = node.dataset.titleEsc
+                    || (node.querySelector('.title') ? node.querySelector('.title').textContent : '')
+                    || fallbackTitle;
+
+                return { id: id, title: title };
+            },
+            openSortMenuIndex: function () {
+                var target = this.getSortMenuIndexTarget();
+                this.itemToChange = target.id;
+                this.selectedObjectName = target.title;
+                this.setSelected(target.id);
+                modx.tabs({ url: modx.MODX_MANAGER_URL + '?a=56&id=' + target.id, title: target.title + '<small>(' + target.id + ')</small>' });
+            },
             setItemToChange: function () {
                 var a = w.main.document && (w.main.document.URL || modx.normalizeUrl(w.main.document.location.href)),
                     b = modx.getActionFromUrl(a);

--- a/manager/media/style/liquid/js/modx.js
+++ b/manager/media/style/liquid/js/modx.js
@@ -1480,6 +1480,32 @@
                 el = d.querySelector('#node' + a + '>.node');
                 if (el) el.classList.add('selected');
             },
+            getSortMenuIndexTarget: function () {
+                var node = d.querySelector('#tree .current')
+                    || d.querySelector('.treeRoot .selected')
+                    || d.querySelector('.treeRoot .node')
+                    || d.querySelector('#node0 > .node');
+                var trigger = d.getElementById('treeMenu_sortingindex');
+                var fallbackTitle = trigger ? trigger.getAttribute('title') : 'Sort menu index';
+
+                if (!node) {
+                    return { id: 0, title: fallbackTitle };
+                }
+
+                var id = node.dataset.id || node.parentNode.id.replace('node', '');
+                var title = node.dataset.titleEsc
+                    || (node.querySelector('.title') ? node.querySelector('.title').textContent : '')
+                    || fallbackTitle;
+
+                return { id: id, title: title };
+            },
+            openSortMenuIndex: function () {
+                var target = this.getSortMenuIndexTarget();
+                this.itemToChange = target.id;
+                this.selectedObjectName = target.title;
+                this.setSelected(target.id);
+                modx.tabs({ url: modx.MODX_MANAGER_URL + '?a=56&id=' + target.id, title: target.title + '<small>(' + target.id + ')</small>' });
+            },
             setItemToChange: function () {
                 var a = w.main.document && (w.main.document.URL || modx.normalizeUrl(w.main.document.location.href)),
                     b = modx.getActionFromUrl(a);

--- a/manager/views/frame/tree.blade.php
+++ b/manager/views/frame/tree.blade.php
@@ -37,7 +37,7 @@ $_style['icon_trash'] = svg('tabler-trash')->toHtml();
         <a class="treeButton" id="treeMenu_refreshtree" onclick="modx.tree.restoreTree();" title="{{ ManagerTheme::getLexicon('refresh_tree') }}">{!! $_style['icon_refresh'] !!}</a>
         <a class="treeButton" id="treeMenu_sortingtree" onclick="modx.tree.showSorter(event);" title="{{ ManagerTheme::getLexicon('sort_tree') }}">{!! $_style['icon_sort'] !!}</a>
         @if(evo()->hasPermission('edit_document') && evo()->hasPermission('save_document'))
-            <a class="treeButton" id="treeMenu_sortingindex" onclick="modx.tabs({url: '{{ MODX_MANAGER_URL }}?a=56&id=0', title: '{{ ManagerTheme::getLexicon('sort_menuindex') }}'});" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
+            <a class="treeButton" id="treeMenu_sortingindex" onclick="modx.tree.openSortMenuIndex();" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
         @endif
         {{-- @if(evo()->getConfig('use_browser') && evo()->hasPermission('assets_images'))
             <a class="treeButton" id="treeMenu_openimages" title="{{ ManagerTheme::getLexicon('images_management') }}&#013;{{ ManagerTheme::getLexicon('em_button_shift') }}"><i class="{{ $_style['icon_camera'] }}"></i></a>


### PR DESCRIPTION
## Problem
Issue #2126 reports that the sort-menuindex button above the tree always opens `a=56&id=0`, which breaks sorting for non-admin managers who do not have access to resource `0`. The context menu already uses the selected resource id correctly.

## What changed
- switch the top tree sort button from a hardcoded URL to a dedicated tree JS handler
- add a shared target resolver in both manager themes that prefers the current tree node, then the selected node, then the first available tree node
- add a regression test that ensures the template no longer hardcodes `id=0` and that both theme scripts include the contextual resolver

## Why this approach
The bug lives in the mismatch between the top toolbar action and the existing context-menu action. Reusing the current tree context keeps the top button aligned with the behavior users already get from the context menu and preserves a safe fallback for non-admin trees.

## Verification
- `./vendor/bin/pest tests/Unit/TreeSortButtonContextTest.php`
- `php -l manager/views/frame/tree.blade.php`
- `php -l core/tests/Unit/TreeSortButtonContextTest.php`
- `node` syntax check for both manager theme `modx.js` files

## Links
- Closes #2126

Prepared by MiddleDuck.