### PR TITLE
[FIX] Escape site name in manager auth templates

### DIFF
--- a/core/src/ManagerTheme.php
+++ b/core/src/ManagerTheme.php
@@ -638,6 +638,8 @@ class ManagerTheme implements ManagerThemeInterface
             'manager_theme_url' => $this->getThemeUrl(),
             'manager_theme_style' => $this->getThemeStyle(),
             'manager_path' => MGR_DIR,
+            'site_name_text' => e((string)$this->getCore()->getConfig('site_name')),
+            'site_name_attr' => htmlspecialchars((string)$this->getCore()->getConfig('site_name'), ENT_QUOTES, $this->getCharset()),
         ];
 
         // set login logo image

--- a/core/tests/Unit/Manager/LoginSiteNameEscapingTest.php
+++ b/core/tests/Unit/Manager/LoginSiteNameEscapingTest.php
@@ -1,0 +1,29 @@
+<?php
+
+it('defines escaped site name placeholders for manager auth templates', function () {
+    $managerThemePath = dirname(__DIR__, 3) . '/src/ManagerTheme.php';
+    $managerTheme = file_get_contents($managerThemePath);
+
+    expect(str_contains($managerTheme, "'site_name_text' => e((string)"))->toBeTrue();
+    expect(str_contains($managerTheme, "'site_name_attr' => htmlspecialchars((string)"))->toBeTrue();
+    expect(str_contains($managerTheme, "getConfig('site_name')"))->toBeTrue();
+});
+
+it('uses escaped site name placeholders in login and lockout templates', function () {
+    $files = [
+        dirname(__DIR__, 4) . '/manager/media/style/common/login.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/default/login.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/liquid/login.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/common/manager.lockout.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/default/manager.lockout.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/liquid/manager.lockout.tpl',
+    ];
+
+    foreach ($files as $file) {
+        $template = file_get_contents($file);
+
+        expect(str_contains($template, '[+site_name_text+]'))->toBeTrue();
+        expect(str_contains($template, 'title="[(site_name)]"'))->toBeFalse();
+        expect(str_contains($template, 'alt="[(site_name)]"'))->toBeFalse();
+    }
+});

--- a/manager/media/style/common/login.tpl
+++ b/manager/media/style/common/login.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>[(site_name)] (Evolution CMS Manager Login)</title>
+    <title>[+site_name_text+] (Evolution CMS Manager Login)</title>
     <meta http-equiv="content-type" content="text/html; charset=[(modx_charset)]" />
     <meta name="robots" content="noindex, nofollow" />
     <meta name="viewport" content="width=device-width">
@@ -63,8 +63,8 @@
         [+OnManagerLoginFormPrerender+]
         <fieldset>
             <div class="text-center">
-                <a class="logo" href="../" title="[(site_name)]">
-                    <img src="media/style/[(manager_theme)]/images/misc/login-logo.png" alt="[(site_name)]" id="logo" />
+                <a class="logo" href="../" title="[+site_name_attr+]">
+                    <img src="media/style/[(manager_theme)]/images/misc/login-logo.png" alt="[+site_name_attr+]" id="logo" />
                 </a>
             </div>
             <label for="username">[%username%]</label>

--- a/manager/media/style/common/manager.lockout.tpl
+++ b/manager/media/style/common/manager.lockout.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>[(site_name)] (Evolution CMS Content Manager)</title>
+	<title>[+site_name_text+] (Evolution CMS Content Manager)</title>
 	<meta http-equiv="content-type" content="text/html; charset=[(modx_charset)]" />
 	<link rel="icon" type="image/ico" href="[+favicon+]">
 	<meta name="robots" content="noindex, nofollow" />
@@ -60,7 +60,7 @@
 		<!-- end #mx_logobox -->
 
 		<div class="sectionBody">
-			<h1>[(site_name)]</h1>
+			<h1>[+site_name_text+]</h1>
 
 			<div class="loginMessage">[%manager_lockout_message%]</div>
 

--- a/manager/media/style/default/login.tpl
+++ b/manager/media/style/default/login.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>[(site_name)] (Evolution CMS Manager Login)</title>
+    <title>[+site_name_text+] (Evolution CMS Manager Login)</title>
     <meta http-equiv="content-type" content="text/html; charset=[+modx_charset+]">
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width">
@@ -561,8 +561,8 @@
 
             <!-- logo -->
             <div class="form-group form-group--logo text-center">
-                <a class="logo" href="../" title="[(site_name)]">
-                    <img src="[+login_logo+]" alt="[(site_name)]" id="logo">
+                <a class="logo" href="../" title="[+site_name_attr+]">
+                    <img src="[+login_logo+]" alt="[+site_name_attr+]" id="logo">
                 </a>
             </div>
 

--- a/manager/media/style/default/manager.lockout.tpl
+++ b/manager/media/style/default/manager.lockout.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>[(site_name)] (Evolution CMS Manager Login)</title>
+	<title>[+site_name_text+] (Evolution CMS Manager Login)</title>
 	<meta http-equiv="content-type" content="text/html; charset=[+modx_charset+]">
 	<meta name="robots" content="noindex, nofollow">
 	<meta name="viewport" content="width=device-width">
@@ -273,13 +273,13 @@
 
 			<!-- logo -->
 			<div class="form-group form-group--logo text-center">
-				<a class="logo" href="../" title="[(site_name)]">
-					<img src="[+login_logo+]" alt="[(site_name)]" id="logo">
+				<a class="logo" href="../" title="[+site_name_attr+]">
+					<img src="[+login_logo+]" alt="[+site_name_attr+]" id="logo">
 				</a>
 			</div>
 
 			<div class="text-muted">
-				<h2>[(site_name)]</h2>
+				<h2>[+site_name_text+]</h2>
 
 				[%manager_lockout_message%]
 			</div>

--- a/manager/media/style/liquid/login.tpl
+++ b/manager/media/style/liquid/login.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>[(site_name)] (Evolution CMS Manager Login)</title>
+    <title>[+site_name_text+] (Evolution CMS Manager Login)</title>
     <meta http-equiv="content-type" content="text/html; charset=[+modx_charset+]">
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
@@ -30,8 +30,8 @@
 
             <!-- logo -->
             <div class="form-group form-group--logo text-center">
-                <a class="logo" href="../" title="[(site_name)]">
-                    <img src="[+login_logo+]" alt="[(site_name)]" id="logo">
+                <a class="logo" href="../" title="[+site_name_attr+]">
+                    <img src="[+login_logo+]" alt="[+site_name_attr+]" id="logo">
                 </a>
             </div>
 

--- a/manager/media/style/liquid/manager.lockout.tpl
+++ b/manager/media/style/liquid/manager.lockout.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>[(site_name)] (Evolution CMS Manager Login)</title>
+	<title>[+site_name_text+] (Evolution CMS Manager Login)</title>
 	<meta http-equiv="content-type" content="text/html; charset=[+modx_charset+]">
 	<meta name="robots" content="noindex, nofollow">
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
@@ -24,13 +24,13 @@
 
 			<!-- logo -->
 			<div class="form-group form-group--logo text-center">
-				<a class="logo" href="../" title="[(site_name)]">
-					<img src="[+login_logo+]" alt="[(site_name)]" id="logo">
+				<a class="logo" href="../" title="[+site_name_attr+]">
+					<img src="[+login_logo+]" alt="[+site_name_attr+]" id="logo">
 				</a>
 			</div>
 
 			<div class="text-muted">
-				<h2>[(site_name)]</h2>
+				<h2>[+site_name_text+]</h2>
 
 				[%manager_lockout_message%]
 			</div>


### PR DESCRIPTION
## Problem

Manager login and lockout templates inject `site_name` directly into text and HTML attributes, so names with quotes can break the page markup.

## What Changed

- added escaped `site_name_text` and `site_name_attr` placeholders in `ManagerTheme`
- switched common, default, and liquid auth templates to use the safe placeholders in text, `title`, and `alt` contexts
- added a regression test that keeps both the placeholders and template usage covered

## Validation

- `./vendor/bin/pest tests/Unit/Manager/LoginSiteNameEscapingTest.php tests/Feature/ModifiersTest.php`
- `php -l core/src/ManagerTheme.php`
- `php -l core/tests/Unit/Manager/LoginSiteNameEscapingTest.php`

## Risk

Low. The change is scoped to manager auth templates and only changes how the configured site name is rendered.

Closes #2249
