### PR TITLE
[FIX] Mark web user email as required in the form.

### DIFF
--- a/core/tests/Unit/Manager/WebUserEmailRequiredMarkerTest.php
+++ b/core/tests/Unit/Manager/WebUserEmailRequiredMarkerTest.php
@@ -1,0 +1,8 @@
+<?php
+
+it('marks the web user email label as required in the form', function () {
+    $formPath = dirname(__DIR__, 4) . '/manager/actions/mutate_web_user.dynamic.php';
+    $form = file_get_contents($formPath);
+
+    expect($form)->toContain('<span class="warning">*</span> <?php echo $_lang[\'user_email\']; ?>:');
+});

--- a/manager/actions/mutate_web_user.dynamic.php
+++ b/manager/actions/mutate_web_user.dynamic.php
@@ -353,7 +353,7 @@ $displayStyle = ($_SESSION['browser'] === 'modern') ? 'table-row' : 'block';
                     </tr>
 
 					<tr>
-						<td><?php echo $_lang['user_email']; ?>:</td>
+						<td><span class="warning">*</span> <?php echo $_lang['user_email']; ?>:</td>
 						<td><input type="text" name="email" class="inputBox" value="<?php echo isset($_POST['email']) ? $_POST['email'] : $userdata['email']; ?>" onChange="documentDirty=true;" />
 							<input type="hidden" name="oldemail" value="<?php echo $modx->getPhpCompat()->htmlspecialchars(!empty($userdata['oldemail']) ? $userdata['oldemail'] : $userdata['email']); ?>" /></td>
 					</tr>


### PR DESCRIPTION
## Summary
- mark the web user email label as required in the create/edit form
- add a regression test for the legacy manager form markup

## Why
- fixes the UI mismatch from issue #2248 where E-mail address is required on save but is not marked as required in the form

## Testing
- ./vendor/bin/pest tests/Unit/Manager/WebUserEmailRequiredMarkerTest.php
- ./vendor/bin/pest tests/Feature/ModifiersTest.php
- php -l manager/actions/mutate_web_user.dynamic.php
- php -l core/tests/Unit/Manager/WebUserEmailRequiredMarkerTest.php

## Notes
- scoped to the web user form label only; save/validation behavior is unchanged