### PR TITLE
fix(tests): [FIX] namespace console uninstall test handler

### DIFF
--- a/core/tests/Unit/SystemTasks/ConsoleUninstallRegistryTest.php
+++ b/core/tests/Unit/SystemTasks/ConsoleUninstallRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Unit\SystemTasks;
+
 use EvolutionCMS\Services\SystemTasks\ConsoleUninstall\ConsoleUninstallHandlerInterface;
 use EvolutionCMS\Services\SystemTasks\ConsoleUninstall\ConsoleUninstallPlan;
 use EvolutionCMS\Services\SystemTasks\ConsoleUninstall\ConsoleUninstallRegistry;


### PR DESCRIPTION
## Summary

This PR fixes a Composer PSR-4 warning emitted during optimized autoload generation.

`core/tests/Unit/SystemTasks/ConsoleUninstallRegistryTest.php` declares `TestConsoleUninstallHandler`, but the file lives under the `Tests\ => tests/` dev autoload tree. Without a namespace, Composer sees a global class in a PSR-4 path and skips it during `composer dump-autoload -o`.

## Changes

- Added the `Tests\Unit\SystemTasks` namespace to `ConsoleUninstallRegistryTest.php`.
- Kept the helper class in the same test file, now matching its PSR-4 path.

## Validation

- `php -l core/tests/Unit/SystemTasks/ConsoleUninstallRegistryTest.php`
- `composer dump-autoload -o` from `core` no longer reports the `TestConsoleUninstallHandler` PSR-4 warning.
