### PR TITLE
fix(backup): [FIX] preserve SQL import string delimiters

### DIFF
--- a/core/functions/actions/bkmanager.php
+++ b/core/functions/actions/bkmanager.php
@@ -1,4 +1,113 @@
 <?php
+if (!function_exists('import_sql_split_statements')) {
+    /**
+     * Split SQL dumps on statement delimiters without breaking values that contain semicolons.
+     *
+     * Backup dumps can contain PHP code inside SQL string literals, for example @EVAL TV values.
+     * A plain preg_split on ";\\n" breaks those rows when the PHP code itself contains semicolons.
+     *
+     * @param string $source
+     * @return array
+     */
+    function import_sql_split_statements($source)
+    {
+        $statements = [];
+        $statement = '';
+        $quote = null;
+        $lineComment = false;
+        $blockComment = false;
+        $length = strlen($source);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $source[$i];
+            $next = $source[$i + 1] ?? null;
+
+            if ($lineComment) {
+                $statement .= $char;
+                if ($char === "\n") {
+                    $lineComment = false;
+                }
+                continue;
+            }
+
+            if ($blockComment) {
+                $statement .= $char;
+                if ($char === '*' && $next === '/') {
+                    $statement .= $next;
+                    $i++;
+                    $blockComment = false;
+                }
+                continue;
+            }
+
+            if ($quote !== null) {
+                $statement .= $char;
+
+                if ($char === '\\' && $quote !== '`' && $next !== null) {
+                    $statement .= $next;
+                    $i++;
+                    continue;
+                }
+
+                if ($char === $quote) {
+                    if ($next === $quote) {
+                        $statement .= $next;
+                        $i++;
+                        continue;
+                    }
+
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ($char === '-' && $next === '-') {
+                $statement .= $char . $next;
+                $i++;
+                $lineComment = true;
+                continue;
+            }
+
+            if ($char === '#') {
+                $statement .= $char;
+                $lineComment = true;
+                continue;
+            }
+
+            if ($char === '/' && $next === '*') {
+                $statement .= $char . $next;
+                $i++;
+                $blockComment = true;
+                continue;
+            }
+
+            if ($char === '\'' || $char === '"' || $char === '`') {
+                $statement .= $char;
+                $quote = $char;
+                continue;
+            }
+
+            if ($char === ';') {
+                $sql = trim($statement, "\r\n\t ;");
+                if ($sql !== '') {
+                    $statements[] = $sql;
+                }
+                $statement = '';
+                continue;
+            }
+
+            $statement .= $char;
+        }
+
+        $sql = trim($statement, "\r\n\t ;");
+        if ($sql !== '') {
+            $statements[] = $sql;
+        }
+
+        return $statements;
+    }
+}
+
 if(!function_exists('import_sql')) {
     /**
      * @param string $source
@@ -23,7 +132,7 @@ if(!function_exists('import_sql')) {
                 "\r"
             ], "\n", $source);
         }
-        $sql_array = preg_split('@;[ \t]*\n@', $source);
+        $sql_array = import_sql_split_statements($source);
         $driver = $modx->getDatabase()->getConfig('driver');
         foreach ($sql_array as $sql_entry) {
             $sql_entry = trim($sql_entry, "\r\n; ");

--- a/core/tests/Unit/BackupManagerSqlImportSplitTest.php
+++ b/core/tests/Unit/BackupManagerSqlImportSplitTest.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once __DIR__ . '/../../functions/actions/bkmanager.php';
+
+test('backup manager import keeps semicolons inside sqlite string literals', function () {
+    $sql = <<<'SQL'
+-- Dumping data for table `evo_site_tmplvars`
+INSERT INTO "evo_site_tmplvars" VALUES
+  ('3','checkbox','tags','tags','','0','1','0','@EVAL return ''||''.EvolutionCMS\Models\SiteContent::whereIn(''parent'',[2,3])->where(''isfolder'',0)->get()->map(function ($product) {
+    return "{$product->pagetitle} ({$product->id})=={$product->id}";
+})->implode(''||'');','0',NULL,NULL,'0','1776962019','1776971909',NULL);
+
+CREATE TABLE "after_restore" ("id" integer not null primary key autoincrement);
+SQL;
+
+    $statements = import_sql_split_statements($sql);
+
+    expect($statements)->toHaveCount(2)
+        ->and($statements[0])->toContain('@EVAL return')
+        ->and($statements[0])->toContain('return "{$product->pagetitle} ({$product->id})=={$product->id}";')
+        ->and($statements[1])->toContain('CREATE TABLE "after_restore"');
+});
+
+test('backup manager import ignores semicolons inside quoted values and comments', function () {
+    $sql = <<<'SQL'
+INSERT INTO "sample" VALUES ('single; quote', "double; quote");
+-- comment with ; delimiter
+/* block ; comment */
+INSERT INTO `sample` VALUES (`identifier; value`, 'done');
+SQL;
+
+    $statements = import_sql_split_statements($sql);
+
+    expect($statements)->toHaveCount(2)
+        ->and($statements[0])->toBe('INSERT INTO "sample" VALUES (\'single; quote\', "double; quote")')
+        ->and($statements[1])->toContain('INSERT INTO `sample` VALUES (`identifier; value`, \'done\')');
+});


### PR DESCRIPTION
## Summary

Fixes #2329.

SQLite backup restore could fail when a dumped value contains PHP code with an internal semicolon, for example a TV `@EVAL` binding. The dump itself quotes the value correctly, but the Backup Manager restore path split SQL with a plain `;\n` regex before executing it. That split cuts the `INSERT` in the middle of the quoted `@EVAL` value and SQLite receives an invalid partial statement.

## Changes

- Replaced the plain SQL split with a small SQL-aware statement splitter for Backup Manager imports.
- The splitter keeps semicolons inside single-quoted strings, double-quoted identifiers/strings, backtick identifiers, and comments.
- Added regression coverage for the SQLite `@EVAL` TV restore case with mixed quotes, multiline PHP code, and an internal semicolon.

## Validation

- `php -l core/functions/actions/bkmanager.php`
- `php -l core/tests/Unit/BackupManagerSqlImportSplitTest.php`
- Manual SQLite smoke test: split and execute a dump containing the reported `@EVAL` value against `sqlite::memory:` successfully.
- `composer dump-autoload -o`

Note: the local checkout currently has no `vendor/bin/pest`, so the targeted Pest command cannot run locally here. The regression test is included for CI / complete dev vendor installs.
