### PR TITLE
fix(lang): [FIX] localize Ukrainian config notice

### DIFF
--- a/core/lang/uk/global.php
+++ b/core/lang/uk/global.php
@@ -1497,7 +1497,7 @@ $_lang['site_indexing_message'] = 'Керування метатегом robots 
 $_lang["ignore"] = 'Не враховувати';
 $_lang["indexing_is_allowed"] = 'Індексацію дозволено';
 $_lang["indexing_is_prohibited"] = 'Індексацію заборонено';
-$_lang["setting_from_file"] = '<strong class="text-danger">Значение параметра задано в core/custom/config/cms/settings</strong>';
+$_lang["setting_from_file"] = '<strong class="text-danger">Значення параметра задано в core/custom/config/cms/settings</strong>';
 
 $_lang["file_groups_saved"] = 'Права доступу збережено.';
 $_lang["file_groups_edit"] = 'Редагувати права доступу';

--- a/core/tests/Unit/Manager/UkSettingFromFileLocalizationTest.php
+++ b/core/tests/Unit/Manager/UkSettingFromFileLocalizationTest.php
@@ -1,0 +1,10 @@
+<?php
+
+it('uses Ukrainian text for config-file-defined setting notices', function () {
+    $_lang = [];
+    include dirname(__DIR__, 3) . '/lang/uk/global.php';
+
+    expect($_lang['setting_from_file'])
+        ->toContain('Значення параметра задано')
+        ->not->toContain('Значение параметра задано');
+});


### PR DESCRIPTION
## Summary
- Fixes #2335.
- Updates the Ukrainian `setting_from_file` manager notice from Russian to Ukrainian.
- Adds a small regression test to keep the Ukrainian notice from drifting back to Russian text.

## Why
When the manager language is Ukrainian, overridden system settings should show the config-file notice in Ukrainian like the rest of the System Settings UI.

## Validation
- `php -l core/lang/uk/global.php`
- `php -l core/tests/Unit/Manager/UkSettingFromFileLocalizationTest.php`
- `php -r` smoke check for the loaded Ukrainian `setting_from_file` value
- `git diff --check`

Targeted Pest execution was attempted, but this checkout does not include `vendor/bin/pest`, so the local runner cannot start here.