### PR TITLE
[FIX] Handle collapsed folder drops in manager tree

### DIFF
--- a/manager/media/script/tests/tree-drop-helper.test.js
+++ b/manager/media/script/tests/tree-drop-helper.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const helper = require('../tree-drop-helper');
+
+function createContainer(children = []) {
+    const container = {
+        nodeType: 1,
+        children: [],
+        appendChild(node) {
+            if (node.parentNode && typeof node.parentNode.removeChild === 'function') {
+                node.parentNode.removeChild(node);
+            }
+
+            this.children.push(node);
+            node.parentNode = this;
+            return node;
+        },
+        removeChild(node) {
+            const index = this.children.indexOf(node);
+
+            if (index >= 0) {
+                this.children.splice(index, 1);
+                node.parentNode = null;
+            }
+
+            return node;
+        }
+    };
+
+    children.forEach((child) => container.appendChild(child));
+
+    return container;
+}
+
+test('moveNodeIntoFolder appends into an empty collapsed folder container', () => {
+    const sourceContainer = createContainer();
+    const draggedNode = { id: 'node10', parentNode: null };
+    sourceContainer.appendChild(draggedNode);
+
+    const targetContainer = createContainer();
+    const targetAnchor = {
+        nextElementSibling: targetContainer
+    };
+
+    const result = helper.moveNodeIntoFolder(targetAnchor, draggedNode);
+
+    assert.equal(result.container, targetContainer);
+    assert.deepEqual(Array.from(result.children).map((node) => node.id), ['node10']);
+    assert.equal(draggedNode.parentNode, targetContainer);
+    assert.deepEqual(sourceContainer.children, []);
+});
+
+test('moveNodeIntoFolder falls back to removing the dragged node when no folder container exists', () => {
+    const sourceContainer = createContainer();
+    const draggedNode = { id: 'node10', parentNode: null };
+    sourceContainer.appendChild(draggedNode);
+
+    const result = helper.moveNodeIntoFolder({ nextElementSibling: null, nextSibling: null }, draggedNode);
+
+    assert.equal(result.container, null);
+    assert.deepEqual(result.children, []);
+    assert.equal(draggedNode.parentNode, null);
+    assert.deepEqual(sourceContainer.children, []);
+});

--- a/manager/media/script/tree-drop-helper.js
+++ b/manager/media/script/tree-drop-helper.js
@@ -1,0 +1,52 @@
+(function (root, factory) {
+    var exported = factory();
+
+    if (typeof module === 'object' && module.exports) {
+        module.exports = exported;
+    }
+
+    root.modxTreeDropHelper = exported;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    function getFolderDropContainer(targetAnchor) {
+        if (!targetAnchor) {
+            return null;
+        }
+
+        var container = targetAnchor.nextElementSibling || targetAnchor.nextSibling || null;
+
+        if (!container || container.nodeType !== 1) {
+            return null;
+        }
+
+        return container;
+    }
+
+    function moveNodeIntoFolder(targetAnchor, draggedNode) {
+        var container = getFolderDropContainer(targetAnchor);
+
+        if (container) {
+            container.appendChild(draggedNode);
+
+            return {
+                container: container,
+                children: container.children
+            };
+        }
+
+        if (draggedNode && draggedNode.parentNode && typeof draggedNode.parentNode.removeChild === 'function') {
+            draggedNode.parentNode.removeChild(draggedNode);
+        }
+
+        return {
+            container: null,
+            children: []
+        };
+    }
+
+    return {
+        getFolderDropContainer: getFolderDropContainer,
+        moveNodeIntoFolder: moveNodeIntoFolder
+    };
+}));

--- a/manager/media/style/default/js/modx.js
+++ b/manager/media/style/default/js/modx.js
@@ -977,12 +977,8 @@
                         indent.innerHTML += '<i></i>';
                     }
                     if (this.nextSibling) {
-                        if (this.nextSibling.innerHTML) {
-                            this.nextSibling.appendChild(el);
-                        } else {
-                            el.parentNode.removeChild(el);
-                        }
-                        els = this.parentNode.lastChild.children;
+                        const dropResult = modxTreeDropHelper.moveNodeIntoFolder(this, el);
+                        els = dropResult.children;
                         for (i = 0; i < els.length; i++) {
                             menuindex[i] = els[i].id.substr(4);
                         }

--- a/manager/media/style/liquid/js/modx.js
+++ b/manager/media/style/liquid/js/modx.js
@@ -994,12 +994,8 @@
                         indent.innerHTML += '<i></i>';
                     }
                     if (this.nextSibling) {
-                        if (this.nextSibling.innerHTML) {
-                            this.nextSibling.appendChild(el);
-                        } else {
-                            el.parentNode.removeChild(el);
-                        }
-                        els = this.parentNode.lastChild.children;
+                        const dropResult = modxTreeDropHelper.moveNodeIntoFolder(this, el);
+                        els = dropResult.children;
                         for (i = 0; i < els.length; i++) {
                             menuindex[i] = els[i].id.substr(4);
                         }

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -218,6 +218,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
         echo (empty($opened) ? '' : 'modx.openedArray[' . implode("] = 1;\n		modx.openedArray[", $opened) . '] = 1;') . "\n";
         ?>
     </script>
+    <script src="media/script/tree-drop-helper.js?v={{evo()->getVersionData('version')}}"></script>
     <script src="{{ManagerTheme::getThemeUrl()}}js/modx.js?v={{evo()->getVersionData('version')}}"></script>
     @if ($modx->getConfig('show_picker'))
         <script src="media/script/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>


### PR DESCRIPTION
## Problem
Dropping a resource into a collapsed folder goes through the folder-drop branch in the manager tree, but that branch only appended into the target child container when the container already had rendered HTML.

Collapsed folders still have a valid child container, but it starts empty, so the move flow becomes inconsistent and the resource can appear to snap back after refresh.

## What changed
- extracted the folder-drop branch into a shared `manager/media/script/tree-drop-helper.js`
- loaded the helper before theme `modx.js` in the manager frame
- updated both `default` and `liquid` manager themes to use the same folder-drop helper
- added a regression test for the empty collapsed-folder container case

## Why this shape
- keeps both manager themes in sync
- fixes the empty-container path without changing before/after sibling drop behavior
- makes the fragile branch testable outside a browser-only harness

## Files
- `manager/media/script/tree-drop-helper.js`
- `manager/media/script/tests/tree-drop-helper.test.js`
- `manager/views/frame/1.blade.php`
- `manager/media/style/default/js/modx.js`
- `manager/media/style/liquid/js/modx.js`

## Verification
- `node --test manager/media/script/tests/tree-drop-helper.test.js`
- `node --check manager/media/style/default/js/modx.js`
- `node --check manager/media/style/liquid/js/modx.js`
- `php -l manager/views/frame/1.blade.php`
- local runtime smoke check on the task branch

## Issue
- closes #2194
