### PR TITLE
fix(config): ignore invalid custom split config

### DIFF
--- a/core/src/AbstractLaravel.php
+++ b/core/src/AbstractLaravel.php
@@ -196,9 +196,26 @@ abstract class AbstractLaravel extends Container implements ApplicationContract
             ksort($files, SORT_NATURAL);
 
             foreach ($files as $key => $path) {
-                $config->set($key, require $path);
+                try {
+                    $config->set($key, require $path);
+                } catch (\ParseError $exception) {
+                    if (!$this->isCustomConfigPath($path)) {
+                        throw $exception;
+                    }
+
+                    error_log(sprintf(
+                        '[EvolutionCMS] Skipped invalid custom config file "%s": %s',
+                        $path,
+                        $exception->getMessage()
+                    ));
+                }
             }
         }
+    }
+
+    protected function isCustomConfigPath(string $path): bool
+    {
+        return str_contains(str_replace('\\', '/', $path), '/custom/config/');
     }
 
     /**

--- a/core/tests/Unit/AbstractLaravelLoadConfigurationTest.php
+++ b/core/tests/Unit/AbstractLaravelLoadConfigurationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use EvolutionCMS\AbstractLaravel;
+use EvolutionCMS\Core;
+use Illuminate\Config\Repository;
+
+function buildConfigLoaderApp(): AbstractLaravel
+{
+    return (new ReflectionClass(Core::class))->newInstanceWithoutConstructor();
+}
+
+function invokeLoadConfiguration(AbstractLaravel $app, Repository $config, string $dir): void
+{
+    $method = new ReflectionMethod(AbstractLaravel::class, 'loadConfiguration');
+    $method->setAccessible(true);
+    $method->invoke($app, $config, $dir);
+}
+
+function writePhpConfigFile(string $path, string $content): void
+{
+    $directory = dirname($path);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0775, true);
+    }
+
+    file_put_contents($path, $content);
+}
+
+function deleteConfigTestTree(string $path): void
+{
+    if (!file_exists($path)) {
+        return;
+    }
+
+    if (is_file($path) || is_link($path)) {
+        unlink($path);
+        return;
+    }
+
+    foreach (scandir($path) as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+
+        deleteConfigTestTree($path . DIRECTORY_SEPARATOR . $item);
+    }
+
+    rmdir($path);
+}
+
+beforeEach(function () {
+    $this->tempDirs = [];
+});
+
+afterEach(function () {
+    foreach ($this->tempDirs as $dir) {
+        deleteConfigTestTree($dir);
+    }
+});
+
+function makeTempConfigRoot(object $testCase, string $suffix): string
+{
+    $root = sys_get_temp_dir() . '/evo-config-' . $suffix . '-' . bin2hex(random_bytes(5));
+    mkdir($root, 0775, true);
+    $testCase->tempDirs[] = $root;
+
+    return $root;
+}
+
+test('loadConfiguration reads valid split custom settings files', function () {
+    $root = makeTempConfigRoot($this, 'valid');
+    $configRoot = $root . '/custom/config';
+    $namespace = "EvolutionCMS\\Main\\Controllers\\";
+
+    writePhpConfigFile(
+        $configRoot . '/cms/settings/ControllerNamespace.php',
+        '<?php return ' . var_export($namespace, true) . ';' . PHP_EOL
+    );
+
+    $config = new Repository([]);
+
+    invokeLoadConfiguration(buildConfigLoaderApp(), $config, $configRoot);
+
+    expect($config->get('cms.settings.ControllerNamespace'))->toBe($namespace)
+        ->and($config->get('cms.settings'))->toBe(['ControllerNamespace' => $namespace]);
+});
+
+test('loadConfiguration skips invalid custom config files without killing bootstrap', function () {
+    $root = makeTempConfigRoot($this, 'broken-custom');
+    $configRoot = $root . '/custom/config';
+
+    writePhpConfigFile(
+        $configRoot . '/cms/settings/ControllerNamespace.php',
+        <<<'PHP'
+<?php return "EvolutionCMS\Main\Controllers\";
+PHP
+        . PHP_EOL
+    );
+
+    $config = new Repository([
+        'cms' => [
+            'settings' => [
+                'site_name' => 'Demo',
+            ],
+        ],
+    ]);
+
+    invokeLoadConfiguration(buildConfigLoaderApp(), $config, $configRoot);
+
+    expect($config->get('cms.settings.site_name'))->toBe('Demo')
+        ->and($config->get('cms.settings.ControllerNamespace'))->toBeNull();
+});
+
+test('loadConfiguration still throws for invalid non-custom config files', function () {
+    $root = makeTempConfigRoot($this, 'broken-core');
+    $configRoot = $root . '/config';
+
+    writePhpConfigFile(
+        $configRoot . '/app.php',
+        <<<'PHP'
+<?php return ["name" => "Broken";
+PHP
+        . PHP_EOL
+    );
+
+    $config = new Repository([]);
+
+    expect(fn () => invokeLoadConfiguration(buildConfigLoaderApp(), $config, $configRoot))
+        ->toThrow(ParseError::class);
+});


### PR DESCRIPTION
## Problem

Issue #2196 reports a white-screen / HTTP 500 after creating `core/custom/config/cms/settings/ControllerNamespace.php`. On current `3.5.x`, the failure path comes from bootstrap config loading: an invalid custom split config file is required directly and kills the whole runtime with a `ParseError`.

## Why

This PR makes the custom config layer resilient without hiding real platform breakage. Custom user config mistakes should not take down the whole application, but invalid core config should still stay fatal.

## What Changed

- wrapped config file loading in `core/src/AbstractLaravel.php` with a narrow `ParseError` guard
- invalid files under `core/custom/config/**` are now skipped and logged instead of crashing bootstrap
- invalid non-custom config files still throw as before
- added a focused unit test that covers:
  - valid split custom config loading
  - invalid custom split config fallback
  - invalid non-custom config remaining fatal

## Where

- `core/src/AbstractLaravel.php`
- `core/tests/Unit/AbstractLaravelLoadConfigurationTest.php`

## Verification

- `./vendor/bin/pest tests/Unit/AbstractLaravelLoadConfigurationTest.php`
- `./vendor/bin/pest tests/Feature/ModifiersTest.php`
- `php -l core/src/AbstractLaravel.php`
- `php -l core/tests/Unit/AbstractLaravelLoadConfigurationTest.php`
- manual bootstrap check with a broken `core/custom/config/cms/settings/ControllerNamespace.php` now logs and falls back instead of fataling

## Remaining Gaps

- this PR does not try to auto-fix the invalid PHP content itself
- the broken custom config file is still ignored until the user corrects it
