### PR TITLE
[FIX] Decode the site name in manager tab titles.

### DIFF
--- a/core/tests/Unit/Manager/FrameManagerTitleContractTest.php
+++ b/core/tests/Unit/Manager/FrameManagerTitleContractTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Manager;
+
+use Tests\TestCase;
+
+class FrameManagerTitleContractTest extends TestCase
+{
+    public function test_frame_title_uses_raw_manager_title_contract(): void
+    {
+        $view = file_get_contents(dirname(__DIR__, 4) . '/manager/views/frame/1.blade.php');
+
+        $this->assertIsString($view);
+        $this->assertStringContainsString(
+            "\$managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';",
+            $view
+        );
+        $this->assertStringContainsString('<title>{!! $managerTitle !!}</title>', $view);
+        $this->assertStringContainsString(
+            'manager_title: {!! json_encode($managerTitle, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!},',
+            $view
+        );
+        $this->assertStringNotContainsString(
+            "<title>{{evo()->getConfig('site_name')}} - (Evolution CMS Manager)</title>",
+            $view
+        );
+    }
+}

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -53,11 +53,12 @@ $_style['icon_expand'] = svg('tabler-arrows-maximize')->toHtml();
 $_style['icon_compress'] = svg('tabler-arrows-minimize')->toHtml();
 $_style['icon_trash'] = svg('tabler-trash-x')->toHtml();
 $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
+$managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
 @endphp
 <!DOCTYPE html>
 <html dir="{{ManagerTheme::getTextDir()}}" lang="{{ManagerTheme::getLang()}}" xml:lang="{{ManagerTheme::getLang()}}">
 <head>
-    <title>{{evo()->getConfig('site_name')}} - (Evolution CMS Manager)</title>
+    <title>{!! $managerTitle !!}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={{ManagerTheme::getCharset()}}" />
     <meta name="viewport" content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width" />
     <meta name="theme-color" content="#000" />
@@ -108,7 +109,7 @@ $_style['icon_trash_alt'] = svg('tabler-trash')->toHtml();
                 groups: {!!json_encode(evo()->getUserDocGroups())!!}
             },
             config: {
-                manager_title: '{{evo()->getConfig('site_name')}} - (Evolution CMS Manager)',
+                manager_title: {!! json_encode($managerTitle, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!},
                 menu_height: {{(int)evo()->getConfig('manager_menu_height')}},
                 tree_width: {{(int)$MODX_widthSideBar}},
                 tree_min_width: {{(int)$tree_min_width}},


### PR DESCRIPTION
## Problem
The manager frame used Blade-escaped `site_name` in the browser tab title and in the JS `manager_title` config, so HTML in `site_name` appeared as entities like `&lt;b&gt;` and `&quot;` instead of the original string.

## Solution
- build one raw manager title string from `site_name`
- use that string directly in the `<title>` tag
- pass the same string to JS through `json_encode(...)` so `document.title` uses the same decoded value safely

## Validation
- `php -l manager/views/frame/1.blade.php`
- `php -l core/tests/Unit/Manager/FrameManagerTitleContractTest.php`
- `./vendor/bin/phpunit tests/Unit/Manager/FrameManagerTitleContractTest.php`
- `./vendor/bin/pest tests/Feature/ModifiersTest.php`

## Risk
Low. The change is limited to manager title surfaces and does not alter escaping in normal HTML body content.

Refs #2268
