### PR TITLE
[FIX] Load main-target helper before manager tabs

### DIFF
--- a/core/tests/Unit/Manager/FrameMainTargetHelperIncludeTest.php
+++ b/core/tests/Unit/Manager/FrameMainTargetHelperIncludeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+test('manager frame loads main target link helper before modx js', function () {
+    $template = file_get_contents(dirname(__DIR__, 4) . '/manager/views/frame/1.blade.php');
+
+    $treeHelper = 'media/script/tree-drop-guard-helper.js?v={{evo()->getVersionData(\'version\')}}';
+    $mainTargetHelper = 'media/script/main-target-link-helper.js?v={{evo()->getVersionData(\'version\')}}';
+    $modxScript = '{{ManagerTheme::getThemeUrl()}}js/modx.js?v={{evo()->getVersionData(\'version\')}}';
+
+    expect(str_contains($template, $treeHelper))->toBeTrue();
+    expect(str_contains($template, $mainTargetHelper))->toBeTrue();
+    expect(strpos($template, $mainTargetHelper))->toBeLessThan(strpos($template, $modxScript));
+});

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -222,6 +222,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
         ?>
     </script>
     <script src="media/script/tree-drop-guard-helper.js?v={{evo()->getVersionData('version')}}"></script>
+    <script src="media/script/main-target-link-helper.js?v={{evo()->getVersionData('version')}}"></script>
     <script src="{{ManagerTheme::getThemeUrl()}}js/modx.js?v={{evo()->getVersionData('version')}}"></script>
     @if ($modx->getConfig('show_picker'))
         <script src="media/script/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>


### PR DESCRIPTION
## Problem
Manager menu links that target `main` trigger a `ReferenceError` because `modx.js` calls `modxMainTargetLinkHelper`, but the frame template does not load that helper script.

## Root Cause
`manager/views/frame/1.blade.php` loads `tree-drop-guard-helper.js` before `modx.js`, but it never loads `main-target-link-helper.js`. As soon as global tabs handle a `target="main"` click, the missing helper breaks the click flow and the browser falls back to opening the link in a new tab.

## What Changed
- load `media/script/main-target-link-helper.js` before `modx.js` in the manager frame
- add a regression test that locks this include order in the frame template

## Validation
- `./vendor/bin/pest tests/Unit/Manager/FrameMainTargetHelperIncludeTest.php tests/Feature/ModifiersTest.php`
- `node --test manager/media/script/tests/main-target-link-helper.test.js`
- `php -l manager/views/frame/1.blade.php`
- `php -l core/tests/Unit/Manager/FrameMainTargetHelperIncludeTest.php`

## Risk
Low. The change only restores a helper include that `modx.js` already depends on.

Closes #2257
