### PR TITLE
fix(core): [FIX] share addDataToView data with Blade views

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -3105,13 +3105,15 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
                     ];
                 }
 
-                $this['view']->share($data);
+                $viewData = $this->getDataForView();
+
+                $this['view']->share(array_merge($data, $viewData));
 
                 if ($this->isChunkProcessor('DLTemplate')) {
-                    app('DLTemplate')->blade->share($data);
+                    app('DLTemplate')->blade->share(array_merge($data, $viewData));
                 }
 
-                $tpl = $this['view']->make($template, $this->dataForView);
+                $tpl = $this['view']->make($template, $viewData);
                 $templateCode = $tpl->render();
             } else {
                 // get the template and start parsing!
@@ -6639,15 +6641,32 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
 
     /**
      * @param array $data
+     * @return $this
      */
     public function addDataToView($data = [])
     {
+        if (!is_array($data)) {
+            return $this;
+        }
+
         $this->dataForView = array_merge($this->dataForView, $data);
+        $this->shareDataForView($data);
+
+        return $this;
     }
 
     public function getDataForView()
     {
         return $this->dataForView;
+    }
+
+    protected function shareDataForView(array $data): void
+    {
+        if ($data === [] || !$this->bound('view')) {
+            return;
+        }
+
+        $this['view']->share($data);
     }
 
     /**

--- a/core/tests/Unit/CoreAddDataToViewTest.php
+++ b/core/tests/Unit/CoreAddDataToViewTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use EvolutionCMS\Core;
+
+function makeCoreForViewDataTest(): Core
+{
+    return (new ReflectionClass(Core::class))->newInstanceWithoutConstructor();
+}
+
+function makeViewFactoryForViewDataTest(): object
+{
+    return new class {
+        public array $shared = [];
+
+        public function share($key, $value = null)
+        {
+            if (is_array($key)) {
+                $this->shared = array_merge($this->shared, $key);
+
+                return $key;
+            }
+
+            $this->shared[$key] = $value;
+
+            return $value;
+        }
+    };
+}
+
+describe('addDataToView', function () {
+
+    test('it stores data and shares it with the view factory', function () {
+        $core = makeCoreForViewDataTest();
+        $view = makeViewFactoryForViewDataTest();
+        $core->instance('view', $view);
+
+        $result = $core->addDataToView([
+            'headline' => 'Shared headline',
+            'meta' => ['source' => 'unit-test'],
+        ]);
+
+        expect($result)->toBe($core)
+            ->and($core->getDataForView())->toMatchArray([
+                'headline' => 'Shared headline',
+                'meta' => ['source' => 'unit-test'],
+            ])
+            ->and($view->shared)->toMatchArray([
+                'headline' => 'Shared headline',
+                'meta' => ['source' => 'unit-test'],
+            ]);
+    });
+
+    test('it ignores non-array data without clearing existing view data', function () {
+        $core = makeCoreForViewDataTest();
+        $view = makeViewFactoryForViewDataTest();
+        $core->instance('view', $view);
+
+        $core->addDataToView(['headline' => 'Shared headline']);
+
+        $result = $core->addDataToView('not-an-array');
+
+        expect($result)->toBe($core)
+            ->and($core->getDataForView())->toMatchArray([
+                'headline' => 'Shared headline',
+            ])
+            ->and($view->shared)->toMatchArray([
+                'headline' => 'Shared headline',
+            ]);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #2321.

`evo()->addDataToView()` already stored the payload in the internal view-data buffer, but that data was only passed directly to the top-level Blade template render. The data was not also shared through the Laravel view factory, so nested or separately rendered Blade views could miss the values and debugging showed the private `dataForView` buffer instead of a public access path.

This keeps `dataForView` encapsulated and exposes the data through the view layer instead of making the property public.

## What changed

- `Core::addDataToView()` now validates array input, keeps returning the Core instance for chaining, stores the data, and shares it with the bound view factory.
- Blade document rendering now uses `getDataForView()` and shares the merged core document data plus added view data with both the main view factory and DLTemplate blade bridge.
- Added a focused unit test covering stored data, shared view data, and safe non-array input handling.

## Verification

- `php -l core/src/Core.php`
- `php -l core/tests/Unit/CoreAddDataToViewTest.php`
- `./vendor/bin/pest tests/Unit/CoreAddDataToViewTest.php` passed locally after installing dev dependencies for the test run.

## Database matrix

Not applicable. This change does not touch schema, migrations, seed data, or update-time database repair.
