### PR TITLE
fix(installer): [UPD] add extras vcs repositories for composer installs

### DIFF
--- a/core/src/Console/Packages/InstallPackageRequireCommand.php
+++ b/core/src/Console/Packages/InstallPackageRequireCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Input\ArrayInput;
 
 class InstallPackageRequireCommand extends Command
 {
+    protected const EXTRAS_CATALOG_URL = 'https://evo.im/extras.json';
+
     /**
      * The name and signature of the console command.
      *
@@ -34,6 +36,7 @@ class InstallPackageRequireCommand extends Command
     public $composerArray = [
         'name' => 'evolutioncms/custom',
         'require' => [],
+        'repositories' => [],
         'autoload' => [
             'psr-4' => []
         ]];
@@ -57,17 +60,42 @@ class InstallPackageRequireCommand extends Command
     {
         if (file_exists($this->composer)) {
             $composerData = file_get_contents($this->composer);
-            $this->composerArray = json_decode($composerData, true);
+            $decoded = json_decode($composerData, true);
+            if (is_array($decoded)) {
+                $this->composerArray = $decoded;
+            }
+        }
+
+        if (!isset($this->composerArray['require']) || !is_array($this->composerArray['require'])) {
+            $this->composerArray['require'] = [];
+        }
+
+        if (!isset($this->composerArray['repositories']) || !is_array($this->composerArray['repositories'])) {
+            $this->composerArray['repositories'] = [];
+        }
+
+        if (!isset($this->composerArray['autoload']) || !is_array($this->composerArray['autoload'])) {
+            $this->composerArray['autoload'] = ['psr-4' => []];
+        }
+
+        if (!isset($this->composerArray['autoload']['psr-4']) || !is_array($this->composerArray['autoload']['psr-4'])) {
+            $this->composerArray['autoload']['psr-4'] = [];
         }
     }
 
     public function updateArray()
     {
-        $this->composerArray['require'][$this->argument('key')] = $this->argument('value');
+        $packageName = trim((string) $this->argument('key'));
+        $this->composerArray['require'][$packageName] = $this->argument('value');
+        $this->appendExtrasRepositoriesForPackage($packageName);
     }
 
     public function putComposer()
     {
+        $composerDir = dirname($this->composer);
+        if (!is_dir($composerDir)) {
+            @mkdir($composerDir, 0775, true);
+        }
         file_put_contents($this->composer, json_encode($this->composerArray, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
     }
 
@@ -79,6 +107,164 @@ class InstallPackageRequireCommand extends Command
         $application->setAutoExit(false);
         $application->run($input);
 
+    }
+
+    protected function appendExtrasRepositoriesForPackage(string $packageName): void
+    {
+        if ($packageName === '') {
+            return;
+        }
+
+        $catalogPackages = $this->loadExtrasCatalogPackages();
+        if ($catalogPackages === []) {
+            return;
+        }
+
+        $visited = [];
+        $queue = [$packageName];
+
+        while ($queue !== []) {
+            $current = strtolower((string) array_shift($queue));
+            if ($current === '' || isset($visited[$current]) || !isset($catalogPackages[$current])) {
+                continue;
+            }
+
+            $visited[$current] = true;
+            $package = $catalogPackages[$current];
+            $repoUrl = $this->getGithubRepoUrl($package);
+
+            if ($repoUrl !== '') {
+                $this->ensureComposerRepository($repoUrl);
+            }
+
+            foreach ($this->getExtrasDependencies($package, $catalogPackages) as $dependency) {
+                if (!isset($visited[$dependency])) {
+                    $queue[] = $dependency;
+                }
+            }
+        }
+    }
+
+    protected function loadExtrasCatalogPackages(): array
+    {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 15,
+                'user_agent' => 'Evolution CMS Store Installer',
+            ],
+            'https' => [
+                'timeout' => 15,
+                'user_agent' => 'Evolution CMS Store Installer',
+            ],
+        ]);
+
+        $raw = @file_get_contents(static::EXTRAS_CATALOG_URL, false, $context);
+        if (!is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['packages']) || !is_array($decoded['packages'])) {
+            return [];
+        }
+
+        $packages = [];
+        foreach ($decoded['packages'] as $package) {
+            if (!is_array($package)) {
+                continue;
+            }
+
+            $composerName = strtolower(trim((string) ($package['composer_name'] ?? '')));
+            $fullName = trim((string) ($package['full_name'] ?? ''));
+            if ($composerName === '' || $fullName === '' || strpos($fullName, '/') === false) {
+                continue;
+            }
+
+            $packages[$composerName] = $package;
+        }
+
+        return $packages;
+    }
+
+    protected function getGithubRepoUrl(array $package): string
+    {
+        $fullName = trim((string) ($package['full_name'] ?? ''));
+        if ($fullName === '' || strpos($fullName, '/') === false) {
+            return '';
+        }
+
+        return 'https://github.com/' . $fullName;
+    }
+
+    protected function getExtrasDependencies(array $package, array $catalogPackages): array
+    {
+        $fullName = trim((string) ($package['full_name'] ?? ''));
+        if ($fullName === '' || strpos($fullName, '/') === false) {
+            return [];
+        }
+
+        $defaultBranch = trim((string) ($package['default_branch'] ?? 'main'));
+        $composerUrl = sprintf(
+            'https://raw.githubusercontent.com/%s/%s/composer.json',
+            $fullName,
+            rawurlencode($defaultBranch !== '' ? $defaultBranch : 'main')
+        );
+
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 15,
+                'user_agent' => 'Evolution CMS Store Installer',
+            ],
+            'https' => [
+                'timeout' => 15,
+                'user_agent' => 'Evolution CMS Store Installer',
+            ],
+        ]);
+
+        $raw = @file_get_contents($composerUrl, false, $context);
+        if (!is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $composer = json_decode($raw, true);
+        if (!is_array($composer) || !isset($composer['require']) || !is_array($composer['require'])) {
+            return [];
+        }
+
+        $dependencies = [];
+        foreach (array_keys($composer['require']) as $dependencyName) {
+            $dependencyName = strtolower(trim((string) $dependencyName));
+            if ($dependencyName === '' || !isset($catalogPackages[$dependencyName])) {
+                continue;
+            }
+
+            $dependencies[] = $dependencyName;
+        }
+
+        return array_values(array_unique($dependencies));
+    }
+
+    protected function ensureComposerRepository(string $repoUrl): void
+    {
+        $repoUrl = trim($repoUrl);
+        if ($repoUrl === '') {
+            return;
+        }
+
+        foreach ($this->composerArray['repositories'] as $repository) {
+            if (!is_array($repository)) {
+                continue;
+            }
+
+            if (($repository['type'] ?? '') === 'vcs' && trim((string) ($repository['url'] ?? '')) === $repoUrl) {
+                return;
+            }
+        }
+
+        $this->composerArray['repositories'][] = [
+            'type' => 'vcs',
+            'url' => $repoUrl,
+        ];
     }
 
 }


### PR DESCRIPTION
## Summary
- make `package:installrequire` register VCS repositories from the extras catalog before running Composer
- fix GitHub-hosted extras like `dAi`/`eAi` failing with `it could not be found in any version`

## Root cause
Store passed the correct Composer package name (`evolution-cms/dai`), but the installer only wrote `require` entries into `core/custom/composer.json`.
For GitHub-only extras that are not available on Packagist, Composer had no matching `repositories` entries, so resolution failed before install.

## What changed
- load `https://evo.im/extras.json`
- find the selected package by `composer_name`
- add its GitHub repo as a `vcs` repository in `core/custom/composer.json`
- recursively add VCS repositories for extras-catalog dependencies found in the package composer manifest
- ensure `custom/composer.json` is created safely with default `require`, `repositories`, and `autoload.psr-4` sections

## Validation
- `php -l core/src/Console/Packages/InstallPackageRequireCommand.php`
- `php core/artisan package:installrequire evolution-cms/dai dev-main 0`
- verified generated `core/custom/composer.json` includes:
  - `https://github.com/Dmi3yy/dAi`
  - `https://github.com/evolution-cms/eAi`
  - `https://github.com/evolution-cms/eMCP`
  - `https://github.com/Seiger/sApi`
  - `https://github.com/Seiger/sTask`