### PR TITLE
Guard file_groups migration when table already exists

### DIFF
--- a/core/database/migrations/2026_03_29_000000_create_file_groups_table.php
+++ b/core/database/migrations/2026_03_29_000000_create_file_groups_table.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateFileGroupsTable extends Migration {
     public function up() {
+        if (Schema::hasTable('file_groups')) {
+            return;
+        }
+
         Schema::create('file_groups', function(Blueprint $table) {
             $indexPrefix = \DB::getTablePrefix() . $table->getTable();
             $table->integer('id', true);
@@ -15,6 +19,6 @@ class CreateFileGroupsTable extends Migration {
         });
     }
     public function down() {
-        Schema::drop('file_groups');
+        Schema::dropIfExists('file_groups');
     }
 }

--- a/core/tests/Unit/FileGroupsSchemaAndModelTest.php
+++ b/core/tests/Unit/FileGroupsSchemaAndModelTest.php
@@ -4,10 +4,15 @@ use EvolutionCMS\Models\FileGroup;
 
 test('file groups migration owns the file_groups table definition', function () {
     $dedicatedMigration = (string) file_get_contents(dirname(__DIR__, 2) . '/database/migrations/2026_03_29_000000_create_file_groups_table.php');
+    $stubMigration = (string) file_get_contents(dirname(__DIR__, 3) . '/install/stubs/migrations/2026_03_29_000000_create_file_groups_table.php');
     $initialSchemaMigration = (string) file_get_contents(dirname(__DIR__, 2) . '/database/migrations/2025_12_25_000000_initial_schema.php');
 
     expect($dedicatedMigration)->toContain("Schema::create('file_groups'")
+        ->and($dedicatedMigration)->toContain("Schema::hasTable('file_groups')")
+        ->and($dedicatedMigration)->toContain("Schema::dropIfExists('file_groups')")
         ->and($dedicatedMigration)->toContain("\$table->unique(['document_group', 'file']")
+        ->and($stubMigration)->toContain("Schema::hasTable('file_groups')")
+        ->and($stubMigration)->toContain("Schema::dropIfExists('file_groups')")
         ->and($initialSchemaMigration)->not->toContain("createTableIfMissing('file_groups'");
 });
 

--- a/install/stubs/migrations/2026_03_29_000000_create_file_groups_table.php
+++ b/install/stubs/migrations/2026_03_29_000000_create_file_groups_table.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateFileGroupsTable extends Migration {
     public function up() {
+        if (Schema::hasTable('file_groups')) {
+            return;
+        }
+
         Schema::create('file_groups', function(Blueprint $table) {
             $indexPrefix = \DB::getTablePrefix() . $table->getTable();
             $table->integer('id', true);
@@ -15,6 +19,6 @@ class CreateFileGroupsTable extends Migration {
         });
     }
     public function down() {
-        Schema::drop('file_groups');
+        Schema::dropIfExists('file_groups');
     }
 }


### PR DESCRIPTION
## Summary
- guard the dedicated file_groups migration so it no-ops when the table already exists
- use dropIfExists in down() for the dedicated migration and install stub
- extend the unit test to cover both guard strings

## Why
The installer can hit `artisan migrate` after extras installation, and on SQLite we observed `2026_03_29_000000_create_file_groups_table` failing because `evo_file_groups` already existed before the migration record was written.