### PR TITLE
[FIX] Show a min-length error for short admin passwords.

### DIFF
--- a/core/tests/Unit/Install/ConnectionTemplatePasswordValidationTest.php
+++ b/core/tests/Unit/Install/ConnectionTemplatePasswordValidationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Install;
+
+use InvalidArgumentException;
+use Tests\TestCase;
+
+require_once dirname(__DIR__, 4) . '/install/src/functions.php';
+
+final class ConnectionTemplatePasswordValidationTest extends TestCase
+{
+    public function testShortAdminPasswordsUseDedicatedMinLengthMessage(): void
+    {
+        $template = (string) file_get_contents(dirname(__DIR__, 4) . '/install/src/template/actions/connection.tpl');
+
+        self::assertStringContainsString('data-minlength="[+adminPasswordMinLengthMessage+]"', $template);
+        self::assertStringContainsString("return setFieldErrorMessage(form.cmspassword, 'minlength');", $template);
+        self::assertStringContainsString("return setFieldErrorMessage(form.cmspasswordconfirm, 'minlength');", $template);
+        self::assertStringContainsString("return setFieldErrorMessage(form.cmspasswordconfirm, 'default');", $template);
+    }
+
+    public function testPasswordValidatorSharesTheSameMinLengthContract(): void
+    {
+        self::assertSame('Admin password should have at least 8 characters', adminPasswordMinLengthMessage());
+
+        try {
+            validateAdminPassword('1234567');
+            self::fail('Expected validateAdminPassword() to reject short passwords.');
+        } catch (InvalidArgumentException $exception) {
+            self::assertSame(adminPasswordMinLengthMessage(), $exception->getMessage());
+        }
+    }
+}

--- a/install/src/controllers/connection.php
+++ b/install/src/controllers/connection.php
@@ -149,6 +149,7 @@ $ph['cmsadmin'] = escapeHtmlAttribute(isset($_POST['cmsadmin']) ? $_POST['cmsadm
 $ph['cmsadminemail'] = escapeHtmlAttribute(isset($_POST['cmsadminemail']) ? $_POST['cmsadminemail'] : '');
 $ph['cmspassword'] = escapeHtmlAttribute(isset($_POST['cmspassword']) ? $_POST['cmspassword'] : '');
 $ph['cmspasswordconfirm'] = escapeHtmlAttribute(isset($_POST['cmspasswordconfirm']) ? $_POST['cmspasswordconfirm'] : '');
+$ph['adminPasswordMinLengthMessage'] = escapeHtmlAttribute(adminPasswordMinLengthMessage());
 $ph['managerLangs'] = getLangs($install_language);
 $ph['install_language'] = escapeHtmlAttribute($install_language);
 $ph['installMode'] = escapeHtmlAttribute($installMode);

--- a/install/src/functions.php
+++ b/install/src/functions.php
@@ -4,6 +4,7 @@ const ANSI_BOLD_GREEN = "\033[1;32m";
 const ANSI_BOLD_RED = "\033[1;31m";
 const ANSI_BOLD_YELLOW = "\033[1;33m";
 const ANSI_RESET = "\033[0m";
+const ADMIN_PASSWORD_MIN_LENGTH = 8;
 /**
  * @param  string  $install_language
  * @return string
@@ -32,6 +33,11 @@ function getLangOptions($install_language = 'en')
 
 function escapeHtmlAttribute($unescaped) {
     return htmlspecialchars($unescaped, ENT_QUOTES, 'UTF-8');
+}
+
+function adminPasswordMinLengthMessage(): string
+{
+    return sprintf('Admin password should have at least %d characters', ADMIN_PASSWORD_MIN_LENGTH);
 }
 
 function getDatabaseCharset($database_collation, $driver): string
@@ -240,8 +246,8 @@ function validateAdminEmail($email)
 function validateAdminPassword($password)
 {
     $password = trim($password);
-    if (strlen($password) < 8) {
-        throw new InvalidArgumentException('Admin password should have at least 8 characters');
+    if (strlen($password) < ADMIN_PASSWORD_MIN_LENGTH) {
+        throw new InvalidArgumentException(adminPasswordMinLengthMessage());
     }
     return $password;
 }

--- a/install/src/template/actions/connection.tpl
+++ b/install/src/template/actions/connection.tpl
@@ -86,12 +86,12 @@
             <p class="labelHolder">
                 <label for="cmspassword">[%connection_screen_default_admin_password%]</label>
                 <input type="password" id="cmspassword" name="cmspassword" value="[+cmspassword+]" />
-                <small class="is-invalid">[%alert_enter_adminpassword%]</small>
+                <small class="is-invalid" data-default="[%alert_enter_adminpassword%]" data-minlength="[+adminPasswordMinLengthMessage+]">[%alert_enter_adminpassword%]</small>
             </p>
             <p class="labelHolder">
                 <label for="cmspasswordconfirm">[%connection_screen_default_admin_password_confirm%]</label>
                 <input type="password" id="cmspasswordconfirm" name="cmspasswordconfirm" value="[+cmspasswordconfirm+]" />
-                <small class="is-invalid">[%alert_enter_adminconfirm%]</small>
+                <small class="is-invalid" data-default="[%alert_enter_adminconfirm%]" data-minlength="[+adminPasswordMinLengthMessage+]">[%alert_enter_adminconfirm%]</small>
             </p>
             <h3 class="mt-5">[%default_language%]</h3>
             <p>[%default_language_description%]</p>
@@ -113,19 +113,40 @@
     var language = '[+install_language+]';
     var installMode = parseInt('[+installMode+]');
 
+    function resetFieldMessage(input) {
+        var help = input?.parentElement?.querySelector('.is-invalid');
+        if (help?.dataset?.default) {
+            help.textContent = help.dataset.default;
+        }
+    }
+
+    function setFieldErrorMessage(input, messageType) {
+        var help = input?.parentElement?.querySelector('.is-invalid');
+        if (help?.dataset?.[messageType]) {
+            help.textContent = help.dataset[messageType];
+        }
+        input.parentElement.classList.add('has-error');
+        input.focus();
+        return false;
+    }
+
     document.querySelectorAll('[name]').forEach(function(el) {
         el.onkeyup = function() {
             if (this.value === '') {
                 this.parentElement.classList.add('has-error');
+                resetFieldMessage(this);
             } else {
-                this.parentElement.classList.remove('has-error')
+                this.parentElement.classList.remove('has-error');
+                resetFieldMessage(this);
             }
         };
         el.onchange = function() {
             if (this.value === '') {
                 this.parentElement.classList.add('has-error');
+                resetFieldMessage(this);
             } else {
-                this.parentElement.classList.remove('has-error')
+                this.parentElement.classList.remove('has-error');
+                resetFieldMessage(this);
             }
         };
     });
@@ -253,19 +274,13 @@
             return false;
         }
         if (form.cmspassword?.value?.length < 8) {
-            form.cmspassword.parentElement.classList.add('has-error');
-            form.cmspassword.focus();
-            return false;
+            return setFieldErrorMessage(form.cmspassword, 'minlength');
         }
         if (form.cmspasswordconfirm?.value?.length < 8) {
-            form.cmspasswordconfirm.parentElement.classList.add('has-error');
-            form.cmspasswordconfirm.focus();
-            return false;
+            return setFieldErrorMessage(form.cmspasswordconfirm, 'minlength');
         }
         if (form.cmspasswordconfirm?.value !== form.cmspassword?.value) {
-            form.cmspasswordconfirm.parentElement.classList.add('has-error');
-            form.cmspasswordconfirm.focus();
-            return false;
+            return setFieldErrorMessage(form.cmspasswordconfirm, 'default');
         }
         form.action = 'index.php?action=options';
         form.submit();


### PR DESCRIPTION
## Problem

On the installer "Default Manager Settings" step, a short admin password is blocked by the frontend precheck, but the inline error still shows the generic required-field message. That makes a length validation failure look like an empty-field error.

Closes #2279.

## Root Cause

`install/src/template/actions/connection.tpl` only toggled the `has-error` class for short passwords. The visible help text under each password field was static, so the browser always kept showing the default required or mismatch copy.

## What Changed

- added a shared installer helper for the admin-password minimum-length message
- passed the min-length copy into the connection step template
- taught the installer precheck to swap the inline password help text to a dedicated min-length message for both password fields
- restored the default confirm message for the mismatch path
- added a regression test for the installer template and validator contract

## Validation

- `php -l install/src/functions.php`
- `php -l install/src/controllers/connection.php`
- `php -l core/tests/Unit/Install/ConnectionTemplatePasswordValidationTest.php`
- `cd core && ./vendor/bin/phpunit tests/Unit/Install/ConnectionTemplatePasswordValidationTest.php`
- `cd core && ./vendor/bin/pest tests/Feature/ModifiersTest.php`

## Risk

Low. The change stays inside the installer connection step and only touches the inline validation copy for short admin passwords.
