### PR TITLE
fix(manager): block deleted tree move targets

### DIFF
--- a/core/src/Controllers/MoveDocument.php
+++ b/core/src/Controllers/MoveDocument.php
@@ -3,6 +3,7 @@
 use EvolutionCMS\Interfaces\ManagerTheme;
 use EvolutionCMS\Models;
 use EvolutionCMS\Legacy\Permissions;
+use EvolutionCMS\Support\MoveDocumentTargetGuard;
 use Exception;
 
 class MoveDocument extends AbstractController implements ManagerTheme\PageControllerInterface
@@ -80,7 +81,7 @@ class MoveDocument extends AbstractController implements ManagerTheme\PageContro
         }
         if ($newParentID > 0) {
             $parentDocument = $this->getDocument($newParentID);
-            if ($parentDocument->deleted) {
+            if (MoveDocumentTargetGuard::blocksParent($parentDocument)) {
                 $this->managerTheme->alertAndQuit('error_parent_deleted');
             };
             $children = allChildren($document->getKey());

--- a/core/src/Support/MoveDocumentTargetGuard.php
+++ b/core/src/Support/MoveDocumentTargetGuard.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EvolutionCMS\Support;
+
+use EvolutionCMS\Models\SiteContent;
+
+class MoveDocumentTargetGuard
+{
+    public static function blocksParent(?SiteContent $parentDocument): bool
+    {
+        return $parentDocument === null || (int)$parentDocument->deleted === 1;
+    }
+}

--- a/core/tests/Unit/MoveDocumentTargetGuardTest.php
+++ b/core/tests/Unit/MoveDocumentTargetGuardTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use EvolutionCMS\Models\SiteContent;
+use EvolutionCMS\Support\MoveDocumentTargetGuard;
+
+test('move document target guard blocks missing or deleted parents', function () {
+    $deletedParent = new SiteContent();
+    $deletedParent->deleted = 1;
+
+    $activeParent = new SiteContent();
+    $activeParent->deleted = 0;
+
+    expect(MoveDocumentTargetGuard::blocksParent(null))->toBeTrue()
+        ->and(MoveDocumentTargetGuard::blocksParent($deletedParent))->toBeTrue()
+        ->and(MoveDocumentTargetGuard::blocksParent($activeParent))->toBeFalse();
+});

--- a/manager/media/script/tests/tree-drop-guard-helper.test.js
+++ b/manager/media/script/tests/tree-drop-guard-helper.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const helper = require('../tree-drop-guard-helper');
+
+test('canDropIntoTarget blocks deleted tree nodes', () => {
+    assert.equal(helper.canDropIntoTarget({
+        dataset: {
+            deleted: '1'
+        }
+    }), false);
+});
+
+test('canDropIntoTarget allows active tree nodes', () => {
+    assert.equal(helper.canDropIntoTarget({
+        dataset: {
+            deleted: '0'
+        }
+    }), true);
+});
+
+test('canDropIntoTarget allows targets without dataset metadata', () => {
+    assert.equal(helper.canDropIntoTarget(null), true);
+    assert.equal(helper.canDropIntoTarget({}), true);
+});

--- a/manager/media/script/tree-drop-guard-helper.js
+++ b/manager/media/script/tree-drop-guard-helper.js
@@ -1,0 +1,28 @@
+(function (root, factory) {
+    var exported = factory();
+
+    if (typeof module === 'object' && module.exports) {
+        module.exports = exported;
+    }
+
+    root.modxTreeDropGuardHelper = exported;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    function isDeletedTarget(targetAnchor) {
+        if (!targetAnchor || !targetAnchor.dataset) {
+            return false;
+        }
+
+        return parseInt(targetAnchor.dataset.deleted || '0', 10) === 1;
+    }
+
+    function canDropIntoTarget(targetAnchor) {
+        return !isDeletedTarget(targetAnchor);
+    }
+
+    return {
+        canDropIntoTarget: canDropIntoTarget,
+        isDeletedTarget: isDeletedTarget
+    };
+}));

--- a/manager/media/style/default/ajax.php
+++ b/manager/media/style/default/ajax.php
@@ -1,6 +1,7 @@
 <?php
 
 use EvolutionCMS\Models\SiteContent;
+use EvolutionCMS\Support\MoveDocumentTargetGuard;
 
 define('IN_MANAGER_MODE', true);  // we use this to make sure files are accessed through
 define('MODX_API_MODE', true);
@@ -594,7 +595,8 @@ if (isset($action)) {
                             $parent = $eventParent;
                         }
                     }
-                    $parentDeleted = $parent > 0 && empty(SiteContent::find($parent));
+                    $parentDocument = $parent > 0 ? SiteContent::withTrashed()->find($parent) : null;
+                    $parentDeleted = $parent > 0 && MoveDocumentTargetGuard::blocksParent($parentDocument);
                     if ($parentDeleted) {
                         $json['errors'] = $_lang['error_parent_deleted'];
                     } elseif (empty($json['errors'])) {

--- a/manager/media/style/default/js/modx.js
+++ b/manager/media/style/default/js/modx.js
@@ -906,8 +906,14 @@
                 e.dataTransfer.dropEffect = 'all';
                 e.dataTransfer.setData('text', this.id.substr(4));
             },
+            isBlockedDropTarget: function (target) {
+                return !!(w.modxTreeDropGuardHelper && !w.modxTreeDropGuardHelper.canDropIntoTarget(target));
+            },
             ondragenter: function (e) {
-                if (d.getElementById('node' + modx.tree.itemToChange) === (this.parentNode.closest('#node' + modx.tree.itemToChange) || this.parentNode)) {
+                if (
+                    d.getElementById('node' + modx.tree.itemToChange) === (this.parentNode.closest('#node' + modx.tree.itemToChange) || this.parentNode)
+                    || modx.tree.isBlockedDropTarget(this)
+                ) {
                     this.parentNode.className = '';
                     e.dataTransfer.effectAllowed = 'none';
                     e.dataTransfer.dropEffect = 'none';
@@ -921,7 +927,12 @@
                 e.preventDefault();
             },
             ondragover: function (e) {
-                if (modx.tree.drag) {
+                if (modx.tree.isBlockedDropTarget(this)) {
+                    this.parentNode.className = '';
+                    e.dataTransfer.effectAllowed = 'none';
+                    e.dataTransfer.dropEffect = 'none';
+                    modx.tree.drag = false;
+                } else if (modx.tree.drag) {
                     var a = e.clientY;
                     var b = parseInt(this.getBoundingClientRect().top);
                     var c = a - b;
@@ -960,6 +971,15 @@
                 e.preventDefault();
             },
             ondrop: function (e) {
+                if (modx.tree.isBlockedDropTarget(this)) {
+                    this.parentNode.removeAttribute('class');
+                    this.parentNode.removeAttribute('draggable');
+                    modx.alert(modx.lang.error_parent_deleted);
+                    modx.tree.restoreTree();
+                    e.preventDefault();
+                    return;
+                }
+
                 let el = d.getElementById('node' + modx.tree.itemToChange);
                 let els = null;
                 let id = modx.tree.itemToChange;

--- a/manager/media/style/liquid/ajax.php
+++ b/manager/media/style/liquid/ajax.php
@@ -1,6 +1,7 @@
 <?php
 
 use EvolutionCMS\Models\SiteContent;
+use EvolutionCMS\Support\MoveDocumentTargetGuard;
 
 define('IN_MANAGER_MODE', true);  // we use this to make sure files are accessed through
 define('MODX_API_MODE', true);
@@ -594,7 +595,8 @@ if (isset($action)) {
                             $parent = $eventParent;
                         }
                     }
-                    $parentDeleted = $parent > 0 && empty(SiteContent::find($parent));
+                    $parentDocument = $parent > 0 ? SiteContent::withTrashed()->find($parent) : null;
+                    $parentDeleted = $parent > 0 && MoveDocumentTargetGuard::blocksParent($parentDocument);
                     if ($parentDeleted) {
                         $json['errors'] = $_lang['error_parent_deleted'];
                     } elseif (empty($json['errors'])) {

--- a/manager/media/style/liquid/js/modx.js
+++ b/manager/media/style/liquid/js/modx.js
@@ -923,8 +923,14 @@
                 e.dataTransfer.dropEffect = 'all';
                 e.dataTransfer.setData('text', this.id.substr(4));
             },
+            isBlockedDropTarget: function (target) {
+                return !!(w.modxTreeDropGuardHelper && !w.modxTreeDropGuardHelper.canDropIntoTarget(target));
+            },
             ondragenter: function (e) {
-                if (d.getElementById('node' + modx.tree.itemToChange) === (this.parentNode.closest('#node' + modx.tree.itemToChange) || this.parentNode)) {
+                if (
+                    d.getElementById('node' + modx.tree.itemToChange) === (this.parentNode.closest('#node' + modx.tree.itemToChange) || this.parentNode)
+                    || modx.tree.isBlockedDropTarget(this)
+                ) {
                     this.parentNode.className = '';
                     e.dataTransfer.effectAllowed = 'none';
                     e.dataTransfer.dropEffect = 'none';
@@ -938,7 +944,12 @@
                 e.preventDefault();
             },
             ondragover: function (e) {
-                if (modx.tree.drag) {
+                if (modx.tree.isBlockedDropTarget(this)) {
+                    this.parentNode.className = '';
+                    e.dataTransfer.effectAllowed = 'none';
+                    e.dataTransfer.dropEffect = 'none';
+                    modx.tree.drag = false;
+                } else if (modx.tree.drag) {
                     var a = e.clientY;
                     var b = parseInt(this.getBoundingClientRect().top);
                     var c = a - b;
@@ -977,6 +988,15 @@
                 e.preventDefault();
             },
             ondrop: function (e) {
+                if (modx.tree.isBlockedDropTarget(this)) {
+                    this.parentNode.removeAttribute('class');
+                    this.parentNode.removeAttribute('draggable');
+                    modx.alert(modx.lang.error_parent_deleted);
+                    modx.tree.restoreTree();
+                    e.preventDefault();
+                    return;
+                }
+
                 let el = d.getElementById('node' + modx.tree.itemToChange);
                 let els = null;
                 let id = modx.tree.itemToChange;

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -136,6 +136,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                 empty_recycle_bin: "{{ManagerTheme::getLexicon('empty_recycle_bin')}}",
                 empty_recycle_bin_empty: "{{ManagerTheme::getLexicon('empty_recycle_bin_empty')}}",
                 error_no_privileges: "{{ManagerTheme::getLexicon('error_no_privileges')}}",
+                error_parent_deleted: "{{ManagerTheme::getLexicon('error_parent_deleted')}}",
                 expand_tree: "{{ManagerTheme::getLexicon('expand_tree')}}",
                 loading_doc_tree: "{{ManagerTheme::getLexicon('loading_doc_tree')}}",
                 loading_menu: "{{ManagerTheme::getLexicon('loading_menu')}}",
@@ -218,6 +219,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
         echo (empty($opened) ? '' : 'modx.openedArray[' . implode("] = 1;\n		modx.openedArray[", $opened) . '] = 1;') . "\n";
         ?>
     </script>
+    <script src="media/script/tree-drop-guard-helper.js?v={{evo()->getVersionData('version')}}"></script>
     <script src="{{ManagerTheme::getThemeUrl()}}js/modx.js?v={{evo()->getVersionData('version')}}"></script>
     @if ($modx->getConfig('show_picker'))
         <script src="media/script/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>


### PR DESCRIPTION
## Problem

Dragging a published resource into a deleted tree node was still allowed by the manager UI. That made the tree attempt a move against a parent that should never accept children in the normal manager flow.

## Why this approach

This keeps the fix bounded to the move flow itself:
- block deleted tree targets in the manager before the DOM is reshuffled
- keep a shared backend guard so deleted or missing parents stay rejected even if the UI is bypassed
- cover both layers with focused regression tests

## What changed

- added `tree-drop-guard-helper.js` and loaded it in the manager frame
- prevented drag enter / drag over / drop onto deleted tree nodes in both manager themes
- exposed `error_parent_deleted` to the manager JS lang payload so the blocked drop shows the right message
- extracted `MoveDocumentTargetGuard` and reused it in both AJAX move handlers and the Move Document controller

## Files / surfaces

- manager frame bootstrap
- default manager tree drag/drop flow
- liquid manager tree drag/drop flow
- move document backend guard
- focused JS + PHP regression tests

## Verification

- `node --test manager/media/script/tests/tree-drop-guard-helper.test.js`
- `./vendor/bin/pest tests/Unit/MoveDocumentTargetGuardTest.php`
- `./vendor/bin/pest tests/Feature/ModifiersTest.php`
- `php -l` on touched PHP files
- `node --check` on touched JS files
- local runtime smoke check on the task branch

## Risks

This is intentionally narrow and does not change unrelated tree ordering or move rules. It only blocks deleted parents and makes the server-side validation explicit.

## Links

- Closes #2057
