### PR TITLE
fix(updater): [UPD] delay package discovery during composer repair

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -284,6 +284,9 @@ HELP;
             $this->line('<fg=green>Install Composer dependencies with custom packages</>');
             $this->runCoreShellCommand($this->buildCustomComposerUpdateCommand($customPackages));
         }
+
+        $this->line('<fg=green>Discover Composer packages</>');
+        $this->runCoreShellCommand('php artisan package:discover');
     }
 
     /**
@@ -358,12 +361,12 @@ HELP;
 
         return 'composer update '
             . implode(' ', array_map('escapeshellarg', $packages))
-            . ' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative';
+            . ' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
     }
 
     protected function composerInstallCommand(): string
     {
-        return 'composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative';
+        return 'composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
     }
 
     protected function normalizeUpdateRepository(string $repository): string

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -62,14 +62,16 @@ test('site updater repairs composer vendor state before artisan commands', funct
     expect($source)
         ->toContain('$this->composerInstallCommand()')
         ->toContain('buildCustomComposerUpdateCommand')
-        ->toContain("composer dump-autoload -o --no-dev --classmap-authoritative")
+        ->toContain("runCoreShellCommand('php artisan package:discover')")
+        ->toContain('--no-scripts')
         ->not->toContain('new Application()')
         ->not->toContain("runCoreShellCommand('composer update')");
 
     expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
     expect(strpos($source, '$this->composerInstallCommand()'))->toBeLessThan(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'));
+    expect(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'))->toBeLessThan(strpos($source, "runCoreShellCommand('php artisan package:discover')"));
     expect(invokeSiteUpdateMethod($this->command, 'composerInstallCommand'))
-        ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative');
+        ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts');
 });
 
 test('site updater builds constrained composer update for custom packages', function () {
@@ -83,5 +85,5 @@ test('site updater builds constrained composer update for custom packages', func
     ]]);
 
     expect($command)
-        ->toBe("composer update 'evolution-cms/eai' 'seiger/stask' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative");
+        ->toBe("composer update 'evolution-cms/eai' 'seiger/stask' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts");
 });


### PR DESCRIPTION
## Summary

Follow-up for the updater Composer repair path. Composer scripts are now disabled while the updater repairs core and custom dependencies, then `php artisan package:discover` is executed explicitly after the final autoload state is valid.

## Why

When a site has providers from `core/custom/composer.json`, Composer can run the `post-autoload-dump` `package:discover` script before the custom package autoload is fully restored. That can make the manager fail on providers such as custom package service providers even after the update task has already completed.

## Verification

- `php -l core/src/Console/SiteUpdateCommand.php`
- `vendor/bin/pest tests/Unit/Console/SiteUpdateCommandTest.php`
- Local smoke: repaired demo custom vendor state and confirmed both custom package providers resolve before running `php artisan package:discover` and migrations.
