### PR TITLE
[FIX] Preserve disabled role permissions on save

### DIFF
--- a/core/src/Controllers/UserRoles/UserRole.php
+++ b/core/src/Controllers/UserRoles/UserRole.php
@@ -66,11 +66,18 @@ class UserRole extends AbstractController implements ManagerTheme\PageController
         $role->description = $_POST['description'];
         $role->save();
 
-        if (isset($_POST['permissions']) && is_array($_POST['permissions'])) {
-            Models\RolePermissions::query()->where('role_id', $role->getKey())->delete();
-            foreach ($_POST['permissions'] as $key => $permission) {
-                Models\RolePermissions::create(['role_id' => $role->getKey(), 'permission' => $key]);
-            }
+        $requiredPermissions = Models\Permissions::query()
+            ->where('disabled', 1)
+            ->pluck('key')
+            ->all();
+        $selectedPermissions = self::normalizePermissionsPayload(
+            is_array($_POST['permissions'] ?? null) ? $_POST['permissions'] : [],
+            $requiredPermissions
+        );
+
+        Models\RolePermissions::query()->where('role_id', $role->getKey())->delete();
+        foreach (array_keys($selectedPermissions) as $key) {
+            Models\RolePermissions::create(['role_id' => $role->getKey(), 'permission' => $key]);
         }
 
         if ($_POST['tvsDirty'] == 1) {
@@ -105,6 +112,15 @@ class UserRole extends AbstractController implements ManagerTheme\PageController
 
         $this->managerTheme->getCore()->getManagerApi()->clearSavedFormValues();
         header('Location: index.php?a=35&id=' . $role->getKey() . '&r=9');
+    }
+
+    public static function normalizePermissionsPayload(array $permissions, array $requiredPermissions = []): array
+    {
+        foreach ($requiredPermissions as $permission) {
+            $permissions[$permission] = 1;
+        }
+
+        return $permissions;
     }
 
     /**

--- a/core/tests/Unit/Controllers/UserRoles/UserRolePermissionPayloadTest.php
+++ b/core/tests/Unit/Controllers/UserRoles/UserRolePermissionPayloadTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use EvolutionCMS\Controllers\UserRoles\UserRole;
+
+test('it keeps disabled manager permissions when no checkbox payload is submitted', function () {
+    $result = UserRole::normalizePermissionsPayload([], ['frames', 'home', 'logout']);
+
+    expect($result)->toBe([
+        'frames' => 1,
+        'home' => 1,
+        'logout' => 1,
+    ]);
+});
+
+test('it merges required permissions into the submitted role payload', function () {
+    $result = UserRole::normalizePermissionsPayload([
+        'new_document' => 1,
+        'edit_document' => 1,
+    ], [
+        'frames',
+        'home',
+        'logout',
+    ]);
+
+    expect($result)->toBe([
+        'new_document' => 1,
+        'edit_document' => 1,
+        'frames' => 1,
+        'home' => 1,
+        'logout' => 1,
+    ]);
+});


### PR DESCRIPTION
## Problem

Saving a custom manager role can silently drop the built-in disabled permissions such as `frames`, `home`, and `logout`.
Those permissions are rendered as checked but disabled in the role form, so the browser does not submit them back in `POST`.
After save, the role loses its required manager entry permissions and newly assigned users can no longer reach the expected manager startup flow.

## What Changed

- normalize the submitted role permission payload before persisting it
- always merge the disabled system permissions from the permissions table into the saved role payload
- keep the change in the role save path instead of loosening manager access checks globally
- add a regression test that covers both an empty submitted payload and a payload with extra resource permissions

## Validation

- `composer install --no-interaction` in `core` to restore dev test tools for the task worktree
- `./vendor/bin/pest tests/Unit/Controllers/UserRoles/UserRolePermissionPayloadTest.php tests/Feature/ModifiersTest.php`
- `php -l core/src/Controllers/UserRoles/UserRole.php`
- `php -l core/tests/Unit/Controllers/UserRoles/UserRolePermissionPayloadTest.php`

## Risk

Low. The change only affects how role permissions are normalized before save, and it preserves the disabled permissions that the UI already presents as mandatory.

Closes #2255
