### PR TITLE
[FIX] Stabilize View Options layout in Manage Elements

### DIFF
--- a/core/tests/Unit/Manager/ViewOptionsPanelLayoutTest.php
+++ b/core/tests/Unit/Manager/ViewOptionsPanelLayoutTest.php
@@ -6,12 +6,16 @@ test('manage elements view options panel has scoped spacing rules', function () 
     $mainCss = file_get_contents($basePath . 'manager/media/style/default/css/main.css');
 
     expect($helper)
-        ->toContain('class="form-group form-inline switchForm"')
+        ->toContain('class="form-group switchForm"')
+        ->not->toContain('form-inline switchForm')
         ->toContain('name="cb_icons"')
         ->toContain('name="fontsize"')
         ->and($mainCss)
-        ->toContain('.switchForm .form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem 1rem;')
-        ->toContain('.switchForm label { display: inline-flex; align-items: center; gap: 0.35rem;')
-        ->toContain('.switchForm input[type="checkbox"], .switchForm input[type="radio"] { margin: 0;')
-        ->toContain('.switchForm .columns, .switchForm .fontsize { width: 5rem;');
+        ->toContain('.switchForm { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem 1rem;')
+        ->toContain('.switchForm .form-row { display: flex; flex: 0 1 auto; flex-wrap: wrap; align-items: center; gap: 0.5rem 0.75rem;')
+        ->toContain('.switchForm label { display: inline-flex; align-items: center; gap: 0.35rem; margin: 0; min-height: 2rem;')
+        ->toContain('.switchForm input[type="checkbox"], .switchForm input[type="radio"] { flex: 0 0 auto; margin: 0;')
+        ->toContain('.switchForm .columns, .switchForm .fontsize { flex: 0 0 5rem; width: 5rem; min-width: 5rem;')
+        ->toContain('.switchForm .optionsReset { display: flex; align-items: center; margin: 0;')
+        ->toContain('@media (max-width: 480px)');
 });

--- a/manager/media/style/default/css/main.css
+++ b/manager/media/style/default/css/main.css
@@ -183,12 +183,15 @@ ul.elements_buttonbar .fa { font-size: 0.875rem; padding: 1px 1px 0; }
 .resourceTable.flex ul.elements > li { overflow: hidden; /* fix for Firefox */
 break-inside: avoid-column; -webkit-column-break-inside: avoid; -moz-column-break-inside: avoid; -o-column-break-inside: avoid; -ms-column-break-inside: avoid; column-break-inside: avoid; page-break-inside: avoid }
 .resourceTable.flex .elements_descr { display: block; margin-left: 1.5em; }
-.switchForm { padding: 0.5rem 0; }
-.switchForm .form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem 1rem; margin-bottom: 0.5rem; }
-.switchForm label { display: inline-flex; align-items: center; gap: 0.35rem; margin: 0; white-space: nowrap; }
-.switchForm input[type="checkbox"], .switchForm input[type="radio"] { margin: 0; }
-.switchForm .columns, .switchForm .fontsize { width: 5rem; }
-.switchForm .optionsReset { margin-top: 0.25rem; }
+.switchForm { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem 1rem; padding: 0.5rem 0; }
+.switchForm .form-row { display: flex; flex: 0 1 auto; flex-wrap: wrap; align-items: center; gap: 0.5rem 0.75rem; margin: 0; min-width: 0; }
+.switchForm label { display: inline-flex; align-items: center; gap: 0.35rem; margin: 0; min-height: 2rem; white-space: nowrap; }
+.switchForm input[type="checkbox"], .switchForm input[type="radio"] { flex: 0 0 auto; margin: 0; }
+.switchForm .columns, .switchForm .fontsize { flex: 0 0 5rem; width: 5rem; min-width: 5rem; }
+.switchForm .optionsReset { display: flex; align-items: center; margin: 0; }
+@media (max-width: 480px) {
+  .switchForm .form-row, .switchForm .optionsReset { width: 100%; }
+}
 #content_body #which_editor { margin-top: 12px; }
 /* resource children list */
 #tabChildren .grid th, #tabChildren .grid tr > td:nth-child(5), #tabChildren .grid tr > td:nth-child(6) { text-align: center; white-space: nowrap }

--- a/manager/views/page/resources/helper/switchButtons.blade.php
+++ b/manager/views/page/resources/helper/switchButtons.blade.php
@@ -1,4 +1,4 @@
-<form id="switchForm_{{ $id }}" class="form-group form-inline switchForm" data-target="{{ $id }}_content" style="display:none">
+<form id="switchForm_{{ $id }}" class="form-group switchForm" data-target="{{ $id }}_content" style="display:none">
     <div class="form-row">
         <label class="form-check">
             <input type="radio" name="view" value="list" />


### PR DESCRIPTION
## Summary
- removes the conflicting Bootstrap `form-inline` behavior from the Manage Elements View Options form
- makes the View Options controls use a scoped responsive flex layout with explicit gaps, stable input widths, and aligned reset action
- updates the layout contract test so future changes do not reintroduce overlapping labels/inputs

## Why
The previous fix only spaced the individual controls, but the parent form still inherited inline flex behavior. That allowed separate View Options rows to sit beside each other and caused labels such as `Icons` and `Font-Size` to collide with neighboring inputs.

## Verification
- `php -l core/tests/Unit/Manager/ViewOptionsPanelLayoutTest.php`
- `php -l manager/views/page/resources/helper/switchButtons.blade.php`
- `vendor/bin/pest tests/Unit/Manager/ViewOptionsPanelLayoutTest.php` after refreshing local test dependencies
- static layout contract check for the scoped View Options selectors
- `git diff --check`

Refs #2338