### PR TITLE
[FIX] Restore link resource type flow in manager

### DIFF
--- a/core/tests/Unit/Manager/ReferenceTypeSwitchFlowTest.php
+++ b/core/tests/Unit/Manager/ReferenceTypeSwitchFlowTest.php
@@ -1,0 +1,23 @@
+<?php
+
+it('syncs the manager form when switching a resource to link', function () {
+    $formPath = dirname(__DIR__, 4) . '/manager/actions/mutate_content.dynamic.php';
+    $form = file_get_contents($formPath);
+
+    expect($form)->toContain('syncReferenceContent()');
+    expect($form)->toContain('syncResourceTypePanels(this.value);');
+    expect($form)->toContain('id="resource-type-reference-fields"');
+    expect($form)->toContain('id="resource-type-document-fields"');
+    expect($form)->toContain('id="weblink-content"');
+    expect($form)->toContain("getSelectedResourceType() === 'reference'");
+});
+
+it('routes new reference saves by selected type instead of the original mode', function () {
+    $processorPath = dirname(__DIR__, 4) . '/manager/processors/save_content.processor.php';
+    $processor = file_get_contents($processorPath);
+
+    expect($processor)->toContain('$newResourceAction = ($type == "reference") ? "72" : "4";');
+    expect($processor)->toContain('if ($type == "reference") {');
+    expect($processor)->not->toContain('if ($_POST[\'mode\'] == "72")');
+    expect($processor)->not->toContain('if ($_POST[\'mode\'] == "4")');
+});

--- a/manager/actions/mutate_content.dynamic.php
+++ b/manager/actions/mutate_content.dynamic.php
@@ -146,6 +146,9 @@ if(isset ($_POST['which_editor'])) {
 $lockElementId = $id;
 $lockElementType = 7;
 require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
+
+$isReferenceResource = ($content['type'] === 'reference' || $modx->getManagerApi()->action == '72');
+$isDocumentResource = !$isReferenceResource;
 ?>
     <style>
         .image_for_field[data-image] { display: block; content: ""; width: 120px; height: 120px; margin: .1rem .1rem 0 0; border: 1px #ccc solid; background: #fff 50% 50% no-repeat; background-size: contain; cursor: pointer }
@@ -175,6 +178,7 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
               document.location.href = "index.php?pid=<?= isset($_REQUEST['id']) ? $_REQUEST['id'] : '' ?>&a=72";
           },
         save: function() {
+          syncReferenceContent();
           documentDirty = false;
           form_save = true;
           document.mutate.save.click();
@@ -194,9 +198,55 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
           }
         },
         view: function() {
-          window.open('<?= $modx->getConfig('friendly_urls') ? UrlProcessor::makeUrl($id) : MODX_SITE_URL . 'index.php?id=' . $id ?>', 'previeWin');
+          var previewUrl = '<?= $modx->getConfig('friendly_urls') ? UrlProcessor::makeUrl($id) : MODX_SITE_URL . 'index.php?id=' . $id ?>';
+          if (getSelectedResourceType() === 'reference') {
+            var linkField = document.getElementById('weblink-content');
+            var rawUrl = linkField ? linkField.value.trim() : '';
+            if (rawUrl !== '') {
+              previewUrl = rawUrl;
+            }
+          }
+          window.open(previewUrl, 'previeWin');
         }
       };
+
+      function getSelectedResourceType() {
+        if (!document.mutate.type) {
+          return 'document';
+        }
+        return document.mutate.type.value === 'reference' ? 'reference' : 'document';
+      }
+
+      function syncReferenceContent() {
+        if (getSelectedResourceType() !== 'reference' || !document.mutate.ta) {
+          return;
+        }
+
+        var linkField = document.getElementById('weblink-content');
+        if (linkField) {
+          document.mutate.ta.value = linkField.value;
+        }
+      }
+
+      function syncResourceTypePanels(type) {
+        var referenceFields = document.getElementById('resource-type-reference-fields');
+        var documentFields = document.getElementById('resource-type-document-fields');
+        if (!referenceFields || !documentFields) {
+          return;
+        }
+
+        if (type === 'reference') {
+          referenceFields.style.display = '';
+          documentFields.style.display = 'none';
+          var linkField = document.getElementById('weblink-content');
+          if (linkField && linkField.value.trim() === '' && document.mutate.ta) {
+            linkField.value = document.mutate.ta.value.trim() !== '' ? document.mutate.ta.value : 'http://';
+          }
+        } else {
+          referenceFields.style.display = 'none';
+          documentFields.style.display = '';
+        }
+      }
 
       var allowParentSelection = false;
       var allowLinkSelection = false;
@@ -221,7 +271,10 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
         }
         else {
           documentDirty = true;
-          document.mutate.ta.value = lId;
+          var linkField = document.getElementById('weblink-content');
+          if (linkField) {
+            linkField.value = lId;
+          }
         }
       }
 
@@ -484,7 +537,7 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
       }
 
       <?php
-      if (get_by_key($content, 'type') === 'reference' || $modx->getManagerApi()->action == '72') {
+      if ($isReferenceResource) {
           $ResourceManagerLoaded = true;
       }
       ?>
@@ -657,19 +710,17 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
                                     </td>
                                 </tr>
 
-                                <?php if($content['type'] == 'reference' || $modx->getManagerApi()->action == '72') { // Web Link specific ?>
-
+                                <tbody id="resource-type-reference-fields"<?= $isReferenceResource ? '' : ' style="display:none"' ?>>
                                     <tr>
                                         <td><span class="warning"><?=ManagerTheme::getLexicon('weblink');?></span>
                                             <i class="<?= $_style["icon_question_circle"] ?>" data-tooltip="<?=ManagerTheme::getLexicon('resource_weblink_help');?>"></i>
                                         </td>
                                         <td>
                                             <i id="llock" class="<?= $_style["icon_chain"] ?>" onclick="enableLinkSelection(!allowLinkSelection);"></i>
-                                            <input name="ta" id="ta" type="text" maxlength="255" value="<?= (!empty($content['content']) ? entities(stripslashes($content['content']), $modx->getConfig('modx_charset')) : 'http://') ?>" class="inputBox" onchange="documentDirty=true;" /><input type="button" value="<?=ManagerTheme::getLexicon('insert');?>" onclick="BrowseFileServer('ta')" />
+                                            <input id="weblink-content" type="text" maxlength="255" value="<?= (!empty($content['content']) ? entities(stripslashes($content['content']), $modx->getConfig('modx_charset')) : 'http://') ?>" class="inputBox" onchange="documentDirty=true;" /><input type="button" value="<?=ManagerTheme::getLexicon('insert');?>" onclick="BrowseFileServer('weblink-content')" />
                                         </td>
                                     </tr>
-
-                                <?php } ?>
+                                </tbody>
 
                                 <tr>
                                     <td valign="top">
@@ -833,7 +884,7 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
                                 }*/
                                 ?>
 
-                                <?php if($content['type'] == 'document' || $modx->getManagerApi()->action == '4') { ?>
+                                <tbody id="resource-type-document-fields"<?= $isDocumentResource ? '' : ' style="display:none"' ?>>
                                     <tr>
                                         <td colspan="2">
                                             <hr>
@@ -888,7 +939,7 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
                                         </td>
                                     </tr>
                                     <!-- end .sectionBody -->
-                                <?php } ?>
+                                </tbody>
                             </table>
 
                             <?php
@@ -1219,9 +1270,9 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
                                             <i class="<?= $_style["icon_question_circle"] ?>" data-tooltip="<?=ManagerTheme::getLexicon('resource_type_message');?>"></i>
                                         </td>
                                         <td>
-                                            <select name="type" class="inputBox" onchange="documentDirty=true;">
-                                                <option value="document"<?= ($content['type'] === 'document' || $modx->getManagerApi()->action == '85' || $modx->getManagerApi()->action == '4') ? ' selected="selected"' : '' ?> ><?=ManagerTheme::getLexicon('resource_type_webpage');?></option>
-                                                <option value="reference"<?= ($content['type'] === 'reference' || $modx->getManagerApi()->action == '72') ? ' selected="selected"' : '' ?> ><?=ManagerTheme::getLexicon('resource_type_weblink');?></option>
+                                            <select name="type" class="inputBox" onchange="documentDirty=true;syncResourceTypePanels(this.value);">
+                                                <option value="document"<?= $isDocumentResource ? ' selected="selected"' : '' ?> ><?=ManagerTheme::getLexicon('resource_type_webpage');?></option>
+                                                <option value="reference"<?= $isReferenceResource ? ' selected="selected"' : '' ?> ><?=ManagerTheme::getLexicon('resource_type_weblink');?></option>
                                             </select>
                                         </td>
                                     </tr>
@@ -1519,9 +1570,10 @@ require_once(MODX_MANAGER_PATH . 'includes/active_user_locks.inc.php');
 
     <script type="text/javascript">
       storeCurTemplate();
+      syncResourceTypePanels(getSelectedResourceType());
     </script>
 <?php
-if((! empty($content['richtext']) || $modx->getManagerApi()->action == '4' || $modx->getManagerApi()->action == '72') && $modx->getConfig('use_editor')) {
+if(((!empty($content['richtext']) && $isDocumentResource) || $modx->getManagerApi()->action == '4' || $modx->getManagerApi()->action == '72') && $modx->getConfig('use_editor')) {
     if(is_array($richtexteditorIds)) {
         foreach($richtexteditorIds as $editor => $elements) {
             // invoke OnRichTextEditorInit event

--- a/manager/processors/save_content.processor.php
+++ b/manager/processors/save_content.processor.php
@@ -55,10 +55,11 @@ if (trim($no_esc_pagetitle) == "") {
 }
 
 
-$actionToTake = "new";
-if ($_POST['mode'] == '73' || $_POST['mode'] == '27') {
-    $actionToTake = "edit";
-}
+$actionToTake = ((int)$id > 0 || $_POST['mode'] == '73' || $_POST['mode'] == '27') ? "edit" : "new";
+$newResourceAction = ($type == "reference") ? "72" : "4";
+$editResourceAction = "27";
+$newResourceRedirect = "index.php?a={$newResourceAction}";
+$editResourceRedirect = "index.php?a={$editResourceAction}&id={$id}";
 
 // friendly url alias checks
 if ($modx->getConfig('friendly_urls')) {
@@ -115,11 +116,11 @@ if ($modx->getConfig('friendly_urls')) {
         $docid = $docid->first();
         if (!is_null($docid)) {
             if ($actionToTake == 'edit') {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), "index.php?a=27&id={$id}");
+                $modx->getManagerApi()->saveFormValues($editResourceAction);
+                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), $editResourceRedirect);
             } else {
-                $modx->getManagerApi()->saveFormValues(4);
-                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), "index.php?a=4");
+                $modx->getManagerApi()->saveFormValues($newResourceAction);
+                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), $newResourceRedirect);
             }
         }
     }
@@ -134,11 +135,11 @@ if ($modx->getConfig('friendly_urls')) {
             ->first();
         if (!is_null($docid)) {
             if ($actionToTake == 'edit') {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), "index.php?a=27&id={$id}");
+                $modx->getManagerApi()->saveFormValues($editResourceAction);
+                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), $editResourceRedirect);
             } else {
-                $modx->getManagerApi()->saveFormValues(4);
-                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), "index.php?a=4");
+                $modx->getManagerApi()->saveFormValues($newResourceAction);
+                $modx->webAlertAndQuit(sprintf($_lang["duplicate_alias_found"], $docid->id, $alias), $newResourceRedirect);
             }
         }
     }
@@ -190,11 +191,11 @@ if($_SESSION['mgrRole'] != 1 && is_array($document_groups)) {
 
         if($count == 0) {
             if ($actionToTake == 'edit') {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit($_lang["resource_permissions_error"], "index.php?a=27&id={$id}");
+                $modx->getManagerApi()->saveFormValues($editResourceAction);
+                $modx->webAlertAndQuit($_lang["resource_permissions_error"], $editResourceRedirect);
             } else {
-                $modx->getManagerApi()->saveFormValues(4);
-                $modx->webAlertAndQuit($_lang["resource_permissions_error"], "index.php?a=4");
+                $modx->getManagerApi()->saveFormValues($newResourceAction);
+                $modx->webAlertAndQuit($_lang["resource_permissions_error"], $newResourceRedirect);
             }
         }
     }
@@ -282,11 +283,11 @@ if ($modx->getConfig('use_udperms') == 1) {
 
         if (!$udperms->checkPermissions()) {
             if ($actionToTake == 'edit') {
-                $modx->getManagerApi()->saveFormValues(27);
-                $modx->webAlertAndQuit($_lang['access_permission_parent_denied'], "index.php?a=27&id={$id}");
+                $modx->getManagerApi()->saveFormValues($editResourceAction);
+                $modx->webAlertAndQuit($_lang['access_permission_parent_denied'], $editResourceRedirect);
             } else {
-                $modx->getManagerApi()->saveFormValues(4);
-                $modx->webAlertAndQuit($_lang['access_permission_parent_denied'], "index.php?a=4");
+                $modx->getManagerApi()->saveFormValues($newResourceAction);
+                $modx->webAlertAndQuit($_lang['access_permission_parent_denied'], $newResourceRedirect);
             }
         }
     }
@@ -470,12 +471,11 @@ switch ($actionToTake) {
 
         // redirect/stay options
         if ($_POST['stay'] != '') {
-            // weblink
-            if ($_POST['mode'] == "72")
+            if ($type == "reference") {
                 $a = ($_POST['stay'] == '2') ? "27&id=$key" : "72&pid=$parentId";
-            // document
-            if ($_POST['mode'] == "4")
+            } else {
                 $a = ($_POST['stay'] == '2') ? "27&id=$key" : "4&pid=$parentId";
+            }
             $redirectUrl = "index.php?a=" . $a . "&r=1&stay=" . $_POST['stay'];
         } else {
             $redirectUrl = "index.php?a=3&id=$key&r=1";


### PR DESCRIPTION
## Problem
Issue #2213 reports that switching a resource from `Document` to `Link` in the manager does not behave correctly. The form keeps the document editing flow, preview does not follow the selected link, and save/return routing still depends on the original action instead of the submitted resource type.

## What changed
- keep the manager form in sync with the live `Resource Type` selection by toggling document and weblink panels client-side
- store the selected weblink URL through the shared `ta` payload before save so a link resource created from the document form keeps the correct target
- make manager preview open the selected link URL when the current type is `reference`
- route new-resource save and validation returns by submitted `type` instead of the original `mode`
- add a regression test that guards the type-switch flow in the manager form and save processor

## Why this approach
The bug is caused by a split-brain flow: the user can switch the resource type in the UI, but the rest of the manager still follows the original action that opened the page. Syncing the form and save processor to the selected type fixes the resource workflow without changing unrelated manager behavior.

## Verification
- `./vendor/bin/pest tests/Unit/Manager/ReferenceTypeSwitchFlowTest.php`
- `php -l manager/actions/mutate_content.dynamic.php`
- `php -l manager/processors/save_content.processor.php`
- `php -l core/tests/Unit/Manager/ReferenceTypeSwitchFlowTest.php`

## Links
- Closes #2213

Prepared by MiddleDuck.