### PR TITLE
fix(backup): [FIX] clean backup list tooltip

### DIFF
--- a/core/tests/Unit/Manager/BackupManagerTooltipMarkupTest.php
+++ b/core/tests/Unit/Manager/BackupManagerTooltipMarkupTest.php
@@ -1,0 +1,12 @@
+<?php
+
+test('backup manager tooltip uses clean plain text lines', function () {
+    $basePath = dirname(__DIR__, 4) . DIRECTORY_SEPARATOR;
+    $backupManager = file_get_contents($basePath . 'manager/actions/bkmanager.static.php');
+    $tooltipCss = file_get_contents($basePath . 'manager/media/style/default/css/custom.css');
+
+    expect($backupManager)->toContain('implode("\n", $tooltipLines)')
+        ->and($backupManager)->not->toContain('\n<br>')
+        ->and($backupManager)->toContain("['Server version', 'PHP Version', 'Host']")
+        ->and($tooltipCss)->toContain('white-space: pre-line');
+});

--- a/manager/actions/bkmanager.static.php
+++ b/manager/actions/bkmanager.static.php
@@ -606,21 +606,23 @@ if (isset($_SESSION['result_msg']) && $_SESSION['result_msg'] != '') {
                                         };
                                         fclose($file);
 
-                                        $tooltip = "Generation Time: " . ($details["Generation Time"] ?? 'Undefined') . "\n<br>";
-                                        $tooltip .= "Server version: " . ($details["Server version"] ?? 'Undefined') . "\n<br>";
-                                        $tooltip .= "PHP Version: " . ($details["PHP Version"] ?? 'Undefined') . "\n<br>";
-                                        $tooltip .= "Host: " . ($details["Host"] ?? 'Undefined') . "\n";
+                                        $tooltipLines = [];
+                                        foreach (['Server version', 'PHP Version', 'Host'] as $label) {
+                                            if (!empty($details[$label])) {
+                                                $tooltipLines[] = $label . ': ' . $details[$label];
+                                            }
+                                        }
+                                        $tooltip = htmlspecialchars(implode("\n", $tooltipLines), ENT_QUOTES, ManagerTheme::getCharset());
                                         ?>
                                         <tr>
                                             <td><?= $filename ?></td>
-                                            <td><i class="<?= $_style['icon_question_circle'] ?>"
-                                                   data-tooltip="<?= $tooltip ?>"></i></td>
+                                            <td><?= $tooltip !== '' ? '<i class="' . $_style['icon_question_circle'] . '" data-tooltip="' . $tooltip . '"></i>' : '' ?></td>
                                             <td><?= $filesize ?></td>
                                             <td><?= ($details['Description'] ?? 'Undefined') ?></td>
                                             <td><?= ($details['Evolution CMS Version'] ?? 'Undefined') ?></td>
                                             <td><?= ($details['Database'] ?? 'Undefined') ?></td>
                                             <td><a href="javascript:;" onclick="confirmRevert('<?= $filename ?>');"
-                                                   title="<?= $tooltip ?>"><?= $_lang["bkmgr_restore_submit"] ?></a>
+                                                   title="<?= $tooltip !== '' ? $tooltip : $_lang["bkmgr_restore_submit"] ?>"><?= $_lang["bkmgr_restore_submit"] ?></a>
                                             </td>
                                         </tr>
                                         <?php

--- a/manager/media/style/default/css/custom.css
+++ b/manager/media/style/default/css/custom.css
@@ -285,7 +285,7 @@ ul.sortableList li { position: relative; z-index: 1; float: left; clear: both; m
     border: 1px solid #ccc; line-height: 1.23076923; background-color: #fff; -webkit-transform: translate3d(0, 0, 0); transform: translate3d(0, 0, 0); box-shadow: none; transition: color .3s, box-shadow .3s, transform .3s, z-index .3s step-end; }
 ul.sortableList li.ghost { z-index: 2; box-shadow: 0 0.25rem 1.5rem rgba(0, 0, 0, 0.15); transition: color .3s, box-shadow .3s, transform 0s, z-index 0s; }
 /* [ TOOLTIPS ] */
-.evo-tooltip, .custom-tip { position: fixed; z-index: 13000; width: 13rem; margin: 1rem; padding: 0.9rem 1rem; font-size: 0.75rem; line-height: 1.5; font-family: inherit; text-align: left; color: #333; background-color: #fff; visibility: hidden; transition-duration: .3s; transform: translate3d(1rem, 0, 0); -webkit-box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.15); box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.15); }
+.evo-tooltip, .custom-tip { position: fixed; z-index: 13000; width: 13rem; margin: 1rem; padding: 0.9rem 1rem; font-size: 0.75rem; line-height: 1.5; font-family: inherit; text-align: left; white-space: pre-line; color: #333; background-color: #fff; visibility: hidden; transition-duration: .3s; transform: translate3d(1rem, 0, 0); -webkit-box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.15); box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.15); }
 .evo-tooltip { opacity: 0; content: attr(data-tooltip); }
 .evo-tooltip.show { opacity: 1; visibility: visible; transform: translate3d(0, 0, 0); }
 [data-tooltip] { cursor: help }


### PR DESCRIPTION
## Summary

Fixes #2330.

This PR cleans up the Backup Manager backup-list tooltip. The tooltip was built with `<br>` fragments inside a `data-tooltip` attribute, which could appear as raw text in the UI. It also always included noisy details such as generation time and an empty host line.

## Changes

- Build backup-list tooltip content as plain text lines separated by newlines instead of inline HTML.
- Render tooltip newlines with `white-space: pre-line`.
- Keep only relevant technical details in the hover tooltip: server version, PHP version, and host only when present.
- Hide the question-mark icon when there is no tooltip content.
- Added regression coverage to keep the Backup Manager tooltip plain-text and prevent `<br>` from returning.

## Validation

- `php -l manager/actions/bkmanager.static.php`
- `php -l core/tests/Unit/Manager/BackupManagerTooltipMarkupTest.php`
- Manual PHP smoke check for tooltip output: no `<br>`, no `Generation Time`, no empty `Host`.
- `composer dump-autoload -o`

Note: the local checkout currently has no `vendor/bin/pest`, so the targeted Pest command cannot run locally here. The regression test is included for CI / complete dev vendor installs.
