### PR TITLE
ref(constants): use evo manager path helpers

### DIFF
--- a/core/src/Controllers/Frame.php
+++ b/core/src/Controllers/Frame.php
@@ -318,7 +318,7 @@ class Frame extends AbstractController implements ManagerTheme\PageControllerInt
 
     protected function evoLogoIcon(): string
     {
-        $path = MODX_MANAGER_PATH . 'media/style/common/images/misc/logo-evo.svg';
+        $path = EVO_MANAGER_PATH . 'media/style/common/images/misc/logo-evo.svg';
         if (is_file($path)) {
             $svg = file_get_contents($path);
             if ($svg !== false) {

--- a/core/src/Controllers/Users/LogInOut.php
+++ b/core/src/Controllers/Users/LogInOut.php
@@ -44,7 +44,7 @@ class LogInOut extends AbstractController implements ManagerTheme\PageController
     {
         \UserManager::logout();
         // show login screen
-        header('Location: ' . MODX_MANAGER_URL);
+        header('Location: ' . EVO_MANAGER_URL);
         exit();
     }
 
@@ -99,7 +99,7 @@ class LogInOut extends AbstractController implements ManagerTheme\PageController
                 header($header);
             }
         } else {
-            $header = 'Location: ' . MODX_MANAGER_URL;
+            $header = 'Location: ' . EVO_MANAGER_URL;
             if ($ajax === 1) {
                 echo $header;
             } else {
@@ -118,7 +118,7 @@ class LogInOut extends AbstractController implements ManagerTheme\PageController
             exit();
         }
 
-        header('Location: ' . MODX_MANAGER_URL.'#?a=28');
+        header('Location: ' . EVO_MANAGER_URL . '#?a=28');
         exit();
     }
 

--- a/core/src/ManagerTheme.php
+++ b/core/src/ManagerTheme.php
@@ -184,8 +184,8 @@ class ManagerTheme implements ManagerThemeInterface
     {
         $this->core = $core;
 
-        $this->getCore()['view']->addNamespace('manager', MODX_MANAGER_PATH . '/media/style/' . $theme . '/views/');
-        $this->getCore()['view']->addNamespace('manager', MODX_MANAGER_PATH . '/views/');
+        $this->getCore()['view']->addNamespace('manager', EVO_MANAGER_PATH . '/media/style/' . $theme . '/views/');
+        $this->getCore()['view']->addNamespace('manager', EVO_MANAGER_PATH . '/views/');
 
         $this->theme = $theme;
 
@@ -317,12 +317,12 @@ class ManagerTheme implements ManagerThemeInterface
      */
     public function getThemeDir($full = true): string
     {
-        return ($full ? MODX_MANAGER_PATH : '') . 'media/style/' . $this->getTheme() . '/';
+        return ($full ? EVO_MANAGER_PATH : '') . 'media/style/' . $this->getTheme() . '/';
     }
 
     public function getThemeUrl(): string
     {
-        return MODX_MANAGER_URL . $this->getThemeDir(false);
+        return EVO_MANAGER_URL . $this->getThemeDir(false);
     }
 
     /**
@@ -363,10 +363,10 @@ class ManagerTheme implements ManagerThemeInterface
             $theme = $this->getTheme();
         }
 
-        if (is_file(MODX_MANAGER_PATH . '/media/style/' . $theme . '/' . $filepath)) {
-            $element = MODX_MANAGER_PATH . '/media/style/' . $theme . '/' . $filepath;
+        if (is_file(EVO_MANAGER_PATH . '/media/style/' . $theme . '/' . $filepath)) {
+            $element = EVO_MANAGER_PATH . '/media/style/' . $theme . '/' . $filepath;
         } else {
-            $element = MODX_MANAGER_PATH . ltrim($filepath, '/');
+            $element = EVO_MANAGER_PATH . ltrim($filepath, '/');
         }
 
         return $element;

--- a/core/src/Traits/Models/ManagerActions.php
+++ b/core/src/Traits/Models/ManagerActions.php
@@ -27,6 +27,6 @@ trait ManagerActions
                 $out = '#';
         }
 
-        return ($full ? MODX_MANAGER_URL : '') . $out;
+        return ($full ? EVO_MANAGER_URL : '') . $out;
     }
 }

--- a/core/src/Traits/Path.php
+++ b/core/src/Traits/Path.php
@@ -77,7 +77,7 @@ trait Path
      */
     public function publicPath($path = '')
     {
-        return MODX_BASE_PATH . $path;
+        return EVO_BASE_PATH . $path;
     }
 
     /**
@@ -184,7 +184,7 @@ trait Path
      */
     public function getManagerUrl()
     {
-        return MODX_MANAGER_URL;
+        return EVO_MANAGER_URL;
     }
 
     /**

--- a/core/src/Traits/Settings.php
+++ b/core/src/Traits/Settings.php
@@ -126,16 +126,16 @@ trait Settings
         }
 
         // store base_url and base_path inside config array
-        $this->setConfig('base_url', MODX_BASE_URL);
-        $this->setConfig('base_path', MODX_BASE_PATH);
-        $this->setConfig('site_url', MODX_SITE_URL);
-        $this->setConfig('site_manager_path', MODX_MANAGER_PATH);
+        $this->setConfig('base_url', EVO_BASE_URL);
+        $this->setConfig('base_path', EVO_BASE_PATH);
+        $this->setConfig('site_url', EVO_SITE_URL);
+        $this->setConfig('site_manager_path', EVO_MANAGER_PATH);
         $this->error_reporting = $this->getConfig('error_reporting');
         $this->setConfig(
             'filemanager_path',
             str_replace(
                 '[(base_path)]',
-                MODX_BASE_PATH,
+                EVO_BASE_PATH,
                 $this->getConfig('filemanager_path')
             )
         );
@@ -143,7 +143,7 @@ trait Settings
             'snapshot_path',
             str_replace(
                 '[(base_path)]',
-                MODX_BASE_PATH,
+                EVO_BASE_PATH,
                 $this->getConfig('snapshot_path')
             )
         );
@@ -151,7 +151,7 @@ trait Settings
             'rb_base_dir',
             str_replace(
                 '[(base_path)]',
-                MODX_BASE_PATH,
+                EVO_BASE_PATH,
                 $this->getConfig('rb_base_dir')
             )
         );

--- a/core/tests/Unit/ManagerPathConstantUsageTest.php
+++ b/core/tests/Unit/ManagerPathConstantUsageTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use EvolutionCMS\ManagerTheme;
+use EvolutionCMS\Traits\Models\ManagerActions;
+use EvolutionCMS\Traits\Path;
+use EvolutionCMS\Traits\Settings;
+use PHPUnit\Framework\TestCase;
+
+final class ManagerPathConstantUsageTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $rootDir = dirname(__DIR__, 3);
+
+        if (!defined('IN_INSTALL_MODE')) {
+            define('IN_INSTALL_MODE', false);
+        }
+        if (!defined('EVO_API_MODE')) {
+            define('EVO_API_MODE', true);
+        }
+        if (!defined('IN_MANAGER_MODE')) {
+            define('IN_MANAGER_MODE', false);
+        }
+        if (!defined('EVO_BASE_PATH')) {
+            define('EVO_BASE_PATH', rtrim($rootDir, '/\\') . '/');
+        }
+        if (!defined('EVO_BASE_URL')) {
+            define('EVO_BASE_URL', '/');
+        }
+        if (!defined('EVO_CORE_PATH')) {
+            define('EVO_CORE_PATH', EVO_BASE_PATH . 'core/');
+        }
+        if (!defined('EVO_STORAGE_PATH')) {
+            define('EVO_STORAGE_PATH', EVO_CORE_PATH . 'storage/');
+        }
+        if (!defined('EVO_MANAGER_PATH')) {
+            define('EVO_MANAGER_PATH', EVO_BASE_PATH . 'manager/');
+        }
+        if (!defined('EVO_MANAGER_URL')) {
+            define('EVO_MANAGER_URL', 'https://example.test/manager/');
+        }
+        if (!defined('EVO_SITE_URL')) {
+            define('EVO_SITE_URL', 'https://example.test/');
+        }
+
+        require_once EVO_BASE_PATH . 'core/vendor/autoload.php';
+    }
+
+    public function testPathTraitExposesEvoPublicAndManagerPaths(): void
+    {
+        $carrier = new class {
+            use Path;
+        };
+
+        $this->assertSame(EVO_BASE_PATH, $carrier->publicPath());
+        $this->assertSame(EVO_MANAGER_URL, $carrier->getManagerUrl());
+    }
+
+    public function testManagerActionsFullUrlsUseEvoManagerUrl(): void
+    {
+        $resource = new class {
+            use ManagerActions;
+
+            public $exists = false;
+            protected $managerActionsMap = [
+                'view' => 27,
+            ];
+        };
+
+        $this->assertSame(EVO_MANAGER_URL . '?a=27', $resource->makeUrl('view', true));
+    }
+
+    public function testManagerThemePathHelpersUseEvoManagerConstants(): void
+    {
+        $theme = (new ReflectionClass(ManagerTheme::class))->newInstanceWithoutConstructor();
+        $setter = \Closure::bind(function (string $themeName): void {
+            $this->theme = $themeName;
+        }, $theme, ManagerTheme::class);
+        $setter('default');
+
+        $this->assertSame(EVO_MANAGER_PATH . 'media/style/default/', $theme->getThemeDir());
+        $this->assertSame('media/style/default/', $theme->getThemeDir(false));
+        $this->assertSame(EVO_MANAGER_URL . 'media/style/default/', $theme->getThemeUrl());
+    }
+
+    public function testSettingsTraitStoresEvoPathConstantsInConfig(): void
+    {
+        $settings = new class {
+            use Settings;
+
+            public $error_reporting;
+
+            public function getFactorySettings(): array
+            {
+                return [];
+            }
+
+            public function getConfig($name = '', $default = null)
+            {
+                return $this->config[$name] ?? $default;
+            }
+
+            public function setConfig($name, $value = '')
+            {
+                $this->config[$name] = $value;
+            }
+        };
+
+        $settings->config = [
+            'filemanager_path' => '[(base_path)]assets/files',
+            'snapshot_path' => '[(base_path)]assets/backup',
+            'rb_base_dir' => '[(base_path)]assets',
+        ];
+
+        $settings->getSettings();
+
+        $this->assertSame(EVO_BASE_URL, $settings->config['base_url']);
+        $this->assertSame(EVO_BASE_PATH, $settings->config['base_path']);
+        $this->assertSame(EVO_SITE_URL, $settings->config['site_url']);
+        $this->assertSame(EVO_MANAGER_PATH, $settings->config['site_manager_path']);
+        $this->assertStringContainsString(EVO_BASE_PATH, $settings->config['filemanager_path']);
+        $this->assertStringContainsString(EVO_BASE_PATH, $settings->config['snapshot_path']);
+        $this->assertStringContainsString(EVO_BASE_PATH, $settings->config['rb_base_dir']);
+    }
+}

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -100,8 +100,10 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
         // GLOBAL variable modx
         var modx = {
             MGR_DIR: '{{MGR_DIR}}',
-            MODX_SITE_URL: '{{MODX_SITE_URL}}',
-            MODX_MANAGER_URL: '{{MODX_MANAGER_URL}}',
+            EVO_SITE_URL: '{{EVO_SITE_URL}}',
+            EVO_MANAGER_URL: '{{EVO_MANAGER_URL}}',
+            MODX_SITE_URL: '{{EVO_SITE_URL}}',
+            MODX_MANAGER_URL: '{{EVO_MANAGER_URL}}',
             user: {
                 role: {{(int)$user['role']}},
                 username: '{{$user['username']}}',
@@ -292,7 +294,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                         <li id="account" class="dropdown account">
                             <a href="javascript:;" class="dropdown-toggle" onclick="return false;">
                                 @if ($user['photo'])
-                                    <span class="icon photo" style="background-image: url({!!MODX_SITE_URL . entities($user['photo'], evo()->getConfig('modx_charset'))!!});"></span>
+                                    <span class="icon photo" style="background-image: url({!!EVO_SITE_URL . entities($user['photo'], evo()->getConfig('modx_charset'))!!});"></span>
                                 @else
                                     <span class="icon">{!! $_style['icon_user'] !!}</span>
                                 @endif
@@ -560,7 +562,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                 e.preventDefault();
                 if (modx.config.global_tabs && !e.shiftKey) {
                     modx.tabs({
-                        url: '{{ MODX_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?filemanager=media/browser/{{ $modx->getConfig('which_browser') }}/browse.php&type=images',
+                        url: '{{ EVO_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?filemanager=media/browser/{{ $modx->getConfig('which_browser') }}/browse.php&type=images',
                         title: '{{ ManagerTheme::getLexicon('images_management') }}'
                     });
                 } else {
@@ -569,7 +571,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                         randomNum += ' #' + Math.floor((Math.random() * 999999) + 1);
                     }
                     modx.openWindow({
-                        url: '{{ MODX_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?&type=images',
+                        url: '{{ EVO_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?&type=images',
                         title: randomNum
                     });
                 }
@@ -582,7 +584,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                 e.preventDefault();
                 if (modx.config.global_tabs && !e.shiftKey) {
                     modx.tabs({
-                        url: '{{ MODX_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?filemanager=media/browser/{{ $modx->getConfig('which_browser') }}/browse.php&type=files',
+                        url: '{{ EVO_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?filemanager=media/browser/{{ $modx->getConfig('which_browser') }}/browse.php&type=files',
                         title: '{{ ManagerTheme::getLexicon('files_files') }}'
                     });
                 } else {
@@ -591,7 +593,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                         randomNum += ' #' + Math.floor((Math.random() * 999999) + 1);
                     }
                     modx.openWindow({
-                        url: '{{ MODX_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?&type=files',
+                        url: '{{ EVO_MANAGER_URL }}media/browser/{{ evo()->getConfig('which_browser') }}/browse.php?&type=files',
                         title: randomNum
                     });
                 }

--- a/manager/views/frame/tree.blade.php
+++ b/manager/views/frame/tree.blade.php
@@ -31,13 +31,13 @@ $_style['icon_trash'] = svg('tabler-trash')->toHtml();
         <a class="treeButton" id="treeMenu_expandtree" onclick="modx.tree.expandTree();" title="{{ ManagerTheme::getLexicon('expand_tree') }}">{!! $_style['icon_arrow_down_circle'] !!}</a>
         <a class="treeButton" id="treeMenu_collapsetree" onclick="modx.tree.collapseTree();" title="{{ ManagerTheme::getLexicon('collapse_tree') }}">{!! $_style['icon_arrow_up_circle'] !!}</a>
         @if(evo()->hasPermission('new_document'))
-            <a class="treeButton" id="treeMenu_addresource" onclick="modx.tabs({url:'{{ MODX_MANAGER_URL }}?a=4', title: '{{ ManagerTheme::getLexicon('add_resource') }}'});" title="{{ ManagerTheme::getLexicon('add_resource') }}">{!! $_style['icon_add'] !!}</a>
-            <a class="treeButton" id="treeMenu_addweblink" onclick="modx.tabs({url:'{{ MODX_MANAGER_URL }}?a=72', title: '{{ ManagerTheme::getLexicon('add_weblink') }}'});" title="{{ ManagerTheme::getLexicon('add_weblink') }}">{!! $_style['icon_chain_broken'] !!}</a>
+            <a class="treeButton" id="treeMenu_addresource" onclick="modx.tabs({url:'{{ EVO_MANAGER_URL }}?a=4', title: '{{ ManagerTheme::getLexicon('add_resource') }}'});" title="{{ ManagerTheme::getLexicon('add_resource') }}">{!! $_style['icon_add'] !!}</a>
+            <a class="treeButton" id="treeMenu_addweblink" onclick="modx.tabs({url:'{{ EVO_MANAGER_URL }}?a=72', title: '{{ ManagerTheme::getLexicon('add_weblink') }}'});" title="{{ ManagerTheme::getLexicon('add_weblink') }}">{!! $_style['icon_chain_broken'] !!}</a>
         @endif
         <a class="treeButton" id="treeMenu_refreshtree" onclick="modx.tree.restoreTree();" title="{{ ManagerTheme::getLexicon('refresh_tree') }}">{!! $_style['icon_refresh'] !!}</a>
         <a class="treeButton" id="treeMenu_sortingtree" onclick="modx.tree.showSorter(event);" title="{{ ManagerTheme::getLexicon('sort_tree') }}">{!! $_style['icon_sort'] !!}</a>
         @if(evo()->hasPermission('edit_document') && evo()->hasPermission('save_document'))
-            <a class="treeButton" id="treeMenu_sortingindex" onclick="modx.tabs({url: '{{ MODX_MANAGER_URL }}?a=56&id=0', title: '{{ ManagerTheme::getLexicon('sort_menuindex') }}'});" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
+            <a class="treeButton" id="treeMenu_sortingindex" onclick="modx.tabs({url: '{{ EVO_MANAGER_URL }}?a=56&id=0', title: '{{ ManagerTheme::getLexicon('sort_menuindex') }}'});" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
         @endif
         {{-- @if(evo()->getConfig('use_browser') && evo()->hasPermission('assets_images'))
             <a class="treeButton" id="treeMenu_openimages" title="{{ ManagerTheme::getLexicon('images_management') }}&#013;{{ ManagerTheme::getLexicon('em_button_shift') }}"><i class="{{ $_style['icon_camera'] }}"></i></a>

--- a/manager/views/page/3.blade.php
+++ b/manager/views/page/3.blade.php
@@ -57,7 +57,7 @@
         'cancel'    => 'index.php?' . ($id == 0 ? 'a=2' : 'a=3&r=1&id=' . $id . $add_path),
         'move'      => 'index.php?id=' . $_REQUEST['id'] . '&a=51',
         'duplicate' => 'index.php?id=' . $_REQUEST['id'] . '&a=94',
-        'view'      => evo()->getConfig('friendly_urls') ? UrlProcessor::makeUrl($id) : MODX_SITE_URL . 'index.php?id=' . $id,
+        'view'      => evo()->getConfig('friendly_urls') ? UrlProcessor::makeUrl($id) : EVO_SITE_URL . 'index.php?id=' . $id,
     ];
 
     /**
@@ -493,7 +493,7 @@
     @if(!empty($show_preview))
         <div class="sectionHeader">{{ ManagerTheme::getLexicon('preview') }}</div>
         <div class="sectionBody" id="lyr2">
-            <iframe src="{{ MODX_SITE_URL }}index.php?id={{ $id }}&z=manprev" frameborder="0" border="0" id="previewIframe"></iframe>
+            <iframe src="{{ EVO_SITE_URL }}index.php?id={{ $id }}&z=manprev" frameborder="0" border="0" id="previewIframe"></iframe>
         </div>
     @endif
 @endsection


### PR DESCRIPTION
## Problem

Issue #2238 is broader than one safe PR. After the bootstrap/runtime slice, manager path and URL helpers were still using legacy `MODX_*` constants across core helpers and manager frame views.

## Why this approach

This keeps the migration incremental:
- switch canonical core manager path/url helpers to `EVO_*`
- update manager frame/views to publish and consume `EVO_*` first
- keep compatibility aliases where frontend runtime still expects `MODX_*`

## What changed

- updated `Path`, `Settings`, `ManagerTheme`, `ManagerActions`, `Frame`, and `Users\\LogInOut` to use `EVO_*` manager/site/base constants
- updated manager frame and tree views to emit `EVO_*` URLs and keep `MODX_*` JS aliases for compatibility
- updated document view/preview manager surfaces to use `EVO_SITE_URL`
- added regression coverage for manager path/url helper usage

## Files / surfaces

- core manager path/url helpers
- manager frame runtime constants
- manager tree and preview view URLs
- targeted unit coverage for manager constant usage

## Verification

- `./vendor/bin/phpunit tests/Unit/ManagerPathConstantUsageTest.php`
- `./vendor/bin/pest tests/Feature/ModifiersTest.php`
- `php -l` on touched files
- local runtime smoke check on the task branch

## Risks

This is still only a bounded slice of #2238. Legacy aliases stay in place where needed so existing manager JS keeps working while the codebase shifts to canonical `EVO_*` constants.

## Links

- Part of #2238
