### PR TITLE
[FIX] Prevent zero-size dump batches for small tables.

### DIFF
--- a/core/src/Support/MysqlDumper.php
+++ b/core/src/Support/MysqlDumper.php
@@ -159,9 +159,7 @@ class MysqlDumper implements MysqlDumperInterface
 
             $tableSize = $tableSizes[$tblval];
 
-            $parts = round($tableSize/5);
-            $parts = !empty($parts)?$parts:1;
-            $rowByOneQuery = round($rowCount/$parts);
+            $rowByOneQuery = $this->calculateRowBatchSize((int) $rowCount, (int) $tableSize);
 
             $total = intval(($rowCount - 1) / $rowByOneQuery) + 1;
 
@@ -385,5 +383,13 @@ class MysqlDumper implements MysqlDumperInterface
         }
 
         $sorted[] = $table;
+    }
+
+    private function calculateRowBatchSize(int $rowCount, int $tableSize): int
+    {
+        $parts = (int) round($tableSize / 5);
+        $parts = max(1, $parts);
+
+        return max(1, (int) ceil($rowCount / $parts));
     }
 }

--- a/core/tests/Unit/Support/MysqlDumperRowBatchSizeTest.php
+++ b/core/tests/Unit/Support/MysqlDumperRowBatchSizeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use EvolutionCMS\Support\MysqlDumper;
+
+test('mysql dumper keeps row batch size above zero for small tables with many parts', function () {
+    $dumper = new MysqlDumper('test');
+    $method = new ReflectionMethod(MysqlDumper::class, 'calculateRowBatchSize');
+    $method->setAccessible(true);
+
+    expect($method->invoke($dumper, 1, 15))->toBe(1)
+        ->and($method->invoke($dumper, 2, 20))->toBe(1)
+        ->and($method->invoke($dumper, 10, 5))->toBe(10);
+});


### PR DESCRIPTION
Closes #2288

## What changed
- prevent `MysqlDumper` from producing a zero row batch size when a table has only a few rows but is split into multiple parts
- move the batch-size math into a small helper for safer regression coverage
- add a regression test for the reported divide-by-zero shape

## Why
`round($rowCount / $parts)` can become `0` for small positive row counts, which then causes a division-by-zero crash when calculating the total page count.

## Validation
- `php -l core/src/Support/MysqlDumper.php`
- `php -l core/tests/Unit/Support/MysqlDumperRowBatchSizeTest.php`
- `cd core && ./vendor/bin/pest tests/Unit/Support/MysqlDumperRowBatchSizeTest.php tests/Feature/ModifiersTest.php`
