### PR TITLE
refactor(constants): start canonical EVO_* bootstrap aliases

### DIFF
--- a/core/includes/define.inc.php
+++ b/core/includes/define.inc.php
@@ -29,6 +29,33 @@ if (!defined('SESSION_COOKIE_NAME')) {
     define('SESSION_COOKIE_NAME', env('SESSION_COOKIE_NAME', genEvoSessionName())); // $site_sessionname
 }
 
+$resolveBootConstant = static function (string $canonicalName, ?string $legacyName, $default = null) {
+    if (defined($canonicalName)) {
+        return constant($canonicalName);
+    }
+
+    if ($legacyName !== null && defined($legacyName)) {
+        return constant($legacyName);
+    }
+
+    $value = $default;
+    if ($legacyName !== null) {
+        $value = env($legacyName, $value);
+    }
+
+    return env($canonicalName, $value);
+};
+
+$defineBootConstant = static function (string $canonicalName, ?string $legacyName, $default = null) use ($resolveBootConstant): void {
+    if (!defined($canonicalName)) {
+        define($canonicalName, $resolveBootConstant($canonicalName, $legacyName, $default));
+    }
+
+    if ($legacyName !== null && !defined($legacyName)) {
+        define($legacyName, constant($canonicalName));
+    }
+};
+
 /**
  * @deprecated
  * @since 3.2.6
@@ -37,12 +64,7 @@ if (!defined('SESSION_COOKIE_NAME')) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_CLASS')) {
-    define('MODX_CLASS', env('MODX_CLASS', '\DocumentParser'));
-}
-if (!defined('EVO_CLASS')) {
-    define('EVO_CLASS', env('EVO_CLASS', '\DocumentParser'));
-}
+$defineBootConstant('EVO_CLASS', 'MODX_CLASS', '\DocumentParser');
 
 /**
  * @deprecated
@@ -52,12 +74,7 @@ if (!defined('EVO_CLASS')) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_SITE_HOSTNAMES')) {
-    define('MODX_SITE_HOSTNAMES', env('MODX_SITE_HOSTNAMES', ''));
-}
-if (!defined('EVO_SITE_HOSTNAMES')) {
-    define('EVO_SITE_HOSTNAMES', env('EVO_SITE_HOSTNAMES', ''));
-}
+$defineBootConstant('EVO_SITE_HOSTNAMES', 'MODX_SITE_HOSTNAMES', '');
 
 if (!defined('MGR_DIR')) {
     define('MGR_DIR', env('MGR_DIR', 'manager'));
@@ -79,7 +96,7 @@ if (!defined('EVO_STORAGE_PATH')) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_BASE_PATH') || !defined('MODX_BASE_URL')) {
+if (!defined('MODX_BASE_PATH') || !defined('MODX_BASE_URL') || !defined('EVO_BASE_PATH') || !defined('EVO_BASE_URL')) {
     // automatically assign base_path and base_url
     $script_name = str_replace(
         '\\',
@@ -129,78 +146,11 @@ if (!defined('MODX_BASE_PATH') || !defined('MODX_BASE_URL')) {
         str_replace('\\', '/', implode(MGR_DIR, $items))
         , '/'
     ) . '/';
-
-    if (!defined('MODX_BASE_PATH')) {
-        define('MODX_BASE_PATH', env('MODX_BASE_PATH', $base_path));
-    }
-    unset($base_path);
-
-    if (!defined('MODX_BASE_URL')) {
-        define('MODX_BASE_URL', env('MODX_BASE_URL', $base_url));
-    }
-    unset($base_url);
 }
-if (!defined('EVO_BASE_PATH') || !defined('EVO_BASE_URL')) {
-    // automatically assign base_path and base_url
-    $script_name = str_replace(
-        '\\',
-        '/',
-        dirname(
-            get_by_key(
-                $_SERVER,
-                ($_SERVER['PHP_SELF'] !== $_SERVER['SCRIPT_NAME'] && ('undefined' === php_sapi_name() || is_cli())) ?
-                    'PHP_SELF' : 'SCRIPT_NAME'
-            )
-        )
-    );
 
-    if (substr($script_name, -1 - strlen(MGR_DIR)) === '/' . MGR_DIR ||
-        strpos($script_name, '/' . MGR_DIR . '/') !== false
-    ) {
-        $separator = MGR_DIR;
-    } elseif (strpos($script_name, '/assets/') !== false) {
-        $separator = 'assets';
-    } else {
-        $separator = '';
-    }
-
-    if ($separator !== '') {
-        $items = explode('/' . $separator, $script_name);
-    } else {
-        $items = [$script_name];
-    }
-    unset($script_name);
-
-    if (count($items) > 1) {
-        array_pop($items);
-    }
-
-    $url = implode($separator, $items);
-
-    $base_url = rtrim(implode($separator, $items), '/') . '/';
-    unset($separator);
-
-    reset($items);
-    $items = explode(MGR_DIR, str_replace('\\', '/', dirname(__DIR__, 2)));
-    if (count($items) > 1) {
-        array_pop($items);
-    }
-
-    $base_path = rtrim(
-        str_replace('\\', '/', implode(MGR_DIR, $items))
-        , '/'
-    ) . '/';
-
-    if (!defined('EVO_BASE_PATH')) {
-        define('EVO_BASE_PATH', env('EVO_BASE_PATH', $base_path));
-    }
-    unset($base_path);
-
-    if (!defined('EVO_BASE_URL')) {
-        define('EVO_BASE_URL', env('EVO_BASE_URL', $base_url));
-    }
-    unset($base_url);
-}
+$defineBootConstant('EVO_BASE_PATH', 'MODX_BASE_PATH', $base_path ?? null);
+$defineBootConstant('EVO_BASE_URL', 'MODX_BASE_URL', $base_url ?? null);
+unset($base_path, $base_url);
 
 /**
  * @deprecated
@@ -227,12 +177,7 @@ if (!preg_match('/\/$/', EVO_BASE_URL)) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_MANAGER_PATH')) {
-    define('MODX_MANAGER_PATH', env('MODX_MANAGER_PATH', MODX_BASE_PATH . MGR_DIR . '/'));
-}
-if (!defined('EVO_MANAGER_PATH')) {
-    define('EVO_MANAGER_PATH', env('EVO_MANAGER_PATH', EVO_BASE_PATH . MGR_DIR . '/'));
-}
+$defineBootConstant('EVO_MANAGER_PATH', 'MODX_MANAGER_PATH', EVO_BASE_PATH . MGR_DIR . '/');
 
 /**
  * @deprecated
@@ -242,53 +187,7 @@ if (!defined('EVO_MANAGER_PATH')) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_SITE_URL')) {
-    // check for valid hostnames
-    $site_hostname = 'localhost';
-    if (!is_cli()) {
-        $site_hostname = str_replace(
-            ':' . $_SERVER['SERVER_PORT'],
-            '',
-            get_by_key($_SERVER, 'HTTP_HOST', $site_hostname)
-        );
-    }
-    $site_hostnames = explode(',', MODX_SITE_HOSTNAMES);
-    if (!empty($site_hostnames[0]) && !in_array($site_hostname, $site_hostnames)) {
-        $site_hostname = $site_hostnames[0];
-    }
-    unset($site_hostnames);
-
-    if (!isset($_SERVER['SERVER_PORT'])) {
-        $_SERVER['SERVER_PORT'] = 80;
-    }
-
-    // assign site_url
-    if ((isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on') ||
-        $_SERVER['SERVER_PORT'] == HTTPS_PORT ||
-        (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
-    ) {
-        $site_url = 'https://' . $site_hostname;
-    } else {
-        $site_url = 'http://' . $site_hostname;
-    }
-    unset($site_hostname);
-
-    if ($_SERVER['SERVER_PORT'] !== 80) { // remove port from HTTP_HOST
-        $site_url = str_replace(':' . $_SERVER['SERVER_PORT'], '', $site_url);
-    }
-
-    if (!in_array((int)$_SERVER['SERVER_PORT'], [80, (int)HTTPS_PORT], true) &&
-        strtolower(get_by_key($_SERVER, 'HTTPS', 'off'))
-    ) {
-        $site_url .= ':' . $_SERVER['SERVER_PORT'];
-    }
-
-    $site_url .= MODX_BASE_URL;
-
-    define('MODX_SITE_URL', env('MODX_SITE_URL', $site_url));
-    unset($site_url);
-}
-if (!defined('EVO_SITE_URL')) {
+if (!defined('MODX_SITE_URL') || !defined('EVO_SITE_URL')) {
     // check for valid hostnames
     $site_hostname = 'localhost';
     if (!is_cli()) {
@@ -330,10 +229,9 @@ if (!defined('EVO_SITE_URL')) {
     }
 
     $site_url .= EVO_BASE_URL;
-
-    define('EVO_SITE_URL', env('EVO_SITE_URL', $site_url));
-    unset($site_url);
 }
+$defineBootConstant('EVO_SITE_URL', 'MODX_SITE_URL', $site_url ?? null);
+unset($site_url);
 
 /**
  * @deprecated
@@ -356,12 +254,7 @@ if (!preg_match('/\/$/', EVO_SITE_URL)) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_MANAGER_URL')) {
-    define('MODX_MANAGER_URL', env('MODX_MANAGER_URL', MODX_SITE_URL . MGR_DIR . '/'));
-}
-if (!defined('EVO_MANAGER_URL')) {
-    define('EVO_MANAGER_URL', env('EVO_MANAGER_URL', EVO_SITE_URL . MGR_DIR . '/'));
-}
+$defineBootConstant('EVO_MANAGER_URL', 'MODX_MANAGER_URL', EVO_SITE_URL . MGR_DIR . '/');
 
 /**
  * @deprecated
@@ -371,12 +264,7 @@ if (!defined('EVO_MANAGER_URL')) {
  *
  * @todo [remove@3.5] Remove in Evolution CMS 3.5
  */
-if (!defined('MODX_SANITIZE_SEED')) {
-    define('MODX_SANITIZE_SEED', 'sanitize_seed_' . base_convert(md5(__FILE__), 16, 36));
-}
-if (!defined('EVO_SANITIZE_SEED')) {
-    define('EVO_SANITIZE_SEED', 'sanitize_seed_' . base_convert(md5(__FILE__), 16, 36));
-}
+$defineBootConstant('EVO_SANITIZE_SEED', 'MODX_SANITIZE_SEED', 'sanitize_seed_' . base_convert(md5(__FILE__), 16, 36));
 
 if (is_cli()) {
     /**
@@ -387,12 +275,7 @@ if (is_cli()) {
      *
      * @todo [remove@3.5] Remove in Evolution CMS 3.5
      */
-    if (!defined('MODX_CLI')) {
-        define('MODX_CLI', true);
-    }
-    if (!defined('EVO_CLI')) {
-        define('EVO_CLI', true);
-    }
+    $defineBootConstant('EVO_CLI', 'MODX_CLI', true);
 
     /**
      * @deprecated

--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -1106,7 +1106,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
 
     public function setConditional()
     {
-        if (!empty($_POST) || (defined('MODX_API_MODE') && MODX_API_MODE) || $this->getLoginUserID('mgr') || !$this->useConditional || empty($this->recentUpdate)) {
+        if (!empty($_POST) || (defined('EVO_API_MODE') && EVO_API_MODE) || $this->getLoginUserID('mgr') || !$this->useConditional || empty($this->recentUpdate)) {
             return;
         }
         $last_modified = gmdate('D, d M Y H:i:s T', $this->recentUpdate);

--- a/core/tests/Feature/ModifiersTest.php
+++ b/core/tests/Feature/ModifiersTest.php
@@ -6,8 +6,8 @@ use Tests\Mocks\MockDocumentParser;
 if (!defined('IN_INSTALL_MODE')) {
     define('IN_INSTALL_MODE', false);
 }
-if (!defined('MODX_API_MODE')) {
-    define('MODX_API_MODE', true);
+if (!defined('EVO_API_MODE')) {
+    define('EVO_API_MODE', true);
 }
 if (!defined('IN_MANAGER_MODE')) {
     define('IN_MANAGER_MODE', false);

--- a/core/tests/Unit/DefineConstantsCompatibilityTest.php
+++ b/core/tests/Unit/DefineConstantsCompatibilityTest.php
@@ -1,0 +1,126 @@
+<?php
+
+function loadBootConstantsInFreshProcess(array $env): array
+{
+    $rootDir = dirname(__DIR__, 3);
+    $script = <<<'PHP'
+<?php
+$rootDir = %s;
+$envValues = %s;
+$managedEnvNames = [
+    'EVO_CLASS',
+    'EVO_SITE_HOSTNAMES',
+    'EVO_BASE_PATH',
+    'EVO_BASE_URL',
+    'EVO_MANAGER_PATH',
+    'EVO_SITE_URL',
+    'EVO_MANAGER_URL',
+    'MODX_CLASS',
+    'MODX_SITE_HOSTNAMES',
+    'MODX_BASE_PATH',
+    'MODX_BASE_URL',
+    'MODX_MANAGER_PATH',
+    'MODX_SITE_URL',
+    'MODX_MANAGER_URL',
+];
+
+foreach ($managedEnvNames as $name) {
+    putenv($name);
+    unset($_ENV[$name], $_SERVER[$name]);
+}
+
+foreach ($envValues as $name => $value) {
+    putenv($name . '=' . $value);
+    $_ENV[$name] = $value;
+}
+
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+$_SERVER['PHP_SELF'] = '/index.php';
+$_SERVER['HTTP_HOST'] = 'example.test';
+$_SERVER['SERVER_PORT'] = 80;
+$_SERVER['HTTPS'] = 'off';
+
+define('IN_INSTALL_MODE', false);
+define('IN_MANAGER_MODE', false);
+define('EVO_API_MODE', true);
+
+require $rootDir . '/core/vendor/autoload.php';
+require $rootDir . '/core/functions/helper.php';
+require $rootDir . '/core/functions/preload.php';
+require $rootDir . '/core/includes/define.inc.php';
+
+$constants = [];
+foreach ([
+    'EVO_CLASS',
+    'EVO_SITE_HOSTNAMES',
+    'EVO_BASE_PATH',
+    'EVO_BASE_URL',
+    'EVO_MANAGER_PATH',
+    'EVO_SITE_URL',
+    'EVO_MANAGER_URL',
+    'MODX_CLASS',
+    'MODX_SITE_HOSTNAMES',
+    'MODX_BASE_PATH',
+    'MODX_BASE_URL',
+    'MODX_MANAGER_PATH',
+    'MODX_SITE_URL',
+    'MODX_MANAGER_URL',
+] as $name) {
+    $constants[$name] = defined($name) ? constant($name) : null;
+}
+
+echo json_encode($constants, JSON_THROW_ON_ERROR);
+PHP;
+
+    $scriptPath = tempnam(sys_get_temp_dir(), 'evo-constants-');
+    file_put_contents($scriptPath, sprintf($script, var_export($rootDir, true), var_export($env, true)));
+
+    $output = [];
+    $status = 0;
+    exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($scriptPath), $output, $status);
+    @unlink($scriptPath);
+
+    expect($status)->toBe(0, implode("\n", $output));
+
+    return json_decode(implode("\n", $output), true, 512, JSON_THROW_ON_ERROR);
+}
+
+test('evo bootstrap constants publish modx aliases', function () {
+    $constants = loadBootConstantsInFreshProcess([
+        'EVO_CLASS' => '\\DocumentParser',
+        'EVO_SITE_HOSTNAMES' => 'example.test',
+        'EVO_BASE_PATH' => '/tmp/evo/',
+        'EVO_BASE_URL' => '/evo/',
+        'EVO_MANAGER_PATH' => '/tmp/evo/manager/',
+        'EVO_SITE_URL' => 'https://example.test/evo/',
+        'EVO_MANAGER_URL' => 'https://example.test/evo/manager/',
+    ]);
+
+    expect($constants['MODX_CLASS'])->toBe($constants['EVO_CLASS'])
+        ->and($constants['MODX_SITE_HOSTNAMES'])->toBe($constants['EVO_SITE_HOSTNAMES'])
+        ->and($constants['MODX_BASE_PATH'])->toBe($constants['EVO_BASE_PATH'])
+        ->and($constants['MODX_BASE_URL'])->toBe($constants['EVO_BASE_URL'])
+        ->and($constants['MODX_MANAGER_PATH'])->toBe($constants['EVO_MANAGER_PATH'])
+        ->and($constants['MODX_SITE_URL'])->toBe($constants['EVO_SITE_URL'])
+        ->and($constants['MODX_MANAGER_URL'])->toBe($constants['EVO_MANAGER_URL']);
+});
+
+test('legacy modx bootstrap env still hydrates evo constants', function () {
+    $constants = loadBootConstantsInFreshProcess([
+        'MODX_CLASS' => '\\DocumentParser',
+        'MODX_SITE_HOSTNAMES' => 'legacy.example.test',
+        'MODX_BASE_PATH' => '/tmp/legacy-evo/',
+        'MODX_BASE_URL' => '/legacy-evo/',
+        'MODX_MANAGER_PATH' => '/tmp/legacy-evo/manager/',
+        'MODX_SITE_URL' => 'https://legacy.example.test/legacy-evo/',
+        'MODX_MANAGER_URL' => 'https://legacy.example.test/legacy-evo/manager/',
+    ]);
+
+    expect($constants['EVO_CLASS'])->toBe($constants['MODX_CLASS'])
+        ->and($constants['EVO_SITE_HOSTNAMES'])->toBe($constants['MODX_SITE_HOSTNAMES'])
+        ->and($constants['EVO_BASE_PATH'])->toBe($constants['MODX_BASE_PATH'])
+        ->and($constants['EVO_BASE_URL'])->toBe($constants['MODX_BASE_URL'])
+        ->and($constants['EVO_MANAGER_PATH'])->toBe($constants['MODX_MANAGER_PATH'])
+        ->and($constants['EVO_SITE_URL'])->toBe($constants['MODX_SITE_URL'])
+        ->and($constants['EVO_MANAGER_URL'])->toBe($constants['MODX_MANAGER_URL']);
+});

--- a/index.php
+++ b/index.php
@@ -106,6 +106,14 @@ if (!defined('IN_MANAGER_MODE')) {
     define('IN_MANAGER_MODE', false);
 }
 /**
+ * Disables automatic request dispatching in the front controller.
+ *
+ * When enabled, this file will not call `$evo->processRoutes()`.
+ */
+if (!defined('EVO_API_MODE')) {
+    define('EVO_API_MODE', false);
+}
+/**
  * @deprecated
  * @since 3.5.0
  *
@@ -114,15 +122,7 @@ if (!defined('IN_MANAGER_MODE')) {
  * @todo [remove@3.5.3] Remove in Evolution CMS 3.5.3
  */
 if (!defined('MODX_API_MODE')) {
-    define('MODX_API_MODE', false);
-}
-/**
- * Disables automatic request dispatching in the front controller.
- *
- * When enabled, this file will not call `$evo->processRoutes()`.
- */
-if (!defined('EVO_API_MODE')) {
-    define('EVO_API_MODE', false);
+    define('MODX_API_MODE', EVO_API_MODE);
 }
 if (!defined('EVO_CLI')) {
     define('EVO_CLI', false);

--- a/install/cli-install.php
+++ b/install/cli-install.php
@@ -3,7 +3,7 @@
 use EvolutionCMS\Facades\Console;
 
 $base_path = dirname(__DIR__) . '/';
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 define('EVO_BASE_PATH', $base_path);
 define('EVO_SITE_URL', '/');
 define('EVO_CORE_PATH', $base_path . 'core/');

--- a/install/index.php
+++ b/install/index.php
@@ -15,8 +15,11 @@ if (! defined('MGR_DIR')) {
         die('MGR_DIR is not defined');
     }
 }
+if (!defined('EVO_MANAGER_PATH')) {
+    define('EVO_MANAGER_PATH', $base_path . MGR_DIR . '/');
+}
 if (!defined('MODX_MANAGER_PATH')) {
-    define('MODX_MANAGER_PATH', $base_path . MGR_DIR . '/');
+    define('MODX_MANAGER_PATH', EVO_MANAGER_PATH);
 }
 if (! defined('EVO_CORE_PATH')) {
     if (is_dir($base_path . 'core')) {

--- a/install/src/controllers/install.php
+++ b/install/src/controllers/install.php
@@ -180,19 +180,19 @@ try {
                 }
             }
         }
-        define('MODX_API_MODE', true);
+        define('EVO_API_MODE', true);
         define('IN_MANAGER_MODE', true);
         define('IN_INSTALL_MODE', true);
-        define('MODX_BASE_PATH', dirname(dirname(dirname(__DIR__))) . '/');
+        define('EVO_BASE_PATH', dirname(dirname(dirname(__DIR__))) . '/');
         define('SESSION_COOKIE_NAME', session_name());
-        require_once(MODX_BASE_PATH . 'core/functions/helper.php');
-        require_once(MODX_BASE_PATH . 'core/includes/define.inc.php');
+        require_once(EVO_BASE_PATH . 'core/functions/helper.php');
+        require_once(EVO_BASE_PATH . 'core/includes/define.inc.php');
 
-        if (file_exists(MODX_BASE_PATH.'core/storage/bootstrap/services.php')) {
-            unlink(MODX_BASE_PATH.'core/storage/bootstrap/services.php');
+        if (file_exists(EVO_BASE_PATH.'core/storage/bootstrap/services.php')) {
+            unlink(EVO_BASE_PATH.'core/storage/bootstrap/services.php');
         }
 
-        include(MODX_BASE_PATH . '/index.php');
+        include(EVO_BASE_PATH . '/index.php');
 
         if ($installMode != 0 && $database_type == 'pgsql') {
             try {
@@ -211,7 +211,7 @@ try {
             }
         }
 
-        Console::call('migrate', ['--path' => MODX_BASE_PATH . 'install/stubs/migrations', '--realpath' => true, '--force' => true]);
+        Console::call('migrate', ['--path' => EVO_BASE_PATH . 'install/stubs/migrations', '--realpath' => true, '--force' => true]);
 
         if ($installMode == 0) {
             seed('install');

--- a/manager/captcha.php
+++ b/manager/captcha.php
@@ -1,5 +1,5 @@
 <?php
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 
 if (file_exists(__DIR__ . '/config.php')) {
     $config = require __DIR__ . '/config.php';

--- a/manager/includes/active_user_locks.php
+++ b/manager/includes/active_user_locks.php
@@ -5,7 +5,7 @@
  * This page is requested by several actions to keep elements/resources locked
  */
 define('IN_MANAGER_MODE', true);
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 include_once('../../index.php');
 
 EvolutionCMS()->invokeEvent('OnManagerPageInit');

--- a/manager/includes/session_keepalive.php
+++ b/manager/includes/session_keepalive.php
@@ -5,7 +5,7 @@
  * This page is requested every 10min to keep the session alive and kicking
  */
 define('IN_MANAGER_MODE', true);
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 include_once('../../index.php');
 if (defined('EVO_SESSION') && EVO_SESSION) {
     \EvoSessionProxy::init();

--- a/manager/media/browser/mcpuk/core/autoload.php
+++ b/manager/media/browser/mcpuk/core/autoload.php
@@ -20,7 +20,7 @@
   *        It's recommended to use constants instead.
   */
 define('IN_MANAGER_MODE', true);
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 include_once(__DIR__."/../../../../../index.php");
 $modx = EvolutionCMS();
 

--- a/manager/media/style/default/ajax.php
+++ b/manager/media/style/default/ajax.php
@@ -3,7 +3,7 @@
 use EvolutionCMS\Models\SiteContent;
 
 define('IN_MANAGER_MODE', true);  // we use this to make sure files are accessed through
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 
 if (file_exists(dirname(__DIR__, 3) . '/config.php')) {
     $config = require dirname(__DIR__) . '/config.php';

--- a/manager/media/style/liquid/ajax.php
+++ b/manager/media/style/liquid/ajax.php
@@ -3,7 +3,7 @@
 use EvolutionCMS\Models\SiteContent;
 
 define('IN_MANAGER_MODE', true);  // we use this to make sure files are accessed through
-define('MODX_API_MODE', true);
+define('EVO_API_MODE', true);
 
 if (file_exists(dirname(__DIR__, 3) . '/config.php')) {
     $config = require dirname(__DIR__) . '/config.php';


### PR DESCRIPTION
## Problem

Issue #2238 asks to move Evolution CMS away from legacy `MODX_*` system constants without breaking existing projects. The risky part is bootstrap: several runtime and installer entrypoints still seed `MODX_*` directly, and `define.inc.php` duplicates constant resolution logic for both naming schemes.

## Why

This PR starts the migration with a safe first slice instead of trying to rename every `MODX_*` usage in one pass. The goal here is to make `EVO_*` canonical in touched bootstrap surfaces while keeping `MODX_*` available as backward-compatible aliases.

## What Changed

- added a small canonical/legacy resolver in `core/includes/define.inc.php`
- resolved class, hostname, path, url, manager, sanitize, and CLI constants through `EVO_*` first
- backfilled missing `MODX_*` constants from the resolved `EVO_*` values
- switched touched runtime entrypoints from `MODX_API_MODE` to `EVO_API_MODE`
- updated the touched installer bootstrap path handling to seed `EVO_BASE_PATH` / `EVO_MANAGER_PATH`
- switched the touched internal runtime conditional in `core/src/Core.php` to `EVO_API_MODE`
- added a fresh-process compatibility test for `EVO_* -> MODX_*` aliasing and `MODX_* -> EVO_*` fallback

## Where

- `core/includes/define.inc.php`
- `index.php`
- `core/src/Core.php`
- `install/index.php`
- `install/cli-install.php`
- `install/src/controllers/install.php`
- `manager/captcha.php`
- `manager/includes/session_keepalive.php`
- `manager/includes/active_user_locks.php`
- `manager/media/browser/mcpuk/core/autoload.php`
- `manager/media/style/default/ajax.php`
- `manager/media/style/liquid/ajax.php`
- `core/tests/Unit/DefineConstantsCompatibilityTest.php`
- `core/tests/Feature/ModifiersTest.php`

## Verification

- `./vendor/bin/pest tests/Unit/DefineConstantsCompatibilityTest.php tests/Feature/ModifiersTest.php`
- `php -l core/includes/define.inc.php`
- `php -l index.php`
- `php -l install/index.php`
- `php -l install/cli-install.php`
- `php -l install/src/controllers/install.php`
- `php -l manager/captcha.php`
- `php -l manager/includes/session_keepalive.php`
- `php -l manager/includes/active_user_locks.php`
- `php -l manager/media/browser/mcpuk/core/autoload.php`
- `php -l manager/media/style/default/ajax.php`
- `php -l manager/media/style/liquid/ajax.php`

## Remaining Gaps

- this is the first slice for `#2238`, not the full repository-wide rename
- many internal `MODX_*` references still remain outside the touched bootstrap/runtime surfaces and can be migrated in follow-up PRs
