### PR TITLE
[FIX] Support legacy prefix placeholders in field lists.

### DIFF
--- a/core/src/Database.php
+++ b/core/src/Database.php
@@ -328,7 +328,7 @@ class Database extends Manager
             $data = '*';
         }
 
-        return $data;
+        return $this->replacePrefixPlaceholderInTableName($data);
     }
 
     /**

--- a/core/tests/Unit/DatabasePrefixPlaceholderCompatibilityTest.php
+++ b/core/tests/Unit/DatabasePrefixPlaceholderCompatibilityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use EvolutionCMS\Database;
+
+test('select replaces legacy prefix placeholders in fields and from clauses', function () {
+    $database = new class extends Database {
+        public array $queries = [];
+
+        public function replacePrefixPlaceholderInTableName($sql)
+        {
+            return str_replace('[+prefix+]', 'evo_', $sql);
+        }
+
+        public function query($sql, $watchError = true)
+        {
+            $this->queries[] = $sql;
+
+            return false;
+        }
+    };
+
+    $database->select(
+        [
+            'name' => '[+prefix+]site_templates.templatename',
+            'id' => '[+prefix+]site_templates.id',
+            'category' => "if(isnull([+prefix+]categories.category),'No category',[+prefix+]categories.category)",
+        ],
+        [
+            '[+prefix+]site_templates',
+            'left join [+prefix+]categories on [+prefix+]site_templates.category=[+prefix+]categories.id',
+        ],
+        '',
+        '5,1'
+    );
+
+    expect($database->queries)->toHaveCount(1);
+
+    $sql = $database->queries[0];
+
+    expect($sql)->not->toContain('[+prefix+]')
+        ->and($sql)->toContain('evo_site_templates.templatename as `name`')
+        ->and($sql)->toContain('evo_site_templates.id as `id`')
+        ->and($sql)->toContain("if(isnull(evo_categories.category),'No category',evo_categories.category) as `category`")
+        ->and($sql)->toContain('FROM evo_site_templates left join evo_categories on evo_site_templates.category=evo_categories.id')
+        ->and($sql)->toContain('ORDER BY 5,1');
+});


### PR DESCRIPTION
## Problem

ElementsInTree 1.5.11 still sends legacy `[+prefix+]` placeholders in its DBAPI field list when rendering the manager tree. On current `3.5.x` this leaves raw placeholders inside the generated SQL and crashes manager tree rendering with a SQL syntax error.

## Why this approach

The plugin still uses the legacy DBAPI placeholder contract, and Evolution already restores that compatibility for table/from clauses. The missing part is field-list normalization, so the smallest coherent fix is to complete the same compatibility layer in `Database::prepareFields()`.

## What changed

- normalize legacy `[+prefix+]` placeholders in DBAPI select fields, not only in table/from clauses
- keep the fix bounded to the database compatibility layer instead of patching one plugin-specific call site
- add a regression test that covers the exact legacy field-plus-join pattern used by ElementsInTree

## Verification

- `./vendor/bin/pest tests/Unit/DatabasePrefixPlaceholderCompatibilityTest.php`
- `./vendor/bin/pest tests/Feature/ModifiersTest.php`
- `php -l core/src/Database.php`
- `php -l core/tests/Unit/DatabasePrefixPlaceholderCompatibilityTest.php`

## Links

- Closes #2245
