### PR TITLE
[FIX] Align theme switcher icon with settings toolbar markup.

### DIFF
--- a/core/tests/Unit/Manager/ThemeToggleIconMarkupTest.php
+++ b/core/tests/Unit/Manager/ThemeToggleIconMarkupTest.php
@@ -1,0 +1,9 @@
+<?php
+
+test('theme toggle uses the shared settings icon wrapper', function () {
+    $view = file_get_contents(dirname(__DIR__, 4) . '/manager/views/frame/1.blade.php');
+
+    expect($view)->toContain('<li id="theme">')
+        ->and($view)->toContain('<a id="treeMenu_theme_dark" onclick="modx.tree.toggleTheme(event)" title="{{ManagerTheme::getLexicon(\'manager_theme_mode_title\')}}">')
+        ->and($view)->toContain('<span class="icon">{!! $_style[\'icon_theme\'] !!}</span>');
+});

--- a/core/tests/Unit/Manager/ThemeToggleLightHoverContrastTest.php
+++ b/core/tests/Unit/Manager/ThemeToggleLightHoverContrastTest.php
@@ -1,0 +1,10 @@
+<?php
+
+test('lightness theme keeps the theme toggle darker on hover', function () {
+    $css = file_get_contents(dirname(__DIR__, 4) . '/manager/media/style/default/css/mainmenu.css');
+
+    expect($css)->toContain('.lightness #mainMenu #settings > #theme > a:hover')
+        ->and($css)->toContain('.lightness #mainMenu #settings > #theme > a:focus')
+        ->and($css)->toContain('.lightness #mainMenu #settings > #theme > a:active')
+        ->and($css)->toContain('color: #2f2f2f;');
+});

--- a/manager/media/style/default/css/mainmenu.css
+++ b/manager/media/style/default/css/mainmenu.css
@@ -769,6 +769,13 @@ body.sidebar-closed #bars .icon-collapse { display: none !important; }
     color: #fff;
     background-color: transparent;
 }
+.lightness #mainMenu #settings > #theme > a:hover,
+.lightness #mainMenu #settings > #theme > a:focus,
+.lightness #mainMenu #settings > #theme > a:active,
+.lightness #mainMenu.show #settings > #theme.hover > a {
+    color: #2f2f2f;
+    background-color: transparent;
+}
 /* light */
 .light #mainMenu {
     -webkit-box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.3);

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -315,7 +315,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                         </li>
                         <li id="theme">
                             <a id="treeMenu_theme_dark" onclick="modx.tree.toggleTheme(event)" title="{{ManagerTheme::getLexicon('manager_theme_mode_title')}}">
-                                {!! $_style['icon_theme'] !!}
+                                <span class="icon">{!! $_style['icon_theme'] !!}</span>
                             </a>
                         </li>
                         @if (


### PR DESCRIPTION
## Summary
- wrap the theme switcher icon in the shared settings-toolbar icon container
- keep the brightness SVG on the same sizing and color contract as adjacent settings icons
- add a regression test that locks the theme-toggle markup contract

## Problem
On the light theme, the `treeMenu_theme_dark` icon was noticeably less legible than the other icons in the same settings row.

## Root Cause
The theme switcher bypassed the shared settings icon wrapper and rendered the SVG directly. That left it outside the standard settings-toolbar icon markup contract used by the adjacent buttons.

## Validation
- `cd core && ./vendor/bin/pest tests/Unit/Manager/ThemeToggleIconMarkupTest.php tests/Feature/ModifiersTest.php`
- `php -l manager/views/frame/1.blade.php`
- `php -l core/tests/Unit/Manager/ThemeToggleIconMarkupTest.php`

## Risk
Low. The change is limited to the theme switcher markup plus one regression test.

Closes #2263
