### PR TITLE
[FIX] Hide dashboard when home access is denied

### DIFF
--- a/core/src/Controllers/Frame.php
+++ b/core/src/Controllers/Frame.php
@@ -360,6 +360,10 @@ class Frame extends AbstractController implements ManagerTheme\PageControllerInt
 
     protected function menuSite()
     {
+        if (!$this->managerTheme->getCore()->hasPermission('home')) {
+            return $this;
+        }
+
         $this->sitemenu['site'] = [
             'site',
             'main',

--- a/core/tests/Unit/Controllers/FrameDashboardPermissionTest.php
+++ b/core/tests/Unit/Controllers/FrameDashboardPermissionTest.php
@@ -1,0 +1,9 @@
+<?php
+
+test('frame menu site checks the home permission before adding dashboard', function () {
+    $controllerPath = dirname(__DIR__, 3) . '/src/Controllers/Frame.php';
+    $controller = file_get_contents($controllerPath);
+
+    expect(str_contains($controller, "hasPermission('home')"))->toBeTrue();
+    expect(str_contains($controller, "'index.php?a=2'"))->toBeTrue();
+});


### PR DESCRIPTION
## Problem

Users without the `home` permission still see the Dashboard entry in the manager menu, even though they cannot access that screen.

## What Changed

- added a `home` permission guard before the Dashboard menu item is registered in `Frame::menuSite()`
- added a regression test that keeps the permission check tied to the Dashboard route entry

## Validation

- `./vendor/bin/pest tests/Unit/Controllers/FrameDashboardPermissionTest.php tests/Feature/ModifiersTest.php`
- `php -l core/src/Controllers/Frame.php`
- `php -l core/tests/Unit/Controllers/FrameDashboardPermissionTest.php`

## Risk

Low. The change is scoped to Dashboard menu visibility and does not change other manager menu branches.

Closes #2250
