### PR TITLE
[FIX] Restore manager info tooltip buttons

### DIFF
--- a/manager/actions/web_user_management.static.php
+++ b/manager/actions/web_user_management.static.php
@@ -128,7 +128,7 @@ if ($numRecords > 0) {
             'role' => $el['name'] ?: ManagerTheme::getLexicon('no_user_role'),
             'user_prevlogin' => $el['thislogin'] ? $modx->toDateFormat($el['thislogin']) : '-',
             'user_logincount' => $el['logincount'],
-            'user_block' => $el['blocked'] ? ManagerTheme::getLexicon('yes').' <i class="fa fa-question-circle help" data-toggle="tooltip" data-placement="top" title="'.$blocked_title.'"></i>' : '-',
+            'user_block' => $el['blocked'] ? ManagerTheme::getLexicon('yes').' <i class="fa fa-question-circle help" data-tooltip="'.htmlspecialchars($blocked_title, ENT_QUOTES, ManagerTheme::getCharset()).'"></i>' : '-',
         ];
     }
 
@@ -186,8 +186,6 @@ if ($numRecords > 0) {
             document.querySelector('.element-edit-message').classList.toggle('show')
         }
 
-        // bootstrap tooltip
-        //document.querySelector('[data-toggle="tooltip"]').tooltip()
     });
 </script>
 

--- a/manager/media/script/main.js
+++ b/manager/media/script/main.js
@@ -20,7 +20,7 @@ evo.tooltips = function (a) {
                 return;
             }
             var x = e.clientX, y = e.clientY;
-            b.innerHTML = (this.dataset && this.dataset.tooltip ? (this.dataset.tooltip[0] === '#' ? document.querySelector(this.dataset.tooltip).innerHTML : this.dataset.tooltip) : this.innerHTML);
+            b.innerHTML = evoTooltipHelper.getTooltipContent(this, document.querySelector.bind(document)) || this.innerHTML;
             if (x + b.offsetWidth + (c * 2) > window.innerWidth) {
                 b.style.left = Math.round(x - b.offsetWidth - (c * 2)) + 'px';
                 b.classList.add('evo-tooltip-right');
@@ -314,7 +314,7 @@ function document_onload() {
             this.parentNode.classList.toggle('show');
         };
     }
-    evo.tooltips('[data-tooltip]');
+    evo.tooltips('[data-tooltip], [data-toggle="tooltip"][title]');
     //evo.collapse('.panel-heading', 'panel-collapse');
 
     if (document.forms.length && document.forms.mutate && window.frameElement.parentNode.parentNode.classList.contains('evo-popup')) {

--- a/manager/media/script/tests/tooltip-helper.test.js
+++ b/manager/media/script/tests/tooltip-helper.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const helper = require('../tooltip-helper');
+
+test('getTooltipContent returns the inline data-tooltip text', () => {
+    const target = {
+        dataset: {
+            tooltip: 'Inline tooltip'
+        },
+        getAttribute(name) {
+            return name === 'title' ? 'Legacy title' : null;
+        }
+    };
+
+    assert.equal(helper.getTooltipContent(target), 'Inline tooltip');
+});
+
+test('getTooltipContent resolves tooltip content from a selector reference', () => {
+    const target = {
+        dataset: {
+            tooltip: '#help-target'
+        }
+    };
+
+    const querySelector = (selector) => selector === '#help-target'
+        ? { innerHTML: '<strong>Shared help</strong>' }
+        : null;
+
+    assert.equal(helper.getTooltipContent(target, querySelector), '<strong>Shared help</strong>');
+});
+
+test('getTooltipContent falls back to legacy title attributes', () => {
+    const target = {
+        dataset: {},
+        getAttribute(name) {
+            return name === 'title' ? 'Blocked until tomorrow' : null;
+        }
+    };
+
+    assert.equal(helper.getTooltipContent(target), 'Blocked until tomorrow');
+});

--- a/manager/media/script/tooltip-helper.js
+++ b/manager/media/script/tooltip-helper.js
@@ -1,0 +1,40 @@
+(function (root, factory) {
+    var exported = factory();
+
+    if (typeof module === 'object' && module.exports) {
+        module.exports = exported;
+    }
+
+    root.evoTooltipHelper = exported;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    function getTooltipContent(target, querySelector) {
+        var datasetTooltip;
+        var tooltipNode;
+
+        if (!target) {
+            return '';
+        }
+
+        datasetTooltip = target.dataset && target.dataset.tooltip;
+        if (datasetTooltip) {
+            if (datasetTooltip.charAt(0) === '#' && typeof querySelector === 'function') {
+                tooltipNode = querySelector(datasetTooltip);
+                return tooltipNode ? tooltipNode.innerHTML : '';
+            }
+
+            return datasetTooltip;
+        }
+
+        if (typeof target.getAttribute === 'function') {
+            return target.getAttribute('title') || '';
+        }
+
+        return '';
+    }
+
+    return {
+        getTooltipContent: getTooltipContent
+    };
+}));

--- a/manager/views/partials/header.blade.php
+++ b/manager/views/partials/header.blade.php
@@ -49,6 +49,7 @@
         // ============================================
         evo.MODX_MANAGER_URL = '{{EVO_MANAGER_URL}}';
     </script>
+    <script src="media/script/tooltip-helper.js"></script>
     <script src="media/script/main.js"></script>
     @if (get_by_key($_REQUEST, 'r', '', 'is_numeric'))
         <script>doRefresh({{ $_REQUEST['r'] }});</script>


### PR DESCRIPTION
## Problem
Issue #2195 reports that the manager `[i]` buttons no longer work. The concrete broken path is the Web User Management blocked-state info icon: it still used a legacy bootstrap tooltip trigger, but the page no longer initializes bootstrap tooltips while the shared manager tooltip flow is based on `data-tooltip`.

## Branch Reason
This branch keeps the fix focused on the manager tooltip regression without changing unrelated manager pages or reintroducing bootstrap-specific wiring.

## Change Summary
- added a small shared tooltip helper that resolves tooltip text from `data-tooltip`, selector-backed tooltip content, and legacy `title` attributes
- wired manager pages to load that helper before `main.js`
- extended the shared tooltip selector to cover legacy tooltip triggers
- switched the Web User Management blocked-state `[i]` icon to the shared `data-tooltip` contract and removed the dead bootstrap tooltip stub
- added a focused Node regression test for tooltip content resolution

## Landing Surfaces
- `manager/media/script/tooltip-helper.js`
- `manager/media/script/tests/tooltip-helper.test.js`
- `manager/media/script/main.js`
- `manager/views/partials/header.blade.php`
- `manager/actions/web_user_management.static.php`

## Verification
- `node --test manager/media/script/tests/tooltip-helper.test.js`
- `node --check manager/media/script/main.js`
- `node --check manager/media/script/tooltip-helper.js`
- `php -l manager/actions/web_user_management.static.php`
- `php -l manager/views/partials/header.blade.php`
- local branch runtime responds on `http://127.0.0.1:9546/`

## Remaining Open Items
- a full manager click-through on the exact blocked-user screen is still useful for maintainer review because the lightweight built-in PHP server does not expose the same routed manager stack as a full local web setup

Closes #2195