### PR TITLE
fix(installer): [UPD] stabilize web installer upgrade flow

### DIFF
--- a/core/includes/define.inc.php
+++ b/core/includes/define.inc.php
@@ -111,7 +111,9 @@ if (!preg_match('/\/$/', EVO_BASE_URL)) {
     throw new RuntimeException('Please, use trailing slash at the end of EVO_BASE_URL');
 }
 
-define('EVO_MANAGER_PATH', EVO_BASE_PATH . MGR_DIR . '/');
+if (!defined('EVO_MANAGER_PATH')) {
+    define('EVO_MANAGER_PATH', EVO_BASE_PATH . MGR_DIR . '/');
+}
 
 if (!defined('EVO_SITE_URL')) {
     // check for valid hostnames

--- a/install/cli-install.php
+++ b/install/cli-install.php
@@ -165,7 +165,9 @@ class InstallEvo
     public function update()
     {
         $this->initEvo();
-        Console::call('migrate', ['--path' => '../install/stubs/migrations', '--force' => true]);
+        $installMigrationsPath = EVO_BASE_PATH . 'install/stubs/migrations';
+        bootstrapInstallMigrationHistory($installMigrationsPath);
+        Console::call('migrate', ['--path' => $installMigrationsPath, '--realpath' => true, '--force' => true]);
         seed('update');
         echo 'Evolution CMS updated!' . "\n";
         $this->checkRemoveInstall();

--- a/install/index.php
+++ b/install/index.php
@@ -18,9 +18,6 @@ if (! defined('MGR_DIR')) {
 if (!defined('EVO_MANAGER_PATH')) {
     define('EVO_MANAGER_PATH', $base_path . MGR_DIR . '/');
 }
-if (!defined('EVO_MANAGER_PATH')) {
-    define('EVO_MANAGER_PATH', EVO_MANAGER_PATH);
-}
 if (! defined('EVO_CORE_PATH')) {
     if (is_dir($base_path . 'core')) {
         define('EVO_CORE_PATH', dirname(__DIR__) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR);
@@ -48,6 +45,8 @@ if ($maxlifetime <= 0) {
 // Define lock file path
 $lockfile = $base_path . 'install.session.php';
 
+$isLoopbackRequest = in_array($ip, ['127.0.0.1', '::1'], true);
+
 if (file_exists("{$base_path}manager/includes/config.inc.php")) { ?>
     Backup and delete the file `manager/includes/config.inc.php` then <a href="<?= htmlspecialchars($_SERVER['REQUEST_URI'],
         ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>" onclick="location.reload(true)">reload the page</a>
@@ -74,6 +73,13 @@ if (file_exists($lockfile)) {
         if ($current_time > $install_timestamp + $maxlifetime) {
             // Expired, remove lock and create new
             @unlink($lockfile);
+            $content = "<?php\n\$install_session = '" . addslashes($sid) . "';\n\$install_ip = '" . addslashes($ip) . "';\n\$install_timestamp = " . $current_time . ";\n";
+            file_put_contents($lockfile, $content);
+            // Proceed
+        } elseif ($isLoopbackRequest && in_array($install_ip, ['127.0.0.1', '::1'], true)) {
+            // Local development can easily desync installer cookies between refreshes.
+            // On loopback, let the current browser session take over the installer lock
+            // instead of failing with an opaque 404.
             $content = "<?php\n\$install_session = '" . addslashes($sid) . "';\n\$install_ip = '" . addslashes($ip) . "';\n\$install_timestamp = " . $current_time . ";\n";
             file_put_contents($lockfile, $content);
             // Proceed

--- a/install/src/controllers/install.php
+++ b/install/src/controllers/install.php
@@ -194,6 +194,12 @@ try {
 
         include(EVO_BASE_PATH . '/index.php');
 
+        $installMigrationsPath = EVO_BASE_PATH . 'install/stubs/migrations';
+
+        if ($installMode != 0) {
+            bootstrapInstallMigrationHistory($installMigrationsPath);
+        }
+
         if ($installMode != 0 && $database_type == 'pgsql') {
             try {
                 $result = \DB::table('migrations_install')->select('id')->orderBy('id', 'DESC')->first();
@@ -211,7 +217,7 @@ try {
             }
         }
 
-        Console::call('migrate', ['--path' => EVO_BASE_PATH . 'install/stubs/migrations', '--realpath' => true, '--force' => true]);
+        Console::call('migrate', ['--path' => $installMigrationsPath, '--realpath' => true, '--force' => true]);
 
         if ($installMode == 0) {
             seed('install');

--- a/install/src/functions.php
+++ b/install/src/functions.php
@@ -379,6 +379,63 @@ function getLangs($install_language)
     return implode("\n", $_);
 }
 
+/**
+ * Existing installs may carry a single synthetic baseline row instead of the
+ * full historical install migration list. Register those older migrations so
+ * upgrade mode only runs genuinely new schema changes.
+ */
+function bootstrapInstallMigrationHistory(string $migrationsPath, string $baselineMigration = '2025_12_25_000000_initial_schema'): int
+{
+    if (!class_exists(\Illuminate\Support\Facades\DB::class) ||
+        !class_exists(\Illuminate\Support\Facades\Schema::class)
+    ) {
+        return 0;
+    }
+
+    try {
+        if (!\Illuminate\Support\Facades\Schema::hasTable('migrations_install') ||
+            !\Illuminate\Support\Facades\Schema::hasTable('active_user_locks')
+        ) {
+            return 0;
+        }
+
+        $registered = \Illuminate\Support\Facades\DB::table('migrations_install')
+            ->pluck('migration')
+            ->all();
+
+        if (!in_array($baselineMigration, $registered, true)) {
+            return 0;
+        }
+
+        $historical = [];
+        foreach (glob(rtrim($migrationsPath, '/') . '/*.php') as $migrationFile) {
+            $migration = basename($migrationFile, '.php');
+            if (strcmp($migration, $baselineMigration) < 0 && !in_array($migration, $registered, true)) {
+                $historical[] = $migration;
+            }
+        }
+
+        if ($historical === []) {
+            return 0;
+        }
+
+        sort($historical);
+        $batch = (int) (\Illuminate\Support\Facades\DB::table('migrations_install')->max('batch') ?: 1);
+        $rows = array_map(static function ($migration) use ($batch) {
+            return [
+                'migration' => $migration,
+                'batch' => $batch,
+            ];
+        }, $historical);
+
+        \Illuminate\Support\Facades\DB::table('migrations_install')->insert($rows);
+
+        return count($historical);
+    } catch (\Throwable $exception) {
+        return 0;
+    }
+}
+
 function sortItem($array = [], $order = 'utf8mb4,utf8')
 {
     $rs = ['recommend' => ''];

--- a/install/src/lang.php
+++ b/install/src/lang.php
@@ -15,7 +15,7 @@ $_lang = [];
 #default fallback language file - english
 $install_language = 'en';
 
-$_langISO6391 = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+$_langISO6391 = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '', 0, 2);
 if (ctype_alpha($_langISO6391) && file_exists(__DIR__ . '/lang/' . $_langISO6391 . '.inc.php')) {
     $install_language = $_langISO6391;
 }


### PR DESCRIPTION
## Summary
- let loopback installer sessions recover instead of returning an opaque 404 after local cookie/session desync
- stop redefining `EVO_MANAGER_PATH` during install bootstrap
- bootstrap historical `migrations_install` entries before upgrade so existing SQLite installs do not rerun fresh schema creation
- guard missing `HTTP_ACCEPT_LANGUAGE` in installer language detection

## Verification
- `php -l` on all touched installer/bootstrap files
- smoke-tested installer landing page on `php -S` with no warning output
- reproduced loopback lock takeover with `POST /install/index.php?action=mode` returning `200`
- validated the migration-history bootstrap logic against the existing Evo SQLite upgrade shape
