### PR TITLE
fix(updater): [UPD] install core dependencies before custom updates

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -277,14 +277,13 @@ HELP;
     {
         $customPackages = $this->resolveCustomComposerPackages();
 
+        $this->line('<fg=green>Install Composer dependencies</>');
+        $this->runCoreShellCommand($this->composerInstallCommand());
+
         if ($customPackages !== []) {
             $this->line('<fg=green>Install Composer dependencies with custom packages</>');
             $this->runCoreShellCommand($this->buildCustomComposerUpdateCommand($customPackages));
-            return;
         }
-
-        $this->line('<fg=green>Install Composer dependencies</>');
-        $this->runCoreShellCommand('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative');
     }
 
     /**
@@ -360,6 +359,11 @@ HELP;
         return 'composer update '
             . implode(' ', array_map('escapeshellarg', $packages))
             . ' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative';
+    }
+
+    protected function composerInstallCommand(): string
+    {
+        return 'composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative';
     }
 
     protected function normalizeUpdateRepository(string $repository): string

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -60,13 +60,16 @@ test('site updater repairs composer vendor state before artisan commands', funct
     $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/SiteUpdateCommand.php');
 
     expect($source)
-        ->toContain("composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative")
+        ->toContain('$this->composerInstallCommand()')
         ->toContain('buildCustomComposerUpdateCommand')
         ->toContain("composer dump-autoload -o --no-dev --classmap-authoritative")
         ->not->toContain('new Application()')
         ->not->toContain("runCoreShellCommand('composer update')");
 
     expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
+    expect(strpos($source, '$this->composerInstallCommand()'))->toBeLessThan(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'));
+    expect(invokeSiteUpdateMethod($this->command, 'composerInstallCommand'))
+        ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative');
 });
 
 test('site updater builds constrained composer update for custom packages', function () {


### PR DESCRIPTION
## Summary

This fixes the site updater path used when `core/custom/composer.json` is present. The updater now always repairs the core Composer vendor state with `composer install` after replacing files, then runs the constrained custom package update only after the core dependencies are aligned with the new lock file.

## Why

A branch/ref update could report success while leaving Composer autoload files pointing at dependencies that were no longer present after the update. That made the manager fail on the next request even though the system task was marked as completed.

## Verification

- `php -l core/src/Console/SiteUpdateCommand.php`
- `vendor/bin/pest tests/Unit/Console/SiteUpdateCommandTest.php`
- Local smoke check: repaired demo vendor autoload and confirmed the manager login page loads instead of the Composer autoload fatal.
