### PR TITLE
fix(manager): unhide system tab after first-login redirect

### DIFF
--- a/manager/media/style/default/js/evo.js
+++ b/manager/media/style/default/js/evo.js
@@ -1836,6 +1836,10 @@
                             }
                             this.page.id = 'evo-tab-page-' + this.uid;
                             this.tab.id = 'evo-tab-' + this.uid;
+                            if (this.olduid === 'home' && this.uid !== 'home') {
+                                this.tab.style.display = '';
+                                this.tab.removeAttribute('data-target');
+                            }
                             this.tab.dataset.url = this.url;
                             this.tab.dataset.title = this.title;
                             this.tab.classList.remove('changed');


### PR DESCRIPTION
## Summary
- keep the hidden home tab hidden only for the dashboard
- unhide the reused home tab when the first-login redirect retitles it into a real manager tab such as System configuration
- preserve the existing dashboard fallback behavior when the last visible tab is closed

## Verification
- `node --check manager/media/style/default/js/evo.js`
- first login to a fresh install opens System configuration with a visible tab
- closing that tab returns to Dashboard
