### PR TITLE
[DEL] Remove Store self-update banner.

### DIFF
--- a/assets/modules/store/js/store.js
+++ b/assets/modules/store/js/store.js
@@ -70,17 +70,6 @@ store = {
 		};
 		return $.extend(obj1,param);
 	},
-	update:function(){
-		$.ajax({
-			url:'http://'+location.hostname+'/assets/modules/store/update.php',
-			cache:false,
-			data:{just:'empty'},
-			type:'get',
-			success:function(data){
-				window.location.reload();
-			}
-		})
-	},
 	verifyUser: function(){
 		if ($('[name="hash"]').val() !='') {
 			store.query('verifyuser',{'verify':'1'},function(data){
@@ -140,12 +129,6 @@ store = {
 			store.loadConsoleCatalog(function(){
 				store.finishCatalogBoot();
 			});
-
-			var version = $('.version').html();
-			if (data.version != version && version != '0.2.0') {
-					$('.new_version').html(data.version);
-					$('#actions').show();
-			}
 
 			if (data.user) {
 				store.showUserForms( data.user.result );

--- a/assets/modules/store/lang/en.php
+++ b/assets/modules/store/lang/en.php
@@ -15,7 +15,6 @@ $_Lang['alert_overwrite'] = "Installing this add-on will overwrite the existing 
 
 /*Main*/
 $_Lang['store_name'] = "Package Management";
-$_Lang['version_evailble'] = "A new version";
 $_Lang['category'] = "Categories";
 
 /*Login form*/

--- a/assets/modules/store/lang/it.php
+++ b/assets/modules/store/lang/it.php
@@ -14,7 +14,6 @@ $_Lang['alert_overwrite'] = "L'installazione di questo add-on sovrascrive quelli
 
 /*Main*/
 $_Lang['store_name'] = "Gestione Pacchetti";
-$_Lang['version_evailble'] = "Una nuova versione";
 $_Lang['category'] = "Categorie";
 
 /*Login form*/

--- a/assets/modules/store/lang/ja.php
+++ b/assets/modules/store/lang/ja.php
@@ -14,7 +14,6 @@ $_Lang['alert_overwrite'] = "すでに存在するアドオンを上書きしま
 
 /*Main*/
 $_Lang['store_name'] = "Package Management";
-$_Lang['version_evailble'] = "新しいバージョン";
 $_Lang['category'] = "カテゴリ";
 
 /*Login form*/

--- a/assets/modules/store/lang/nl.php
+++ b/assets/modules/store/lang/nl.php
@@ -14,7 +14,6 @@ $_Lang['alert_overwrite'] = "Installeren van deze add-on zal uw bestaande oversc
 
 /*Main*/
 $_Lang['store_name'] = "Pakket Manager";
-$_Lang['version_evailble'] = "Een nieuwe versie";
 $_Lang['category'] = "Categorieën";
 
 /*Login form*/

--- a/assets/modules/store/lang/ru.php
+++ b/assets/modules/store/lang/ru.php
@@ -14,7 +14,6 @@ $_Lang['alert_overwrite'] = "Установка данного дополнен�
 
 /*Main*/
 $_Lang['store_name'] = "Управление пакетами";
-$_Lang['version_evailble'] = "Доступна новая версия";
 $_Lang['category'] = "Категории";
 
 /*Login form*/

--- a/assets/modules/store/lang/uk.php
+++ b/assets/modules/store/lang/uk.php
@@ -15,7 +15,6 @@ $_Lang['alert_overwrite'] = "Встановлення цього доповне�
 
 /* Main */
 $_Lang['store_name'] = "Керування пакетами";
-$_Lang['version_evailble'] = "Доступна нова версія";
 $_Lang['category'] = "Категорії";
 
 /* Login form */

--- a/assets/modules/store/template/main.html
+++ b/assets/modules/store/template/main.html
@@ -21,9 +21,6 @@
       </span>
       <span class="pagetitle-text">[+store_name+]</span>
     </h1>
-    <div id="actions" style="display:none">
-        <span class="warning">[+version_evailble+]: <span class="new_version">0.2.0</span> (<a href="javascript:store.update()">[+update+]</a>)</span>
-    </div>
     <input type="hidden" name="console_category_label" value="[+console_category+]">
     <input type="hidden" name="installed_category_label" value="Installed">
     <input type="hidden" name="reinstall_label" value="[+reinstall+]">

--- a/core/tests/Unit/Store/StoreSelfUpdateBannerTest.php
+++ b/core/tests/Unit/Store/StoreSelfUpdateBannerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+test('store module does not expose legacy self update banner', function () {
+    $template = file_get_contents(dirname(__DIR__, 4) . '/assets/modules/store/template/main.html');
+    $script = file_get_contents(dirname(__DIR__, 4) . '/assets/modules/store/js/store.js');
+    $languageFiles = glob(dirname(__DIR__, 4) . '/assets/modules/store/lang/*.php');
+
+    expect($template)->not->toContain('id="actions"')
+        ->and($template)->not->toContain('version_evailble')
+        ->and($template)->not->toContain('new_version')
+        ->and($template)->not->toContain('javascript:store.update()')
+        ->and($script)->not->toContain('/assets/modules/store/update.php')
+        ->and($script)->not->toContain('new_version')
+        ->and($script)->not->toContain('#actions')
+        ->and($script)->not->toMatch('/\bupdate\s*:\s*function\b/');
+
+    foreach ($languageFiles as $languageFile) {
+        expect(file_get_contents($languageFile))->not->toContain('version_evailble');
+    }
+});


### PR DESCRIPTION
## Summary
- Removed the legacy Store self-update banner from the Package Management module header.
- Removed the old `store.update()` client-side updater call to `assets/modules/store/update.php`.
- Removed the now-unused `version_evailble` language key from Store translations.
- Added a regression test that keeps this legacy self-update UI from coming back.

## Why
Store is now shipped as a system module inside Evolution CMS, so it should not advertise or trigger a separate module-level update flow. Package update/install UI for actual Extras remains untouched.

## Validation
- `php -l` for changed Store language files and the new test.
- `node --check assets/modules/store/js/store.js`.
- `vendor/bin/pest tests/Unit/Store/StoreSelfUpdateBannerTest.php`.
- `vendor/bin/pest tests/Unit` was also checked after installing local dev test dependencies. The new Store test passed; the full suite still has pre-existing unrelated failures in `ManagerAclBaselineRepairTest`, `LockoutHomeButtonLabelTest`, `LoginSiteNameEscapingTest`, and `RemoveLocksConfirmMessageTest` on the current base branch.
