### PR TITLE
[FIX] Prioritize KCFinder callbacks over TinyMCE fallback.

### DIFF
--- a/manager/media/browser/mcpuk/js/browser/files.js
+++ b/manager/media/browser/mcpuk/js/browser/files.js
@@ -195,20 +195,6 @@ browser.returnFile = function(file) {
         }
         tinyMCEPopup.close();
 
-    } else if (hasTinyMCE) {
-        win.tinymceCallBackURL = fileURL;
-        try {
-            if (win.tinymce.activeEditor.windowManager &&
-                win.tinymce.activeEditor.windowManager.close
-            )
-                win.tinymce.activeEditor.windowManager.close();
-            else if (win.console && win.console.warn)
-                win.console.warn("TinyMCE windowManager.close is unavailable.");
-        } catch (err) {
-            if (win.console && win.console.warn)
-                win.console.warn("TinyMCE windowManager.close failed.", err);
-        }
-
     } else if (this.opener.callBack) {
 
         if (window.opener && window.opener.KCFinder) {
@@ -234,6 +220,20 @@ browser.returnFile = function(file) {
             if (button.hasClass('selected'))
                 this.maximize(button);
             this.opener.callBackMultiple([fileURL]);
+        }
+
+    } else if (hasTinyMCE) {
+        win.tinymceCallBackURL = fileURL;
+        try {
+            if (win.tinymce.activeEditor.windowManager &&
+                win.tinymce.activeEditor.windowManager.close
+            )
+                win.tinymce.activeEditor.windowManager.close();
+            else if (win.console && win.console.warn)
+                win.console.warn("TinyMCE windowManager.close is unavailable.");
+        } catch (err) {
+            if (win.console && win.console.warn)
+                win.console.warn("TinyMCE windowManager.close failed.", err);
         }
 
     }

--- a/manager/media/browser/mcpuk/js/tests/return-file-priority.test.js
+++ b/manager/media/browser/mcpuk/js/tests/return-file-priority.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('custom KCFinder callbacks take priority over the generic TinyMCE fallback', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'browser', 'files.js'),
+    'utf8'
+  );
+
+  const tinyMcePopup = source.indexOf("} else if (this.opener.TinyMCE && (typeof tinyMCEPopup !== 'undefined')) {");
+  const callBack = source.indexOf('} else if (this.opener.callBack) {');
+  const callBackMultiple = source.indexOf('} else if (this.opener.callBackMultiple) {');
+  const hasTinyMce = source.indexOf('} else if (hasTinyMCE) {');
+
+  assert.notEqual(tinyMcePopup, -1);
+  assert.notEqual(callBack, -1);
+  assert.notEqual(callBackMultiple, -1);
+  assert.notEqual(hasTinyMce, -1);
+  assert.ok(tinyMcePopup < callBack);
+  assert.ok(callBack < callBackMultiple);
+  assert.ok(callBackMultiple < hasTinyMce);
+});


### PR DESCRIPTION
## Summary
- let explicit `KCFinder.callBack` and `callBackMultiple` flows run before the generic TinyMCE-active fallback
- keep TinyMCE-specific integrations intact, but stop them from hijacking PageBuilder / Multifields style custom image pickers
- add a small regression test that locks the branch order inside `browser.returnFile`

## Problem
When a page contains an active TinyMCE editor, selecting an image from KCFinder can bypass custom callback-based integrations and fall into the generic TinyMCE close path instead. That matches the report where PageBuilder image fields stop returning a value and other callback-based image fields break after the first failed pick.

## Root Cause
`browser.returnFile` checked `hasTinyMCE` before `this.opener.callBack` and `this.opener.callBackMultiple`. Any opener window with an active TinyMCE editor could therefore steal control from explicit callback integrations that were never asking for TinyMCE handling.

## Validation
- `node --test manager/media/browser/mcpuk/js/tests/return-file-priority.test.js`
- `node --check manager/media/browser/mcpuk/js/browser/files.js`

## Remaining Gap
This PR addresses the callback-priority bug from problem 1 only.
The `.thumbs` / dot-directory visibility part of `#2266` is a separate boundary question and is intentionally not changed here.

Refs #2266
