### PR TITLE
fix(store): wire scheduler and limit installed extras list

### DIFF
--- a/assets/modules/store/js/store.js
+++ b/assets/modules/store/js/store.js
@@ -927,18 +927,11 @@ store = {
 
 		var items = store.toArray(store.category[store.allCategoryId]);
 		var installed = [];
-		var representedLegacy = {};
 		$.each(items, function(index, item){
 			var prepared = store.applyInstalledStateToItem(item);
 			if (prepared.is_installed) {
 				installed.push(prepared);
-				if ((prepared.source_kind || (prepared.install_method === 'console-extra' ? 'console' : 'legacy')) !== 'console') {
-					representedLegacy[store.getLegacyInstalledKey(prepared)] = true;
-				}
 			}
-		});
-		$.each(store.buildSyntheticLegacyInstalledItems(representedLegacy), function(index, item){
-			installed.push(item);
 		});
 		installed.sort(function(a, b){
 			var titleA = store.normalizeTitle(a);
@@ -958,61 +951,6 @@ store = {
 			return versionA.localeCompare(versionB);
 		});
 		store.installedCatalog = installed;
-	},
-	buildSyntheticLegacyInstalledItems: function(representedLegacy){
-		var legacyItems = (store.installedState && store.installedState.legacy_items) || [];
-		var synthetic = [];
-		var sourceLabel = $('[name="source_label_legacy"]').val() || 'Legacy';
-
-		$.each(legacyItems, function(index, item){
-			var normalizedType = store.normalizeLegacyLookupType(item.type);
-			var name = $.trim(String((item && item.name) || ''));
-			var version = $.trim(String((item && item.version) || ''));
-			var key;
-
-			if (!normalizedType || !name) {
-				return;
-			}
-
-			key = normalizedType + '::' + name.toLowerCase();
-			if (representedLegacy[key]) {
-				return;
-			}
-
-			representedLegacy[key] = true;
-			synthetic.push({
-				id: '',
-				title: name,
-				name: name,
-				name_in_modx: name,
-				description: '',
-				type: store.getLegacyDisplayType(normalizedType),
-				install_method: store.getLegacyDisplayType(normalizedType),
-				install_target: name,
-				source_kind: 'legacy',
-				source_label: sourceLabel,
-				is_installed: 1,
-				installed_state: 1,
-				current_version: version,
-				version: version,
-				catalog_version: version,
-				cls: 'pack_reinstall',
-				state_class: 'is-installed',
-				url: '',
-				dependencies: '',
-				downloads: '',
-				source_url: '',
-				repo_full_name: '',
-				readme_branch: '',
-				install_hidden_class: 'hidden',
-				version_hidden_class: 'hidden',
-				more_hidden_class: 'hidden',
-				delete_hidden_class: 'hidden',
-				synthetic_installed_only: 1
-			});
-		});
-
-		return synthetic;
 	},
 	renderInstalledCategory: function(count){
 		var label = $('[name="installed_category_label"]').val() || 'Installed';

--- a/core/config/app.php
+++ b/core/config/app.php
@@ -65,6 +65,7 @@
         'Evolution_Routing' => EvolutionCMS\Providers\RoutingServiceProvider::class,
         'Evolution_Config' => EvolutionCMS\Providers\ConfigServiceProvider::class,
         'Evolution_Session' => EvolutionCMS\Providers\SessionServiceProvider::class,
+        'Evolution_SystemTasks' => EvolutionCMS\Providers\SystemTasksServiceProvider::class,
         'Evolution_Tailwind' => EvolutionCMS\Providers\TailwindServiceProvider::class,
         'Fix_DLTemplate' => EvolutionCMS\Providers\DLTemplateServiceProvider::class,
         'Fix_Phx' => EvolutionCMS\Providers\PhxServiceProvider::class,


### PR DESCRIPTION
## Summary
- register the Store system task scheduler provider in core app providers so `schedule:work` and `schedule:run` actually see `system:*` jobs without relying on sTask
- limit the Installed category to extras represented in the Store catalog instead of synthesizing every legacy object found in the database
- keep Store/system task scheduling independent from sTask while remaining compatible if sTask is installed later

## Verification
- `php -l core/config/app.php`
- `node --check assets/modules/store/js/store.js`
- `php artisan schedule:list`
