### PR TITLE
fix(manager): [FIX] sanitize resource lock alert

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -3399,7 +3399,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
                 <script>
                     function __alertQuit() {
                         var el = document.querySelector('p');
-                        alert(el.innerHTML);
+                        alert(el.textContent || el.innerText || '');
                         el.remove();
                         " . $fnc . "
                     }

--- a/core/tests/Unit/Manager/WebAlertAndQuitPlainTextTest.php
+++ b/core/tests/Unit/Manager/WebAlertAndQuitPlainTextTest.php
@@ -1,0 +1,9 @@
+<?php
+
+it('passes web alert content to the native alert as plain text', function () {
+    $core = file_get_contents(dirname(__DIR__, 3) . '/src/Core.php');
+
+    expect($core)
+        ->toContain("alert(el.textContent || el.innerText || '')")
+        ->not->toContain('alert(el.innerHTML)');
+});


### PR DESCRIPTION
## Summary
- Fixes #2333.
- Sends `webAlertAndQuit()` messages to native `alert()` as plain text so browser dialogs do not display raw HTML tags.
- Keeps the existing alert document markup intact for manager rendering, only changing the native dialog boundary.

## Why
Native browser dialogs do not render HTML. Some localized lock messages include formatting tags, so `innerHTML` leaked `<b>` tags into the alert shown when another user has a resource locked.

## Validation
- `php -l core/src/Core.php`
- `php -l core/tests/Unit/Manager/WebAlertAndQuitPlainTextTest.php`
- `git diff --check`

Targeted Pest execution was attempted, but this checkout does not include `vendor/bin/pest`, so the local runner cannot start here.