### PR TITLE
Fix SQLite backup restore with serialized settings

### DIFF
--- a/core/functions/actions/bkmanager.php
+++ b/core/functions/actions/bkmanager.php
@@ -132,21 +132,19 @@ if(!function_exists('import_sql')) {
                 "\r"
             ], "\n", $source);
         }
-        $sql_array = import_sql_split_statements($source);
         $driver = $modx->getDatabase()->getConfig('driver');
-        foreach ($sql_array as $sql_entry) {
-            $sql_entry = trim($sql_entry, "\r\n; ");
-            if (empty($sql_entry)) {
-                continue;
-            }
+        if (in_array($driver, ['sqlite', 'sqlite3'], true)) {
+            $rs = \DB::connection()->getPdo()->exec($source);
+        } else {
+            $sql_array = import_sql_split_statements($source);
+            foreach ($sql_array as $sql_entry) {
+                $sql_entry = trim($sql_entry, "\r\n; ");
+                if (empty($sql_entry)) {
+                    continue;
+                }
 
-            if (in_array($driver, ['sqlite', 'sqlite3'], true)) {
-                $rs = \DB::statement($sql_entry);
-            } else {
                 $rs = $modx->getDatabase()->query($sql_entry);
             }
-
-
         }
         restoreSettings($settings);
 
@@ -163,20 +161,29 @@ if (!function_exists('import_sql_from_file')) {
         if (!file_exists($path)) {
             return false;
         }
+        $evo = evolutionCMS();
+        $driver = $evo->getDatabase()->getConfig('driver');
+        if (in_array($driver, ['sqlite', 'sqlite3'], true)) {
+            import_sql(file_get_contents($path), $result_code);
+            return true;
+        }
+
         $fp = fopen($path, 'r');
         $output = '';
         while (($buffer = fgets($fp)) !== false) {
             $output .= $buffer . "\n";
             if (strlen($output) > 5040000 && $buffer === "\n") {
 
-                import_sql($output);
+                import_sql($output, $result_code);
                 $output = '';
             }
         }
 
         if(!empty($output)){
-            import_sql($output);
+            import_sql($output, $result_code);
         }
+
+        return true;
     }
 }
 

--- a/core/tests/Unit/BackupManagerSqlImportSplitTest.php
+++ b/core/tests/Unit/BackupManagerSqlImportSplitTest.php
@@ -35,3 +35,26 @@ SQL;
         ->and($statements[0])->toBe('INSERT INTO "sample" VALUES (\'single; quote\', "double; quote")')
         ->and($statements[1])->toContain('INSERT INTO `sample` VALUES (`identifier; value`, \'done\')');
 });
+
+test('backup manager import keeps serialized sqlite settings values together', function () {
+    $sql = <<<'SQL'
+INSERT INTO "evo_system_settings" VALUES
+  (1,'sys_files_checksum','a:4:{s:36:"D:/OSPanel/domains/site.loc/index.php";s:32:"checksum;with;semicolons";s:44:"D:/OSPanel/domains/site.loc/core/vendor.php";s:14:"quoted \"value\"";}',NULL);
+CREATE TABLE "after_restore" ("id" integer not null primary key autoincrement);
+SQL;
+
+    $statements = import_sql_split_statements($sql);
+
+    expect($statements)->toHaveCount(2)
+        ->and($statements[0])->toContain('sys_files_checksum')
+        ->and($statements[0])->toContain('checksum;with;semicolons')
+        ->and($statements[1])->toContain('CREATE TABLE "after_restore"');
+});
+
+test('backup manager executes sqlite restore dumps as one script', function () {
+    $source = file_get_contents(__DIR__ . '/../../functions/actions/bkmanager.php');
+
+    expect($source)->toContain('in_array($driver, [\'sqlite\', \'sqlite3\'], true)')
+        ->and($source)->toContain('\\DB::connection()->getPdo()->exec($source)')
+        ->and($source)->toContain('import_sql(file_get_contents($path), $result_code)');
+});


### PR DESCRIPTION
Fixes #2349

## Summary

- Restore SQLite backup dumps through PDO as one SQL script instead of splitting them into individual statements.
- Read SQLite restore files fully before import so large serialized values are not cut across chunk boundaries.
- Add regression coverage for serialized `sys_files_checksum` values and the SQLite full-script restore contract.

## Why

SQLite backups can contain serialized settings values with semicolons and quoted Windows paths, especially in `sys_files_checksum`. Splitting the dump before execution can leave SQLite receiving a truncated value fragment and produce `SQLSTATE[HY000]: General error: 1 unrecognized token` during Backup Manager restore.

## Validation

- `php -l core/functions/actions/bkmanager.php`
- `php -l core/tests/Unit/BackupManagerSqlImportSplitTest.php`
- `git diff --check`
- `php` SQLite smoke: `PDO sqlite::memory:` executed a full dump containing serialized `sys_files_checksum` data with semicolons and then verified the following table was created.
- `composer run-script test -- --filter BackupManagerSqlImportSplitTest` could not run locally because `core/vendor/bin/pest` is unavailable in this checkout.
- Issue intake was performed via GitHub API as `MiddleSokilAI`; assign and labels (`Type/Bug`, `Area/Manager`, `Status/In-progress`) returned `403 Must have admin rights to Repository`.

## Visual Proof

![SQLite restore proof](https://github.com/MiddleSokilAI/evolution/releases/download/proof-assets-2349/sqlite-restore-proof-2349.png)
