### PR TITLE
[FIX] Space Manage Elements view options controls

### DIFF
--- a/core/tests/Unit/Manager/ViewOptionsPanelLayoutTest.php
+++ b/core/tests/Unit/Manager/ViewOptionsPanelLayoutTest.php
@@ -1,0 +1,17 @@
+<?php
+
+test('manage elements view options panel has scoped spacing rules', function () {
+    $basePath = dirname(__DIR__, 4) . DIRECTORY_SEPARATOR;
+    $helper = file_get_contents($basePath . 'manager/views/page/resources/helper/switchButtons.blade.php');
+    $mainCss = file_get_contents($basePath . 'manager/media/style/default/css/main.css');
+
+    expect($helper)
+        ->toContain('class="form-group form-inline switchForm"')
+        ->toContain('name="cb_icons"')
+        ->toContain('name="fontsize"')
+        ->and($mainCss)
+        ->toContain('.switchForm .form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem 1rem;')
+        ->toContain('.switchForm label { display: inline-flex; align-items: center; gap: 0.35rem;')
+        ->toContain('.switchForm input[type="checkbox"], .switchForm input[type="radio"] { margin: 0;')
+        ->toContain('.switchForm .columns, .switchForm .fontsize { width: 5rem;');
+});

--- a/manager/media/style/default/css/main.css
+++ b/manager/media/style/default/css/main.css
@@ -183,6 +183,12 @@ ul.elements_buttonbar .fa { font-size: 0.875rem; padding: 1px 1px 0; }
 .resourceTable.flex ul.elements > li { overflow: hidden; /* fix for Firefox */
 break-inside: avoid-column; -webkit-column-break-inside: avoid; -moz-column-break-inside: avoid; -o-column-break-inside: avoid; -ms-column-break-inside: avoid; column-break-inside: avoid; page-break-inside: avoid }
 .resourceTable.flex .elements_descr { display: block; margin-left: 1.5em; }
+.switchForm { padding: 0.5rem 0; }
+.switchForm .form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem 1rem; margin-bottom: 0.5rem; }
+.switchForm label { display: inline-flex; align-items: center; gap: 0.35rem; margin: 0; white-space: nowrap; }
+.switchForm input[type="checkbox"], .switchForm input[type="radio"] { margin: 0; }
+.switchForm .columns, .switchForm .fontsize { width: 5rem; }
+.switchForm .optionsReset { margin-top: 0.25rem; }
 #content_body #which_editor { margin-top: 12px; }
 /* resource children list */
 #tabChildren .grid th, #tabChildren .grid tr > td:nth-child(5), #tabChildren .grid tr > td:nth-child(6) { text-align: center; white-space: nowrap }


### PR DESCRIPTION
Fixes #2338

## Summary
- Add scoped spacing rules for the Manage Elements View Options panel.
- Keep radio buttons, checkboxes, and numeric controls aligned with flex wrapping and consistent gaps.
- Add a static regression test for the View Options helper/CSS contract.

## Why
The View Options panel could visually collapse controls together, especially the Icons checkbox and Font-Size label, making the manager UI hard to scan.

## Validation
- `php -l core/tests/Unit/Manager/ViewOptionsPanelLayoutTest.php`
- `git diff --check`
- `php -r` smoke-check for the scoped View Options CSS and helper markup
- `composer run-script test -- --filter ViewOptionsPanelLayoutTest` could not run locally because `core/vendor/bin/pest` is unavailable in this checkout.
- Browser smoke was not run because this fresh local checkout is missing runtime bootstrap artifacts: `config.php`, `database.sqlite`, and `core/.install`.

## Visual Proof
<img src="https://github.com/MiddleSokilAI/evolution/releases/download/proof-assets-2341/view-options-layout-proof.png" width="800" alt="View Options layout proof">

Proof image is hosted as a fork release asset so it stays visible in the PR without adding screenshot files to the Evolution implementation diff.