### PR TITLE
fix(manager): restore dashboard after closing last default tab

### DIFF
--- a/manager/media/style/default/js/evo.js
+++ b/manager/media/style/default/js/evo.js
@@ -1918,6 +1918,8 @@
                                     evo.tabs({ url: url, title: title, reload: 0 });
                                 }
                             }
+                        } else {
+                            evo.tabs({ url: '?a=2', title: 'Dashboard', reload: 0 });
                         }
                     }
                     evo.tabsStore();


### PR DESCRIPTION
## Summary
- restore the default manager tab fallback to Dashboard when the last active tab is closed
- keep the fix scoped to the default theme only

## Problem
On installs that use the default manager theme, closing the last active tab could leave the manager without a visible fallback tab instead of returning to Dashboard.

## Fix
- add an explicit `?a=2` fallback in `manager/media/style/default/js/evo.js` when no selected tab remains after close

## Validation
- `php -l manager/media/style/default/js/evo.js`
- manual verification path:
  - open System Settings in a tab
  - close the tab
  - manager returns to Dashboard
