### PR TITLE
[FIX] Restore contextual tree menu index handler.

### DIFF
--- a/manager/views/frame/tree.blade.php
+++ b/manager/views/frame/tree.blade.php
@@ -37,7 +37,7 @@ $_style['icon_trash'] = svg('tabler-trash')->toHtml();
         <a class="treeButton" id="treeMenu_refreshtree" onclick="modx.tree.restoreTree();" title="{{ ManagerTheme::getLexicon('refresh_tree') }}">{!! $_style['icon_refresh'] !!}</a>
         <a class="treeButton" id="treeMenu_sortingtree" onclick="modx.tree.showSorter(event);" title="{{ ManagerTheme::getLexicon('sort_tree') }}">{!! $_style['icon_sort'] !!}</a>
         @if(evo()->hasPermission('edit_document') && evo()->hasPermission('save_document'))
-            <a class="treeButton" id="treeMenu_sortingindex" onclick="modx.tabs({url: '{{ EVO_MANAGER_URL }}?a=56&id=0', title: '{{ ManagerTheme::getLexicon('sort_menuindex') }}'});" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
+            <a class="treeButton" id="treeMenu_sortingindex" onclick="modx.tree.openSortMenuIndex();" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
         @endif
         {{-- @if(evo()->getConfig('use_browser') && evo()->hasPermission('assets_images'))
             <a class="treeButton" id="treeMenu_openimages" title="{{ ManagerTheme::getLexicon('images_management') }}&#013;{{ ManagerTheme::getLexicon('em_button_shift') }}"><i class="{{ $_style['icon_camera'] }}"></i></a>


### PR DESCRIPTION
## Problem
A previous merge left `manager/views/frame/tree.blade.php` pointing the menu-index sort button back to `?a=56&id=0`, even though the current manager JS already resolves the active tree context through `modx.tree.openSortMenuIndex()`.

## What changed
- switched the tree sort button from the hardcoded root-id tab call to `modx.tree.openSortMenuIndex()`

## Why this is safe
- the helper already exists in both manager themes
- the change only restores the intended contextual entrypoint
- no backend behavior changed

## Validation
- `php -l manager/views/frame/tree.blade.php`
- file-contract check confirmed the template now uses `onclick="modx.tree.openSortMenuIndex();"` and no longer contains `?a=56&id=0`

## Notes
This is a follow-up merge-conflict regression fix for the existing tree sort context test coverage.