### PR TITLE
[FIX] Preserve portable path settings in system config.

### DIFF
--- a/core/src/Support/SystemSettingPathNormalizer.php
+++ b/core/src/Support/SystemSettingPathNormalizer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace EvolutionCMS\Support;
+
+final class SystemSettingPathNormalizer
+{
+    private const BASE_PATH_PLACEHOLDER = '[(base_path)]';
+
+    public static function normalizeStorageValue(string $settingName, string $value, string $basePath): string
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $value = self::collapseBasePathPlaceholder($value, $basePath);
+
+        if ($settingName === 'filemanager_path' && rtrim($value, '/') === self::BASE_PATH_PLACEHOLDER) {
+            return self::BASE_PATH_PLACEHOLDER;
+        }
+
+        if ($settingName === 'rb_base_dir' && rtrim($value, '/') === self::BASE_PATH_PLACEHOLDER . 'assets') {
+            return self::BASE_PATH_PLACEHOLDER . 'assets/';
+        }
+
+        return rtrim($value, '/') . '/';
+    }
+
+    public static function collapseBasePathPlaceholder(string $value, string $basePath): string
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $normalizedValue = self::normalizeDirectory($value);
+        $normalizedBasePath = self::normalizeDirectory($basePath);
+
+        if ($normalizedBasePath === '') {
+            return $value;
+        }
+
+        $compareValue = self::comparisonPath($normalizedValue);
+        $compareBasePath = self::comparisonPath($normalizedBasePath);
+
+        if ($compareValue === rtrim($compareBasePath, '/')) {
+            return self::BASE_PATH_PLACEHOLDER;
+        }
+
+        if (strpos($compareValue, $compareBasePath) !== 0) {
+            return $value;
+        }
+
+        $suffix = ltrim(substr($normalizedValue, strlen($normalizedBasePath)), '/');
+
+        if ($suffix === '') {
+            return self::BASE_PATH_PLACEHOLDER;
+        }
+
+        return self::BASE_PATH_PLACEHOLDER . $suffix;
+    }
+
+    private static function normalizeDirectory(string $path): string
+    {
+        $path = str_replace('\\', '/', trim($path));
+        return rtrim($path, '/') . '/';
+    }
+
+    private static function comparisonPath(string $path): string
+    {
+        if (preg_match('/^[A-Za-z]:\//', $path) === 1) {
+            return strtolower($path);
+        }
+
+        return $path;
+    }
+}

--- a/core/tests/Unit/SystemSettingPathNormalizerTest.php
+++ b/core/tests/Unit/SystemSettingPathNormalizerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use EvolutionCMS\Support\SystemSettingPathNormalizer;
+
+test('it preserves the base path placeholder for portable storage values', function () {
+    $basePath = 'D:/OSPanel/domains/test2.loc/';
+
+    expect(SystemSettingPathNormalizer::normalizeStorageValue('filemanager_path', $basePath, $basePath))
+        ->toBe('[(base_path)]');
+
+    expect(SystemSettingPathNormalizer::normalizeStorageValue('filemanager_path', '[(base_path)]', $basePath))
+        ->toBe('[(base_path)]');
+
+    expect(SystemSettingPathNormalizer::normalizeStorageValue('rb_base_dir', $basePath . 'assets/', $basePath))
+        ->toBe('[(base_path)]assets/');
+
+    expect(SystemSettingPathNormalizer::normalizeStorageValue('rb_base_dir', '[(base_path)]assets/', $basePath))
+        ->toBe('[(base_path)]assets/');
+});
+
+test('it keeps external paths untouched', function () {
+    $basePath = 'D:/OSPanel/domains/test2.loc/';
+    $externalPath = 'D:/shared/uploads/';
+
+    expect(SystemSettingPathNormalizer::normalizeStorageValue('filemanager_path', $externalPath, $basePath))
+        ->toBe($externalPath);
+
+    expect(SystemSettingPathNormalizer::normalizeStorageValue('rb_base_dir', $externalPath, $basePath))
+        ->toBe($externalPath);
+});

--- a/manager/processors/save_settings.processor.php
+++ b/manager/processors/save_settings.processor.php
@@ -2,6 +2,7 @@
 if (!defined('IN_MANAGER_MODE') || IN_MANAGER_MODE !== true) {
     die("<b>INCLUDE_ORDERING_ERROR</b><br /><br />Please use the EVO Content Manager instead of accessing this file directly.");
 }
+
 if (!$modx->hasPermission('settings')) {
     $modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
@@ -42,9 +43,6 @@ if (file_exists(MODX_MANAGER_PATH . 'media/style/' . $modx->getConfig('manager_t
     unlink(MODX_MANAGER_PATH . 'media/style/' . $modx->getConfig('manager_theme') . '/css/styles.min.css');
 }
 
-$data['filemanager_path'] = str_replace('[(base_path)]', MODX_BASE_PATH, $data['filemanager_path']);
-$data['rb_base_dir'] = str_replace('[(base_path)]', MODX_BASE_PATH, $data['rb_base_dir']);
-
 if (isset($data) && count($data) > 0) {
     if (isset($data['manager_language'])) {
         $lang_path = EVO_CORE_PATH . 'lang/' . $data['manager_language'] . '/global.php';
@@ -78,8 +76,10 @@ if (isset($data) && count($data) > 0) {
                 $k = '';
                 break;
             case 'rb_base_dir':
-            case 'rb_base_url':
             case 'filemanager_path':
+                $v = \EvolutionCMS\Support\SystemSettingPathNormalizer::normalizeStorageValue($k, $v, MODX_BASE_PATH);
+                break;
+            case 'rb_base_url':
                 $v = trim($v);
                 $v = rtrim($v, '/') . '/';
                 break;


### PR DESCRIPTION
## Summary
- preserve `filemanager_path` and `rb_base_dir` as portable `[(base_path)]...` values when they point inside the current installation
- keep external/custom absolute directories untouched
- add a focused regression test for the Windows-style migration case from the issue

## Why
The current manager save flow expands `[(base_path)]` to the live absolute root before writing system settings. After moving a project with the same database into a new directory, the migrated instance keeps the old absolute path from the source environment, so file manager and resource browser surfaces can keep pointing at the previous install root.

## Validation
- `php -l manager/processors/save_settings.processor.php`
- `php -l core/src/Support/SystemSettingPathNormalizer.php`
- `php -l core/tests/Unit/SystemSettingPathNormalizerTest.php`
- direct PHP regression harness for placeholder preservation and external-path no-op behavior

## Notes
- this patch intentionally fixes the storage layer, not the runtime placeholder parser, because runtime replacement already exists in current core
- existing migrated installs with already-persisted stale absolute paths may still need one settings re-save to rewrite the stored values into the portable form

Closes #2272
