### PR TITLE
fix(updater): [UPD] isolate core migration update step

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -215,8 +215,7 @@ HELP;
             $this->installComposerDependencies();
             $this->line('<fg=green>Rebuild optimized autoload</>');
             $this->runCoreShellCommand('composer dump-autoload -o --no-dev --classmap-authoritative');
-            $this->line('<fg=green>Run Core Migrations</>');
-            $this->runCoreShellCommand('php artisan migrate --force');
+            $this->runCoreMigrations();
 
             $this->line('<fg=green>Remove Install Directory</>');
             self::rmdirs(EVO_BASE_PATH . 'install');
@@ -225,6 +224,18 @@ HELP;
         } else {
             $this->line('<fg=yellow;bg=blue>You use almost current version</>');
         }
+    }
+
+    /**
+     * Run database migrations shipped with the updated core.
+     *
+     * @since 3.5.7
+     * @return void
+     */
+    protected function runCoreMigrations(): void
+    {
+        $this->line('<fg=green>Run Core Migrations</>');
+        $this->runCoreShellCommand('php artisan migrate --force');
     }
 
     /**

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -51,6 +51,7 @@ test('normalizeUpdateRepository trims custom repository slugs', function () {
 test('site updater runs core migrations during updates', function () {
     $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/SiteUpdateCommand.php');
 
+    expect($source)->toContain('$this->runCoreMigrations();');
     expect($source)->toContain("runCoreShellCommand('php artisan migrate --force')");
     expect($source)->not->toContain('cli-install.php --typeInstall=2');
 });
@@ -65,7 +66,7 @@ test('site updater repairs composer vendor state before artisan commands', funct
         ->not->toContain('new Application()')
         ->not->toContain("runCoreShellCommand('composer update')");
 
-    expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, 'php artisan migrate --force'));
+    expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
 });
 
 test('site updater builds constrained composer update for custom packages', function () {


### PR DESCRIPTION
## Summary
- Replaces the conflicting updater migration PR #2312 with a clean branch based on the current `3.5.x` head.
- Keeps the core database migration step explicit by moving `php artisan migrate --force` into `runCoreMigrations()`.
- Preserves the already merged updater fixes from #2314, including Composer dependency repair before migrations and custom Composer package handling.

## Why
The old #2312 branch correctly targeted the SQL/core migration gap, but applying it directly now would regress newer updater logic already merged into `3.5.x`. This PR carries the same intent forward without reintroducing the old Composer/update flow.

## Verification
- `vendor/bin/pest tests/Unit/Console/SiteUpdateCommandTest.php` — 9 passed, 18 assertions.
- `vendor/bin/pest tests/Unit` was also checked; unrelated existing failures remain outside this change, while `SiteUpdateCommandTest` passed.
