### PR TITLE
fix(updater): [FIX] restore custom composer update order

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -72,15 +72,23 @@ HELP;
      */
     public function handle()
     {
-        switch ($this->argument('command_site')) {
-            case 'pizdato':
-                echo 'Remove MODX REVO and install Evolution CMS' . "\n";
-                $this->startUpdate();
-                break;
-            case 'update':
-                $this->startUpdate();
-                break;
+        try {
+            switch ($this->argument('command_site')) {
+                case 'pizdato':
+                    echo 'Remove MODX REVO and install Evolution CMS' . "\n";
+                    $this->startUpdate();
+                    return self::SUCCESS;
+
+                case 'update':
+                    $this->startUpdate();
+                    return self::SUCCESS;
+            }
+        } catch (\Throwable $exception) {
+            $this->error($exception->getMessage());
+            return self::FAILURE;
         }
+
+        return self::FAILURE;
     }
 
     /**
@@ -213,8 +221,6 @@ HELP;
             }
             putenv('COMPOSER_HOME=' . EVO_CORE_PATH . 'composer');
             $this->installComposerDependencies();
-            $this->line('<fg=green>Rebuild optimized autoload</>');
-            $this->runCoreShellCommand('composer dump-autoload -o --no-dev --classmap-authoritative');
             $this->runCoreMigrations();
 
             $this->line('<fg=green>Remove Install Directory</>');
@@ -277,13 +283,16 @@ HELP;
     {
         $customPackages = $this->resolveCustomComposerPackages();
 
-        $this->line('<fg=green>Install Composer dependencies</>');
-        $this->runCoreShellCommand($this->composerInstallCommand());
-
         if ($customPackages !== []) {
-            $this->line('<fg=green>Install Composer dependencies with custom packages</>');
+            $this->line('<fg=green>Update Composer dependencies with custom packages</>');
             $this->runCoreShellCommand($this->buildCustomComposerUpdateCommand($customPackages));
+        } else {
+            $this->line('<fg=green>Install Composer dependencies</>');
+            $this->runCoreShellCommand($this->composerInstallCommand());
         }
+
+        $this->line('<fg=green>Rebuild optimized autoload</>');
+        $this->runCoreShellCommand($this->composerDumpAutoloadCommand());
 
         $this->line('<fg=green>Discover Composer packages</>');
         $this->runCoreShellCommand('php artisan package:discover');
@@ -367,6 +376,11 @@ HELP;
     protected function composerInstallCommand(): string
     {
         return 'composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
+    }
+
+    protected function composerDumpAutoloadCommand(): string
+    {
+        return 'composer dump-autoload -o --no-dev --classmap-authoritative --no-scripts';
     }
 
     protected function normalizeUpdateRepository(string $repository): string

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -62,16 +62,21 @@ test('site updater repairs composer vendor state before artisan commands', funct
     expect($source)
         ->toContain('$this->composerInstallCommand()')
         ->toContain('buildCustomComposerUpdateCommand')
+        ->toContain('$this->composerDumpAutoloadCommand()')
         ->toContain("runCoreShellCommand('php artisan package:discover')")
         ->toContain('--no-scripts')
+        ->toContain('return self::FAILURE')
+        ->toContain('catch (\Throwable $exception)')
         ->not->toContain('new Application()')
         ->not->toContain("runCoreShellCommand('composer update')");
 
     expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
-    expect(strpos($source, '$this->composerInstallCommand()'))->toBeLessThan(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'));
-    expect(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'))->toBeLessThan(strpos($source, "runCoreShellCommand('php artisan package:discover')"));
+    expect(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'))->toBeLessThan(strpos($source, '$this->composerDumpAutoloadCommand()'));
+    expect(strpos($source, '$this->composerDumpAutoloadCommand()'))->toBeLessThan(strpos($source, "runCoreShellCommand('php artisan package:discover')"));
     expect(invokeSiteUpdateMethod($this->command, 'composerInstallCommand'))
         ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts');
+    expect(invokeSiteUpdateMethod($this->command, 'composerDumpAutoloadCommand'))
+        ->toBe('composer dump-autoload -o --no-dev --classmap-authoritative --no-scripts');
 });
 
 test('site updater builds constrained composer update for custom packages', function () {
@@ -86,4 +91,10 @@ test('site updater builds constrained composer update for custom packages', func
 
     expect($command)
         ->toBe("composer update 'evolution-cms/eai' 'seiger/stask' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts");
+});
+
+test('site updater updates custom packages before install-only path', function () {
+    $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/SiteUpdateCommand.php');
+
+    expect(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'))->toBeLessThan(strpos($source, '$this->composerInstallCommand()'));
 });


### PR DESCRIPTION
## Summary

Restores the correct Composer order for scheduler-driven site updates when `core/custom/composer.json` is present.

- Sites with custom Composer packages now run the constrained custom package `composer update ... --no-scripts` first, so the copied core lock file is refreshed with the merged custom requirements.
- Clean core installs still use `composer install ... --no-scripts`.
- Optimized autoload rebuild and `php artisan package:discover` run only after Composer dependencies are in a valid final state.
- `make:site` now returns `FAILURE` when the update command throws, so scheduler tasks are marked failed instead of completed when Composer breaks.

## Root cause

After #2316/#2317 the updater ran `composer install` before refreshing the lock for `core/custom/composer.json`. Composer correctly failed with `Required package "evolution-cms/eai" is not present in the lock file`, but the scheduler flow still reported the site update task as successful.

## Verification

- `php -l core/src/Console/SiteUpdateCommand.php`
- `vendor/bin/pest tests/Unit/Console/SiteUpdateCommandTest.php`
- Local demo composer repair: custom package providers resolve, `php artisan package:discover`, and `php artisan migrate --force` pass.
