### PR TITLE
Fix TinyMCE4 legacy API compatibility

### DIFF
--- a/core/tests/Unit/LegacyApiModeCompatibilityTest.php
+++ b/core/tests/Unit/LegacyApiModeCompatibilityTest.php
@@ -1,0 +1,9 @@
+<?php
+
+test('front controller maps legacy modx api mode to evo api mode', function () {
+    $index = file_get_contents(dirname(__DIR__, 3) . '/index.php');
+
+    expect($index)
+        ->toContain("define('EVO_API_MODE', defined('MODX_API_MODE') ? (bool)MODX_API_MODE : false);")
+        ->toContain("define('MODX_API_MODE', EVO_API_MODE);");
+});

--- a/core/tests/Unit/Manager/FrameLegacyTreeBootstrapTest.php
+++ b/core/tests/Unit/Manager/FrameLegacyTreeBootstrapTest.php
@@ -1,10 +1,12 @@
 <?php
 
-test('manager frame seeds legacy modx tree bootstrap for TinyMCE4 integrations', function () {
+test('manager frame exposes legacy tree aliases for TinyMCE4 integrations', function () {
     $frame = file_get_contents(dirname(__DIR__, 4) . '/manager/views/frame/1.blade.php');
 
     expect($frame)
         ->toContain('tree: {')
         ->toContain("itemToChange: ''")
-        ->toContain('selectedObjectName: null');
+        ->toContain('selectedObjectName: null')
+        ->toContain('window.modx = evo;')
+        ->toContain('window.tree = evo.tree;');
 });

--- a/index.php
+++ b/index.php
@@ -111,7 +111,10 @@ if (!defined('IN_MANAGER_MODE')) {
  * When enabled, this file will not call `$evo->processRoutes()`.
  */
 if (!defined('EVO_API_MODE')) {
-    define('EVO_API_MODE', false);
+    define('EVO_API_MODE', defined('MODX_API_MODE') ? (bool)MODX_API_MODE : false);
+}
+if (!defined('MODX_API_MODE')) {
+    define('MODX_API_MODE', EVO_API_MODE);
 }
 if (!defined('EVO_CORE_PATH')) {
     define('EVO_CORE_PATH', $config['core'] . '/');

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -225,6 +225,9 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
         $opened = array_filter(array_map('intval', explode('|', isset($_SESSION['openedArray']) && is_scalar($_SESSION['openedArray']) ? $_SESSION['openedArray'] : '')));
         echo (empty($opened) ? '' : 'evo.openedArray[' . implode("] = 1;\n		evo.openedArray[", $opened) . '] = 1;') . "\n";
         ?>
+        // Legacy aliases for manager plugins that still read parent.modx.tree / parent.tree.
+        window.modx = evo;
+        window.tree = evo.tree;
     </script>
     <script src="media/script/tree-drop-guard-helper.js?v={{evo()->getVersionData('version')}}"></script>
     <script src="media/script/main-target-link-helper.js?v={{evo()->getVersionData('version')}}"></script>


### PR DESCRIPTION
Fixes #2293

## Summary
- map legacy `MODX_API_MODE` requests into `EVO_API_MODE` in the front controller
- expose `window.modx` and `window.tree` aliases in the manager frame for TinyMCE4 integrations
- add regression coverage for both compatibility shims

## Context
TinyMCE4 legacy endpoints and dialogs still rely on MODX-era globals. Without these shims, legacy API requests and manager tree integrations break in the modern manager runtime.