### PR TITLE
[FIX] Use the site label on the lockout home button

### DIFF
--- a/core/tests/Unit/Manager/LockoutHomeButtonLabelTest.php
+++ b/core/tests/Unit/Manager/LockoutHomeButtonLabelTest.php
@@ -1,0 +1,17 @@
+<?php
+
+it('uses the site label for lockout home buttons instead of the dashboard label', function () {
+    $files = [
+        dirname(__DIR__, 4) . '/manager/media/style/common/manager.lockout.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/default/manager.lockout.tpl',
+        dirname(__DIR__, 4) . '/manager/media/style/liquid/manager.lockout.tpl',
+    ];
+
+    foreach ($files as $file) {
+        $template = file_get_contents($file);
+
+        expect(str_contains($template, 'value="[%site%]"'))->toBeTrue();
+        expect(str_contains($template, 'value="[%home%]"'))->toBeFalse();
+        expect(str_contains($template, "[+homeurl+]"))->toBeTrue();
+    }
+});

--- a/manager/media/style/common/manager.lockout.tpl
+++ b/manager/media/style/common/manager.lockout.tpl
@@ -65,7 +65,7 @@
 			<div class="loginMessage">[%manager_lockout_message%]</div>
 
 			<fieldset class="buttonset">
-				<input type="button" class="login" id="submitButton" value="[%home%]" onclick="return gotoHome();" />&nbsp;
+				<input type="button" class="login" id="submitButton" value="[%site%]" onclick="return gotoHome();" />&nbsp;
 				<input type="button" class="login" id="submitButton" value="[%logout%]" onclick="return doLogout();" />
 			</fieldset>
 		</div>

--- a/manager/media/style/default/manager.lockout.tpl
+++ b/manager/media/style/default/manager.lockout.tpl
@@ -286,7 +286,7 @@
 
 			<!-- actions -->
 			<div class="form-group form-group--actions">
-				<input type="button" class="btn btn-default" value="[%home%]" onclick="return gotoHome();" />
+				<input type="button" class="btn btn-default" value="[%site%]" onclick="return gotoHome();" />
 				<input type="button" class="btn btn-success" value="[%logout%]" onclick="return doLogout();" />
 			</div>
 

--- a/manager/media/style/liquid/manager.lockout.tpl
+++ b/manager/media/style/liquid/manager.lockout.tpl
@@ -37,7 +37,7 @@
 
 			<!-- actions -->
 			<div class="form-group form-group--actions">
-				<input type="button" class="btn btn-default" value="[%home%]" onclick="return gotoHome();" />
+				<input type="button" class="btn btn-default" value="[%site%]" onclick="return gotoHome();" />
 				<input type="button" class="btn btn-success" value="[%logout%]" onclick="return doLogout();" />
 			</div>
 


### PR DESCRIPTION
## Problem

The access or lockout page shows a button that goes to `[+homeurl+]`, but the label is rendered through the manager lexicon key `home`, which is translated as `Dashboard` in English. That makes the button misleading for users who land on this page after login.

## What Changed

- switched the lockout button label from `[%home%]` to `[%site%]` in the common, default, and liquid manager lockout templates
- added a regression test that keeps the lockout button tied to the neutral site label while still pointing at `homeurl`

## Validation

- `./vendor/bin/pest tests/Unit/Manager/LockoutHomeButtonLabelTest.php tests/Feature/ModifiersTest.php`
- `php -l core/tests/Unit/Manager/LockoutHomeButtonLabelTest.php`

## Risk

Low. The change is scoped to the lockout page button label and does not change auth or redirect behavior.

Closes #2250
