### PR TITLE
fix(store): polish Store UI follow-ups

### DIFF
--- a/assets/modules/store/core.php
+++ b/assets/modules/store/core.php
@@ -176,31 +176,19 @@ case 'console_readme':
 	exit();
 
 default:
-	//prepare list of snippets
-	$types = ['snippets','plugins','modules'];
-    $snippets = \EvolutionCMS\Models\SiteSnippet::query()->get();
-    foreach ($snippets as $snippet){
-        $PACK[$value][$snippet->name]= $Store->get_version($snippet->description) ;
-    }
-    $PACK['snippets_writable']  = is_writable(EVO_BASE_PATH.'assets/snippets');
-
-    $plugins = \EvolutionCMS\Models\SitePlugin::query()->get();
-    foreach ($plugins as $plugin){
-        $PACK[$value][$plugin->name]= $Store->get_version($plugin->description) ;
-    }
-    $PACK['plugins_writable']  = is_writable(EVO_BASE_PATH.'assets/plugins');
-
-    $modules = \EvolutionCMS\Models\SiteModule::query()->get();
-    foreach ($modules as $module){
-        $PACK[$value][$module->name]= $Store->get_version($module->description) ;
-    }
-    $PACK['modules_writable']  = is_writable(EVO_BASE_PATH.'assets/modules');
+	$legacyInstalled = $Store->getLegacyInstalledState();
+	$installedState = [
+		'legacy_by_type' => $legacyInstalled['by_type'],
+		'legacy_items' => $legacyInstalled['items'],
+		'console_by_composer' => $Store->getConsoleInstalledState(),
+	];
 
 
 	$Store->lang['user_email'] = $_SESSION['mgrEmail'];
 	$Store->lang['hash'] = isset($_SESSION['STORE_USER']) ? stripslashes( $_SESSION['STORE_USER'] ) : '';
 	$Store->lang['lang'] = $Store->language;
-	$Store->lang['_type'] = json_encode($PACK);
+	$Store->lang['_type'] = json_encode($legacyInstalled['by_type'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+	$Store->lang['installed_state'] = json_encode($installedState, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 	$Store->lang['v'] = $version;
 	$Store->lang['project_path'] = rtrim(EVO_BASE_PATH, '/\\');
 	$Store->lang['core_path'] = defined('EVO_CORE_PATH')
@@ -347,6 +335,7 @@ class Store{
 		}
 
 		$items = [];
+		$consoleInstalled = $this->getConsoleInstalledState();
 		foreach ($data['packages'] as $package) {
 			if (!is_array($package)) {
 				continue;
@@ -365,9 +354,19 @@ class Store{
 			$displayVersion = $installVersion !== '' ? $installVersion : 'main';
 			$fullName = isset($package['full_name']) ? trim((string) $package['full_name']) : '';
 			$author = '';
+			$composerKey = strtolower($composerName);
 			if ($fullName !== '' && strpos($fullName, '/') !== false) {
 				$author = explode('/', $fullName)[0];
 			}
+			$installedVersion = '';
+			$rawInstalledVersion = '';
+			$isInstalled = false;
+			if (isset($consoleInstalled[$composerKey])) {
+				$isInstalled = !empty($consoleInstalled[$composerKey]['is_installed']);
+				$installedVersion = isset($consoleInstalled[$composerKey]['version']) ? (string) $consoleInstalled[$composerKey]['version'] : '';
+				$rawInstalledVersion = isset($consoleInstalled[$composerKey]['raw_version']) ? (string) $consoleInstalled[$composerKey]['raw_version'] : '';
+			}
+			$statusClass = $this->resolveConsoleStatusClass($installedVersion, $displayVersion, $defaultBranch);
 
 			$versionOptions = [];
 			$stableTags = [];
@@ -416,13 +415,17 @@ class Store{
 				'title' => $name,
 				'name' => $name,
 				'name_in_modx' => $name,
+				'composer_name' => $composerName,
 				'description' => isset($package['description']) ? trim((string) $package['description']) : '',
 				'type' => 'package',
 				'install_method' => 'console-extra',
 				'install_target' => $name,
 				'install_command' => '',
 				'version' => $displayVersion,
-				'current_version' => '',
+				'current_version' => $installedVersion,
+				'raw_current_version' => $rawInstalledVersion,
+				'is_installed' => $isInstalled ? 1 : 0,
+				'cls' => $statusClass,
 				'downloads' => '',
 				'author' => $author,
 				'date' => '',
@@ -516,6 +519,159 @@ class Store{
 		return $repo;
 	}
 
+	public function getLegacyInstalledState() {
+		$byType = [
+			'snippets' => [],
+			'plugins' => [],
+			'modules' => [],
+		];
+		$items = [];
+
+		$snippets = \EvolutionCMS\Models\SiteSnippet::query()->get();
+		foreach ($snippets as $snippet) {
+			$version = $this->get_version($snippet->description);
+			$byType['snippets'][$snippet->name] = $version;
+			$items[] = [
+				'type' => 'snippets',
+				'name' => $snippet->name,
+				'version' => $version,
+				'is_installed' => 1,
+			];
+		}
+		$byType['snippets_writable'] = is_writable(EVO_BASE_PATH . 'assets/snippets');
+
+		$plugins = \EvolutionCMS\Models\SitePlugin::query()->get();
+		foreach ($plugins as $plugin) {
+			$version = $this->get_version($plugin->description);
+			$byType['plugins'][$plugin->name] = $version;
+			$items[] = [
+				'type' => 'plugins',
+				'name' => $plugin->name,
+				'version' => $version,
+				'is_installed' => 1,
+			];
+		}
+		$byType['plugins_writable'] = is_writable(EVO_BASE_PATH . 'assets/plugins');
+
+		$modules = \EvolutionCMS\Models\SiteModule::query()->get();
+		foreach ($modules as $module) {
+			$version = $this->get_version($module->description);
+			$byType['modules'][$module->name] = $version;
+			$items[] = [
+				'type' => 'modules',
+				'name' => $module->name,
+				'version' => $version,
+				'is_installed' => 1,
+			];
+		}
+		$byType['modules_writable'] = is_writable(EVO_BASE_PATH . 'assets/modules');
+
+		return [
+			'by_type' => $byType,
+			'items' => $items,
+		];
+	}
+
+	public function getConsoleInstalledState() {
+		static $state = null;
+		if ($state !== null) {
+			return $state;
+		}
+
+		$state = [];
+		if (!class_exists('\\Composer\\InstalledVersions')) {
+			return $state;
+		}
+
+		try {
+			foreach (\Composer\InstalledVersions::getInstalledPackages() as $packageName) {
+				if (!is_string($packageName) || $packageName === '') {
+					continue;
+				}
+
+				$key = strtolower($packageName);
+				$prettyVersion = '';
+				try {
+					$prettyVersion = (string) \Composer\InstalledVersions::getPrettyVersion($packageName);
+				} catch (\Throwable $exception) {
+					$prettyVersion = '';
+				}
+
+				$state[$key] = [
+					'is_installed' => true,
+					'raw_version' => $prettyVersion,
+					'version' => $this->normalizeInstalledComposerVersion($prettyVersion),
+				];
+			}
+		} catch (\Throwable $exception) {
+			return [];
+		}
+
+		return $state;
+	}
+
+	private function normalizeInstalledComposerVersion($version) {
+		$version = trim((string) $version);
+		if ($version === '') {
+			return '';
+		}
+
+		if (strpos($version, 'dev-') === 0) {
+			return substr($version, 4);
+		}
+
+		return $version;
+	}
+
+	private function resolveConsoleStatusClass($installedVersion, $catalogVersion, $defaultBranch = '') {
+		$installedVersion = trim((string) $installedVersion);
+		$catalogVersion = trim((string) $catalogVersion);
+		$defaultBranch = trim((string) $defaultBranch);
+
+		if ($installedVersion === '') {
+			return 'pack_install';
+		}
+
+		$normalizedInstalled = $this->normalizeComparableVersion($installedVersion, $defaultBranch);
+		$normalizedCatalog = $this->normalizeComparableVersion($catalogVersion, $defaultBranch);
+
+		if ($normalizedInstalled !== '' && $normalizedCatalog !== '' && $normalizedInstalled === $normalizedCatalog) {
+			return 'pack_reinstall';
+		}
+
+		if ($this->isComparableSemver($normalizedInstalled) && $this->isComparableSemver($normalizedCatalog)) {
+			return version_compare($normalizedInstalled, $normalizedCatalog, '<') ? 'pack_update' : 'pack_reinstall';
+		}
+
+		return 'pack_reinstall';
+	}
+
+	private function normalizeComparableVersion($version, $defaultBranch = '') {
+		$version = trim((string) $version);
+		$defaultBranch = trim((string) $defaultBranch);
+		if ($version === '') {
+			return '';
+		}
+
+		if (strpos($version, 'dev-') === 0) {
+			$version = substr($version, 4);
+		}
+
+		if ($defaultBranch !== '' && $version === $defaultBranch) {
+			return $defaultBranch;
+		}
+
+		if (preg_match('/^v(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.\-]+)?)$/', $version, $matches)) {
+			return $matches[1];
+		}
+
+		return $version;
+	}
+
+	private function isComparableSemver($version) {
+		return (bool) preg_match('/^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.\-]+)?$/', (string) $version);
+	}
+
 	private function sanitizeRefName($ref) {
 		$ref = trim((string) $ref);
 		if ($ref === '') {
@@ -541,6 +697,28 @@ class Store{
 	}
 
 	private function renderMarkdownHtml($markdown, $repoUrl = '', $branch = 'main') {
+		$markdown = str_replace(["\r\n", "\r"], "\n", (string) $markdown);
+		$markdown = preg_replace("/\n{3,}/", "\n\n", $markdown);
+
+		if (class_exists('\\Illuminate\\Support\\Str')) {
+			try {
+				$html = (string) \Illuminate\Support\Str::markdown($markdown, [
+					'html_input' => 'allow',
+					'allow_unsafe_links' => false,
+					'max_nesting_level' => 20,
+				]);
+
+				if (trim($html) !== '') {
+					return $this->postProcessRenderedMarkdownHtml($html, $repoUrl, $branch);
+				}
+			} catch (\Throwable $exception) {
+			}
+		}
+
+		return $this->renderMarkdownHtmlFallback($markdown, $repoUrl, $branch);
+	}
+
+	private function renderMarkdownHtmlFallback($markdown, $repoUrl = '', $branch = 'main') {
 		$markdown = str_replace(["\r\n", "\r"], "\n", (string) $markdown);
 		$markdown = preg_replace("/\n{3,}/", "\n\n", $markdown);
 
@@ -682,6 +860,52 @@ class Store{
 		$flushIndentedCode();
 
 		return implode("\n", $html);
+	}
+
+	private function postProcessRenderedMarkdownHtml($html, $repoUrl = '', $branch = 'main') {
+		$html = trim((string) $html);
+		if ($html === '' || !class_exists('\\DOMDocument')) {
+			return $html;
+		}
+
+		$previous = libxml_use_internal_errors(true);
+		$document = new \DOMDocument('1.0', 'UTF-8');
+		$loaded = $document->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+		if (!$loaded) {
+			libxml_clear_errors();
+			libxml_use_internal_errors($previous);
+			return $html;
+		}
+
+		$images = $document->getElementsByTagName('img');
+		for ($index = $images->length - 1; $index >= 0; $index--) {
+			$image = $images->item($index);
+			if ($image instanceof \DOMElement && $image->hasAttribute('src')) {
+				$image->setAttribute('src', $this->resolveMarkdownUrl($image->getAttribute('src'), $repoUrl, $branch, true));
+			}
+		}
+
+		$links = $document->getElementsByTagName('a');
+		for ($index = $links->length - 1; $index >= 0; $index--) {
+			$link = $links->item($index);
+			if (!($link instanceof \DOMElement) || !$link->hasAttribute('href')) {
+				continue;
+			}
+
+			$resolvedHref = $this->resolveMarkdownUrl($link->getAttribute('href'), $repoUrl, $branch, false);
+			$link->setAttribute('href', $resolvedHref);
+
+			if (!preg_match('~^#~', $resolvedHref)) {
+				$link->setAttribute('target', '_blank');
+				$link->setAttribute('rel', 'noopener');
+			}
+		}
+
+		$result = $document->saveHTML();
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+
+		return preg_replace('/^<\\?xml.+?\\?>/i', '', (string) $result);
 	}
 
 	private function renderMarkdownInline($text, $repoUrl = '', $branch = 'main') {

--- a/assets/modules/store/css/style.css
+++ b/assets/modules/store/css/style.css
@@ -77,18 +77,21 @@ body {
 }
 
 .pack_install .item-reinstall,
-.pack_install .item-update {
-  display: none;
-}
-
+.pack_install .item-update,
 .pack_update .item-reinstall,
-.pack_update .item-install {
-  display: none;
+.pack_update .item-update,
+.pack_reinstall .item-reinstall,
+.pack_reinstall .item-update,
+.item-reinstall,
+.item-update {
+  display: none !important;
 }
 
+.pack_update .item-install,
 .pack_reinstall .item-install,
-.pack_reinstall .item-update {
-  display: none;
+.pack_install .item-install,
+.item-install {
+  display: inline-block !important;
 }
 
 .informer {
@@ -168,6 +171,10 @@ body {
 
 .item_list .catalog_item .item_content:hover {
   border: 1px solid #3697cd;
+}
+
+.item_list .catalog_item.is-installed .item_content:hover {
+  border-color: #38b86d;
 }
 
 .row-category H3 {
@@ -260,7 +267,7 @@ nav ul li {
 .info {
   border-top: 1px solid #ececec;
   background: #fff;
-  display: block;
+  display: none;
   position: absolute;
   height: 30px;
   width: 100%;
@@ -271,16 +278,31 @@ nav ul li {
 }
 
 .install_extras {
-  border-top: 1px solid #e0e0e0;
+  border: 0;
   background: #fafafa;
-  display: block;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 10px;
   position: absolute;
-  height: 75px;
+  min-height: 58px;
   width: 100%;
   left: 0;
   bottom: 0;
   text-align: left;
   padding: 7px 9px;
+  box-sizing: border-box;
+}
+
+.install_extras .btn {
+  height: 34px;
+  padding: 0 16px !important;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-sizing: border-box;
 }
 
 .store-select-wrap {
@@ -321,15 +343,16 @@ nav ul li {
 }
 
 .store-version-wrap {
-  margin-left: 8px;
+  margin-left: 0;
   min-width: 96px;
   max-width: 152px;
   width: auto;
+  flex: 0 0 auto;
 }
 
 .catalog_item:not(.liststyle) .store-version-wrap {
-  min-width: 88px;
-  max-width: 132px;
+  min-width: 84px;
+  max-width: 118px;
 }
 
 .install_extras select[name="link"] {
@@ -354,7 +377,7 @@ nav ul li {
 }
 
 .install_extras .store-version-wrap {
-  height: 36px;
+  height: 34px;
   border: 1px solid #cfd7e1;
   border-radius: 8px;
   background: #ffffff;
@@ -366,29 +389,149 @@ nav ul li {
 }
 
 .catalog_item:not(.liststyle) .install_extras .store-select-display {
-  padding: 0 28px 0 14px;
-  font-size: 14px;
+  padding: 0 24px 0 12px;
+  font-size: 13px;
 }
 
 .catalog_item:not(.liststyle) .install_extras .store-select-wrap::after {
-  right: 10px;
+  right: 9px;
   font-size: 13px;
+}
+
+.store-title-state {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-left: 0;
+  vertical-align: middle;
+}
+
+.store-version-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 20px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.store-version-chip-current {
+  border-color: #2d8a49;
+  background: rgba(45, 138, 73, 0.08);
+  color: #2d8a49;
+}
+
+.store-version-chip-latest {
+  border-color: #6fb3ff;
+  background: rgba(111, 179, 255, 0.08);
+  color: #2f6fa8;
+}
+
+.catalog_item.is-installed .item_content {
+  border-color: #2d8a49;
+  background: linear-gradient(180deg, rgba(45, 138, 73, 0.06) 0%, rgba(45, 138, 73, 0.02) 100%);
+  box-shadow: inset 0 0 0 1px rgba(45, 138, 73, 0.14);
 }
 
 .catalog_item.col-lg-12 .install_extras {
   text-align: right;
 }
 
+.install_extras .btn,
+.install_extras .store-version-wrap {
+  align-self: center;
+}
+
+.catalog_item.is-installed .item-install.btn-primary {
+  background: #1976d2;
+  border-color: #1976d2;
+  color: #fff;
+}
+
+.catalog_item.is-installed .item-install.btn-primary:hover,
+.catalog_item.is-installed .item-install.btn-primary:focus {
+  background: #1565c0;
+  border-color: #1565c0;
+  color: #fff;
+}
+
 .info_extras {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
   background-color: transparent;
   position: absolute;
   height: 28px;
   right: 10px;
-  bottom: 82px;
-  text-align: right;
+  bottom: 66px;
   padding: 0;
   z-index: 1;
+}
+
+.info_extras .item-downloads {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 0 2px;
+  color: #aeb6bf;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.info_extras .item-downloads .fa {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  margin: 0;
+  color: #5fb6ff;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.info_extras .item-downloads-value {
+  display: inline-block;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: 1;
+}
+
+.info_extras .item-more {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 12px !important;
+  line-height: 1;
+  font-size: 12px;
+  text-transform: lowercase;
+  box-sizing: border-box;
+}
+
+.info_extras .item-more .fa {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  line-height: 1;
+  font-size: 13px;
 }
 
 .info .version {
@@ -451,6 +594,7 @@ nav ul li {
 .descript {
   min-height: 36px;
   display: block;
+  margin-top: 4px;
   margin-bottom: -15px;
   line-height: 1.25em;
   opacity: .6;
@@ -927,8 +1071,8 @@ input#store_search:focus {
 }
 
 .evo-popup .evo-popup-header {
-  padding: 8px 56px 12px 18px;
-  margin: 0 0 12px;
+  padding: 8px 56px 12px 0;
+  margin: 0 0 8px;
   font-size: 17px;
   font-weight: 700;
   line-height: 1.35;
@@ -936,6 +1080,10 @@ input#store_search:focus {
   display: flex;
   align-items: flex-start;
   justify-content: flex-start;
+  position: relative;
+  left: -16px;
+  border-bottom: 0 !important;
+  box-shadow: none !important;
 }
 
 .evo-popup .evo-popup-header small,
@@ -1092,20 +1240,28 @@ body,
 
 .row-category h3 {
   padding: 0px!important;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  line-height: 1.05;
 }
 
 .package-dev-badge {
   display: inline-flex;
   align-items: center;
-  margin-left: 8px;
-  padding: 1px 7px;
+  justify-content: center;
+  margin-left: 0;
+  min-height: 20px;
+  padding: 0 10px;
   border-radius: 999px;
   background: rgba(222, 142, 20, 0.16);
   border: 1px solid rgba(222, 142, 20, 0.38);
   color: #d98a1f;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.04em;
+  line-height: 1;
   vertical-align: middle;
 }
 
@@ -1146,7 +1302,7 @@ body,
 }
 
 .catalog_item.liststyle .info_extras {
-  display: block;
+  display: flex;
   background: transparent;
   position: absolute;
   height: 28px;
@@ -1165,15 +1321,20 @@ body,
 }
 
 .catalog_item.liststyle .install_extras {
-  border-top: 1px solid #e0e0e0;
+  border: 0;
   background: #fff;
-  display: block;
+  display: flex;
   position: absolute;
-  height: 45px;
+  min-height: 45px;
   left: 0;
   bottom: 0;
   text-align: left;
   padding: 7px;
+}
+
+.catalog_item.liststyle .install_extras .btn,
+.catalog_item.liststyle .install_extras .store-version-wrap {
+  height: 31px;
 }
 
 /*.catalog_item.liststyle .row-category h3:before {*/
@@ -1191,7 +1352,9 @@ body,
   height: 37px;
   left: auto;
   right: 6px;
-  bottom: -2px;
+  top: 50%;
+  bottom: auto;
+  transform: translateY(-50%);
 }
 
 #hide-side {
@@ -1199,8 +1362,14 @@ body,
   margin-right:8px;
 }
 
-.darkness .box, .darkness .item_content, .darkness .install_extras, .darkness .info, .darkness .catalog_item.liststyle .install_extras{
+.darkness .box, .darkness .item_content, .darkness .info{
   border: 1px solid #414449;
+  background: #202329;
+}
+
+.darkness .install_extras,
+.darkness .catalog_item.liststyle .install_extras{
+  border: 0;
   background: #202329;
 }
 
@@ -1263,6 +1432,14 @@ body.darkness {
 
 .darkness .info span {
   color: #b9c0c8;
+}
+
+.darkness .info_extras .item-downloads {
+  color: #b9c0c8;
+}
+
+.darkness .info_extras .item-downloads .fa {
+  color: #5fb6ff;
 }
 
 .darkness .descript {
@@ -1350,6 +1527,22 @@ body.darkness {
   border-color: #6fb3ff !important;
 }
 
+.darkness .catalog_item.is-installed .item_content {
+  border-color: #2d8a49;
+  background: linear-gradient(180deg, rgba(45, 138, 73, 0.09) 0%, rgba(32, 35, 41, 1) 28%);
+  box-shadow: inset 0 0 0 1px rgba(45, 138, 73, 0.22);
+}
+
+.darkness .store-version-chip-current {
+  background: rgba(45, 138, 73, 0.14);
+  color: #8ce0a4;
+}
+
+.darkness .store-version-chip-latest {
+  background: rgba(111, 179, 255, 0.14);
+  color: #8fc8ff;
+}
+
 .darkness .store-sort-wrap .store-select-display {
   border-color: #414449 !important;
   background: #202329;
@@ -1424,9 +1617,17 @@ body.darkness {
   content: '\f120';
 }
 
-.catalog-source-console .typesbadge {
-  background: rgba(255,255,255,.12);
-  border-color: rgba(255,255,255,.14);
+.catalog-source-console .catalog_thumb .typesbadge {
+  background: rgba(15, 23, 42, 0.32) !important;
+  border-color: rgba(255,255,255,.16) !important;
+  color: #f8fafc !important;
+  text-shadow: 0 1px 1px rgba(15, 23, 42, 0.45);
+}
+
+body:not(.darkness) .catalog-source-console .catalog_thumb .typesbadge {
+  background: rgba(15, 23, 42, 0.36) !important;
+  border-color: rgba(15, 23, 42, 0.22) !important;
+  color: #f8fafc !important;
 }
 
 .catalog-source-console .item_content {

--- a/assets/modules/store/js/store.js
+++ b/assets/modules/store/js/store.js
@@ -30,6 +30,8 @@ function store_search(val){
 store = {
 	categories:{},
 	types:{},
+	installedState:{},
+	installedCatalog:[],
 	currentList:[],
 	currentTemplate:'list',
 	consoleCatalog:[],
@@ -111,6 +113,7 @@ store = {
 			var id = $('.category_list').find('li').first().find('a').attr('data-id');
 			store.allCategoryId = id;
 			$('[name=parent]').val(id);
+			store.buildInstalledCatalog();
 			store.update_list( store.category[id] );
 			store.loadConsoleCatalog();
 
@@ -127,11 +130,8 @@ store = {
 		});
 
 		store.types =  eval('('+$('[name="types"]').val()+')');
+		store.installedState = store.parseInstalledState();
 
-		$('a.item-reinstall,a.item-update').live('click',function(){
-			if (confirm($(this).attr('data-text'))) store.install(this);
-			return false;
-		});
 		$('a.item-install').live('click',function(){
 			store.install(this);
 			return false;
@@ -150,6 +150,10 @@ store = {
 		$('.category_list a').live('click',function(){
 			if ($(this).attr('data-source') === 'console') {
 				store.update_list(store.consoleCatalog, 'list');
+				return false;
+			}
+			if ($(this).attr('data-source') === 'installed') {
+				store.update_list(store.installedCatalog, 'list');
 				return false;
 			}
 			$('[name=parent]').val($(this).attr('data-id'));
@@ -225,9 +229,14 @@ store = {
             });
         });
 	},
-	install:function(elm){
+	install:function(elm, skipConfirm){
 		if ($(elm).attr('data-method') == 'console-extra') {
 			store.showConsoleInstallHelp(elm);
+			return false;
+		}
+
+		var installedState = parseInt($(elm).attr('data-installed-state') || '0', 10);
+		if (!skipConfirm && installedState && !confirm($(elm).attr('data-text'))) {
 			return false;
 		}
 
@@ -260,8 +269,7 @@ store = {
                             });
                         });
                     }
-					el.closest('.catalog_item').removeClass('item-install').removeClass('item-update').addClass('item-reinstall');
-					el.closest('.catalog_item').find('.curr').hide();
+					el.closest('.catalog_item').addClass('is-installed');
 
 					$('.item_list .catalog_item').removeClass('blocked');
 				}
@@ -302,6 +310,7 @@ store = {
 
 	update_category: function(data){
 		$('.category_list').html( '<ul>' +store.parse_list1( data , $('.tpl #tpl_category').html() ) + '</ul>' );
+		store.renderInstalledCategory(store.installedCatalog.length);
 	},
 	loadConsoleCatalog: function(){
 		$.ajax({
@@ -315,7 +324,9 @@ store = {
 				}
 				store.consoleCatalog = data.items;
 				store.mergeConsoleIntoAll();
+				store.buildInstalledCatalog();
 				store.renderConsoleCategory(data.items.length);
+				store.renderInstalledCategory(store.installedCatalog.length);
 			}
 		});
 	},
@@ -352,6 +363,50 @@ store = {
 			return;
 		}
 		list.find('.console-category-item').remove();
+		var first = list.children('li').first();
+		if (first.length) {
+			first.after(html);
+			return;
+		}
+		list.append(html);
+	},
+	buildInstalledCatalog: function(){
+		if (!store.allCategoryId || !store.category[store.allCategoryId]) {
+			store.installedCatalog = [];
+			return;
+		}
+
+		var items = store.toArray(store.category[store.allCategoryId]);
+		var installed = [];
+		$.each(items, function(index, item){
+			var prepared = store.applyInstalledStateToItem(item);
+			if (prepared.is_installed) {
+				installed.push(prepared);
+			}
+		});
+		store.installedCatalog = installed;
+	},
+	renderInstalledCategory: function(count){
+		var label = $('[name="installed_category_label"]').val() || 'Installed';
+		var html = store.parse($('.tpl #tpl_category').html(), {
+			id: 'installed-extras',
+			tpl: '',
+			title: label,
+			count: count,
+			source_attr: 'data-source="installed"'
+		});
+		html = html.replace('<li>', '<li class="installed-category-item">');
+		var list = $('.category_list ul');
+		if (!list.length) {
+			$('.category_list').html('<ul>' + html + '</ul>');
+			return;
+		}
+		list.find('.installed-category-item').remove();
+		var insertBefore = list.find('.console-category-item');
+		if (insertBefore.length) {
+			insertBefore.before(html);
+			return;
+		}
 		var first = list.children('li').first();
 		if (first.length) {
 			first.after(html);
@@ -401,8 +456,8 @@ store = {
 	},
 	parse_list_item: function(str,array,tpl){
 		tpl = tpl || 'list';
-		array = $.extend(true, {}, array || {});
-		array.cls = 'pack_install';
+		array = store.applyInstalledStateToItem(array);
+		array.cls = array.cls || 'pack_install';
 		array.install_method = array.install_method || array.type;
 		array.install_command = array.install_command || '';
 		array.source_kind = array.source_kind || (array.install_method === 'console-extra' ? 'console' : 'legacy');
@@ -479,25 +534,6 @@ store = {
 			str = $str.wrapAll('<div></div>').parent().html();
 
 		}
-
-		if ( array.type ) {
-			array.type = array.type == 'snippet'?'snippets':array.type;
-			array.type = array.type == 'module'?'modules':array.type;
-			array.type = array.type == 'plugin'?'plugins':array.type;
-
-			if ( store.types[ array.type ]) {
-				if ( store.types[ array.type ][ array.name_in_modx ]) {
-					array.current_version = store.types[ array.type ][ array.name_in_modx ];
-					if ( store.types[ array.type ][ array.name_in_modx ] <  array.version){
-						array.cls = 'pack_update';
-					}
-					if ( store.types[ array.type ][ array.name_in_modx ] ==  array.version){
-						array.cls = 'pack_reinstall';
-					}
-				}
-			}
-		}
-
 		out = str.replace(/%\w+%/g, function(placeholder) {
 			return array[ placeholder.split('%').join('') ] || '';
 		});
@@ -522,6 +558,17 @@ store = {
 			.attr('data-repo-full-name', array.repo_full_name || '')
 			.attr('data-readme-branch', array.readme_branch || '');
 
+		if ((array.source_kind || '') === 'console') {
+			$out.find('.item-more').html('<i class="fa fa-book"></i> readme');
+		}
+
+		if (array.is_installed) {
+			$out.find('.item-install')
+				.text($('[name="reinstall_label"]').val() || 'Reinstall')
+				.removeClass('btn-success')
+				.addClass('btn-primary');
+		}
+
 		return $out.html();
 	},
 	showConsoleInstallHelp: function(elm){
@@ -532,7 +579,6 @@ store = {
 		var sourceUrl = $(elm).attr('data-source-url') || $(elm).attr('data-url') || '';
 		var corePath = $('[name="console_core_path"]').val() || '';
 		var title = $('[name="console_install_title"]').val() || 'Install via console';
-		var intro = $('[name="console_install_intro"]').val() || '';
 		var openCoreLabel = $('[name="console_install_step_open_core"]').val() || '';
 		var runArtisanLabel = $('[name="console_install_step_run_artisan"]').val() || '';
 		var sourceLabel = $('[name="console_install_source_label"]').val() || 'Source';
@@ -543,7 +589,6 @@ store = {
 
 		var html = ''
 			+ '<div class="store-popup-shell store-popup-shell-install store-popup-shell-console ' + store.getPopupThemeClass() + '">'
-			+ '<p class="store-popup-description store-popup-install-description">' + store.escapeHtml(intro) + '</p>'
 			+ '<div class="store-install-card">'
 			+ '<div class="store-install-step">'
 			+ '<div class="store-install-card-head">'
@@ -944,14 +989,12 @@ store = {
 		return store.isDarkTheme() ? 'store-popup-theme-dark' : 'store-popup-theme-light';
 	},
 	bindPopupCopyButtons: function(){
-		var parentDoc = window.parent && window.parent.document ? window.parent.document : document;
 		var copiedLabel = $('[name="popup_copied"]').val() || 'Copied';
 		var copyLabel = $('[name="popup_copy_command"]').val() || 'Copy command';
-		var $doc = window.parent && window.parent.jQuery
-			? window.parent.jQuery(parentDoc)
-			: $(parentDoc);
+		var $popup = store.getActivePopup();
+		var $buttons = $popup.length ? $popup.find('.store-copy-button') : $('.store-copy-button');
 
-		$doc.off('click.storecopy', '.store-copy-button').on('click.storecopy', '.store-copy-button', function(event){
+		$buttons.off('click.storecopy').on('click.storecopy', function(event){
 			event.preventDefault();
 			event.stopPropagation();
 			var button = this;
@@ -960,7 +1003,7 @@ store = {
 				return false;
 			}
 
-			store.copyText(text, function(success){
+			store.copyText(text, button.ownerDocument, function(success){
 				if (!success) {
 					return;
 				}
@@ -977,7 +1020,7 @@ store = {
 			return false;
 		});
 	},
-	copyText: function(text, callback){
+	copyText: function(text, sourceDocument, callback){
 		var done = function(result){
 			if (typeof callback === 'function') {
 				callback(result);
@@ -986,7 +1029,10 @@ store = {
 
 		try {
 			var clipboard = null;
-			if (window.navigator && window.navigator.clipboard && window.navigator.clipboard.writeText) {
+			var sourceWindow = sourceDocument && sourceDocument.defaultView ? sourceDocument.defaultView : window;
+			if (sourceWindow.navigator && sourceWindow.navigator.clipboard && sourceWindow.navigator.clipboard.writeText) {
+				clipboard = sourceWindow.navigator.clipboard;
+			} else if (window.navigator && window.navigator.clipboard && window.navigator.clipboard.writeText) {
 				clipboard = window.navigator.clipboard;
 			} else if (window.parent && window.parent.navigator && window.parent.navigator.clipboard && window.parent.navigator.clipboard.writeText) {
 				clipboard = window.parent.navigator.clipboard;
@@ -995,15 +1041,15 @@ store = {
 				clipboard.writeText(text).then(function(){
 					done(true);
 				}).catch(function(){
-					done(store.copyTextFallback(text));
+					done(store.copyTextFallback(text, sourceDocument));
 				});
 				return;
 			}
 		} catch (e) {}
 
-		done(store.copyTextFallback(text));
+		done(store.copyTextFallback(text, sourceDocument));
 	},
-	copyTextFallback: function(text){
+	copyTextFallback: function(text, sourceDocument){
 		var tryCopyInDocument = function(targetDoc){
 			try {
 				var textarea = targetDoc.createElement('textarea');
@@ -1027,6 +1073,9 @@ store = {
 		};
 
 		try {
+			if (sourceDocument && tryCopyInDocument(sourceDocument)) {
+				return true;
+			}
 			if (tryCopyInDocument(document)) {
 				return true;
 			}
@@ -1165,6 +1214,199 @@ store = {
 			store.syncSelectDisplay($wrap);
 		});
 	},
+	parseInstalledState: function(){
+		var raw = $('[name="installed_state"]').val() || '';
+		if (!raw) {
+			return {
+				legacy_by_type: store.types || {},
+				legacy_items: [],
+				console_by_composer: {}
+			};
+		}
+
+		try {
+			return eval('(' + raw + ')');
+		} catch (error) {
+			return {
+				legacy_by_type: store.types || {},
+				legacy_items: [],
+				console_by_composer: {}
+			};
+		}
+	},
+	applyInstalledStateToItem: function(item){
+		var array = $.extend(true, {}, item || {});
+		if (!array.cls) {
+			array.cls = 'pack_install';
+		}
+		array.state_class = '';
+		array.title_state_html = '';
+		array.install_state_html = '';
+		array.catalog_version = array.catalog_version || array.version || '';
+		array.installed_state = parseInt(array.installed_state || 0, 10) ? 1 : 0;
+		array.current_version = array.current_version || '';
+		array.is_installed = parseInt(array.is_installed || 0, 10) ? 1 : 0;
+
+		if ((array.install_method || '') === 'console-extra' || (array.source_kind || '') === 'console') {
+			array = store.applyConsoleInstalledState(array);
+		} else {
+			array = store.applyLegacyInstalledState(array);
+		}
+
+		return store.decorateInstalledVisualState(array);
+	},
+	applyConsoleInstalledState: function(array){
+		var composerName = String(array.composer_name || '').toLowerCase();
+		var consoleMap = (store.installedState && store.installedState.console_by_composer) || {};
+		if (!composerName || !consoleMap[composerName]) {
+			return array;
+		}
+
+		var installed = consoleMap[composerName];
+		array.is_installed = installed.is_installed ? 1 : 0;
+		array.current_version = installed.version || array.current_version || '';
+		array.raw_current_version = installed.raw_version || array.raw_current_version || '';
+		array.cls = store.resolveInstalledClass(array.current_version, array.version, array.readme_branch);
+		return array;
+	},
+	applyLegacyInstalledState: function(array){
+		var normalizedType = store.normalizeLegacyType(array.type);
+		var legacyMap = (store.installedState && store.installedState.legacy_by_type) || store.types || {};
+		var itemName = array.name_in_modx || array.title || array.name || '';
+		var installedVersion = '';
+
+		if (normalizedType && legacyMap[normalizedType] && legacyMap[normalizedType][itemName]) {
+			installedVersion = legacyMap[normalizedType][itemName];
+		}
+
+		if (!installedVersion) {
+			installedVersion = store.findLegacyInstalledVersionByName(itemName);
+		}
+
+		if (!installedVersion && !store.hasLegacyInstalledName(itemName)) {
+			return array;
+		}
+
+		array.is_installed = 1;
+		array.current_version = installedVersion || array.current_version || '';
+		array.cls = store.resolveInstalledClass(array.current_version, array.version, '');
+		return array;
+	},
+	decorateInstalledVisualState: function(array){
+		array.installed_state = array.is_installed ? 1 : 0;
+		if (!array.is_installed) {
+			array.state_class = '';
+			array.title_state_html = '';
+			array.install_state_html = '';
+			return array;
+		}
+
+		var installedVersion = $.trim(String(array.current_version || ''));
+		var latestVersion = $.trim(String(array.catalog_version || array.version || ''));
+		var normalizedInstalled = store.normalizeComparableVersion(installedVersion, array.readme_branch);
+		var normalizedLatest = store.normalizeComparableVersion(latestVersion, array.readme_branch);
+		var badges = [];
+
+		badges.push(
+			'<span class="store-version-chip store-version-chip-current">' +
+				store.escapeHtml(installedVersion || 'installed') +
+			'</span>'
+		);
+
+		if (latestVersion && normalizedLatest && normalizedLatest !== normalizedInstalled) {
+			badges.push(
+				'<span class="store-version-chip store-version-chip-latest">' +
+					store.escapeHtml('→ ' + latestVersion) +
+				'</span>'
+			);
+		}
+
+		array.state_class = 'is-installed';
+		array.title_state_html = '<span class="store-title-state">' + badges.join('') + '</span>';
+		array.install_state_html = '';
+		return array;
+	},
+	findLegacyInstalledVersionByName: function(name){
+		var target = String(name || '');
+		if (!target) {
+			return '';
+		}
+
+		var items = (store.installedState && store.installedState.legacy_items) || [];
+		var foundVersion = '';
+		$.each(items, function(index, item){
+			if ((item.name || '') === target) {
+				foundVersion = item.version || '';
+				return false;
+			}
+		});
+		return foundVersion;
+	},
+	hasLegacyInstalledName: function(name){
+		var target = String(name || '');
+		if (!target) {
+			return false;
+		}
+
+		var items = (store.installedState && store.installedState.legacy_items) || [];
+		var found = false;
+		$.each(items, function(index, item){
+			if ((item.name || '') === target) {
+				found = true;
+				return false;
+			}
+		});
+		return found;
+	},
+	normalizeLegacyType: function(type){
+		type = String(type || '');
+		if (type === 'snippet') return 'snippets';
+		if (type === 'plugin') return 'plugins';
+		if (type === 'module') return 'modules';
+		return type;
+	},
+	resolveInstalledClass: function(installedVersion, catalogVersion, defaultBranch){
+		var normalizedInstalled = store.normalizeComparableVersion(installedVersion, defaultBranch);
+		var normalizedCatalog = store.normalizeComparableVersion(catalogVersion, defaultBranch);
+
+		if (!normalizedInstalled) {
+			return 'pack_reinstall';
+		}
+
+		if (normalizedInstalled === normalizedCatalog && normalizedCatalog !== '') {
+			return 'pack_reinstall';
+		}
+
+		if (store.isComparableSemver(normalizedInstalled) && store.isComparableSemver(normalizedCatalog)) {
+			return window.versionCompare(normalizedInstalled, normalizedCatalog) < 0 ? 'pack_update' : 'pack_reinstall';
+		}
+
+		return 'pack_reinstall';
+	},
+	normalizeComparableVersion: function(version, defaultBranch){
+		version = $.trim(String(version || ''));
+		defaultBranch = $.trim(String(defaultBranch || ''));
+		if (!version) {
+			return '';
+		}
+
+		if (version.indexOf('dev-') === 0) {
+			version = version.substring(4);
+		}
+
+		if (/^v\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.\-]+)?$/.test(version)) {
+			version = version.substring(1);
+		}
+
+		if (defaultBranch && version === defaultBranch) {
+			return defaultBranch;
+		}
+
+		return version;
+	},
+	isComparableSemver: function(version){
+		return /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.\-]+)?$/.test(String(version || ''));
+	},
 	sortList: function(data){
 		var items = store.toArray(data);
 		var mode = $('#store_sort').val() || 'default';
@@ -1244,3 +1486,25 @@ store = {
 $(function(){
 	store.init();
 })
+
+window.versionCompare = function(a, b) {
+	var normalize = function(version) {
+		return String(version || '').split(/[-+]/)[0].split('.').map(function(part) {
+			var value = parseInt(part, 10);
+			return isNaN(value) ? 0 : value;
+		});
+	};
+
+	var left = normalize(a);
+	var right = normalize(b);
+	var length = Math.max(left.length, right.length);
+
+	for (var index = 0; index < length; index++) {
+		var leftPart = left[index] || 0;
+		var rightPart = right[index] || 0;
+		if (leftPart < rightPart) return -1;
+		if (leftPart > rightPart) return 1;
+	}
+
+	return 0;
+};

--- a/assets/modules/store/template/main.html
+++ b/assets/modules/store/template/main.html
@@ -3,12 +3,12 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
     <title>Evolution CMS Store</title>
     <link rel="stylesheet" type="text/css" href="media/style/[+manager_theme+]/style.css" />
-    <link rel="stylesheet" type="text/css" href="[+site_url+]/assets/modules/store/css/style.css?v=[+v+]-legacyfix1" />
+    <link rel="stylesheet" type="text/css" href="[+site_url+]/assets/modules/store/css/style.css?v=[+v+]-legacyfix3" />
     <!--- <link rel="stylesheet" type="text/css" href="media/style/[+manager_theme+]/store.css" /> -->
     <link rel="stylesheet" href="media/style/common/font-awesome/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="[+site_url+]/assets/modules/store/js/fancybox/jquery.fancybox.css" media="screen" />
     <script src="[+site_url+]/assets/modules/store/js/jquery.min.js" type="text/javascript"></script>
-    <script src="[+site_url+]/assets/modules/store/js/store.js?v=1.0.16" type="text/javascript"></script>
+    <script src="[+site_url+]/assets/modules/store/js/store.js?v=1.0.20" type="text/javascript"></script>
     <script type="text/javascript" src="[+site_url+]/assets/modules/store/js/fancybox/jquery.mousewheel-3.0.6.pack.js"></script>
     <script type="text/javascript" src="[+site_url+]/assets/modules/store/js/fancybox/jquery.fancybox.pack.js"></script>
     [+onManagerMainFrameHeaderHTMLBlock+]
@@ -27,6 +27,8 @@
         <span class="warning">[+version_evailble+]: <span class="new_version">0.2.0</span> (<a href="javascript:store.update()">[+update+]</a>)</span>
     </div>
     <input type="hidden" name="console_category_label" value="[+console_category+]">
+    <input type="hidden" name="installed_category_label" value="Installed">
+    <input type="hidden" name="reinstall_label" value="[+reinstall+]">
     <input type="hidden" name="console_install_title" value="[+console_install_title+]">
     <input type="hidden" name="console_install_intro" value="[+console_install_intro+]">
     <input type="hidden" name="console_install_step_open_core" value="[+console_install_step_open_core+]">
@@ -191,6 +193,7 @@
     <div class="clearz"></div>
     <div style="display:none" class="tpl">
         <textarea name="types">[+_type+]</textarea>
+        <textarea name="installed_state">[+installed_state+]</textarea>
         <input type="hidden" name="language" value="[+lang+]">
         <textarea type="hidden" name="hash">[+hash+]</textarea>
         <div id="tpl_category">
@@ -204,7 +207,7 @@
             </li>
         </div>
         <div id="tpl_list">
-            <div class="col-sm-4 catalog_item %cls% catalog-source-%source_kind% item-%title% type-%type% deprecated-%deprecated%">
+            <div class="col-sm-4 catalog_item %cls% %state_class% catalog-source-%source_kind% item-%title% type-%type% deprecated-%deprecated%">
                 <div class="item_content">
                     <div class="info_block">
                         <div id="catalog_img" class="catalog_thumb">
@@ -214,16 +217,15 @@
                         </div>
                         <div class="catalog_info">
                             <a class="row-category">
-                                <h3>%title%<span class="package-dev-badge %dev_badge_class%">%dev_badge%</span></h3>
+                                <h3>%title%<span class="package-dev-badge %dev_badge_class%">%dev_badge%</span>%title_state_html%</h3>
                             </a>
                             <span class="descript">%description%</span>
                             <div class="info_extras">
+                                <span class="item-downloads %download_class%"><i class="fa fa-download"></i><span class="item-downloads-value">%downloads%</span></span>
                                 <button type="button" class="btn btn-sm btn-secondary pull-right item-more"><i class="fa fa-info"></i> [+more+]</button>
                             </div>
                             <div class="install_extras">
-                                <a href="#" class="btn btn-success item-install" data-url="%url%" data-source-url="%source_url%" data-id="%id%" data-name="%title%" data-package="%install_target%" data-method="%install_method%" data-command="%install_command%" data-dependencies="%dependencies%">[+install+]</a>
-                                <a href="#" class="btn btn-primary item-reinstall" data-text="[+alert_overwrite+]" data-url="%url%" data-source-url="%source_url%" data-id="%id%" data-name="%title%" data-package="%install_target%" data-method="%install_method%" data-command="%install_command%">[+reinstall+] <i class="curr">[+installed+]</i></a>
-                                <a href="#" class="btn btn-primary item-update" data-text="[+alert_overwrite+]" data-url="%url%" data-source-url="%source_url%" data-id="%id%" data-name="%title%" data-package="%install_target%" data-method="%install_method%" data-command="%install_command%">[+update+] <i class="curr">[+installed+] - %current_version%</i></a>
+                                <a href="#" class="btn btn-success item-install" data-text="[+alert_overwrite+]" data-url="%url%" data-source-url="%source_url%" data-id="%id%" data-name="%title%" data-package="%install_target%" data-method="%install_method%" data-command="%install_command%" data-dependencies="%dependencies%" data-installed-state="%installed_state%">[+install+]</a>
                                 <span class="store-select-wrap store-version-wrap"><span class="store-select-display"></span><select name="link"></select></span>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- polish the post-0.2.0 Store UI with installed-state badges, restored legacy download counts, and cleaner card actions
- refine popup and README UX, including markdown HTML rendering, copy-button behavior, and console/readme button labeling
- tighten card spacing, badge alignment, light-theme contrast, and list/grid action placement for the Store manager experience

## Validation
- `php -l assets/modules/store/core.php`
- `php -l assets/modules/store/template/main.html`
- `node --check assets/modules/store/js/store.js`
- `git diff --check`