### PR TITLE
[REF] replace (boolean) casts with (bool)

### DIFF
--- a/core/functions/nodes.php
+++ b/core/functions/nodes.php
@@ -55,7 +55,7 @@ if (!function_exists('makeHTML')) {
         }
 
         if ($modx->getConfig('tree_show_protected') !== null) {
-            $showProtected = (boolean)$modx->getConfig('tree_show_protected');
+            $showProtected = (bool)$modx->getConfig('tree_show_protected');
         } else {
             $showProtected = false;
         }


### PR DESCRIPTION
replace deprecated in php 8.5 non canonical scalar type cast - https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated