### PR TITLE
fix(manager): preserve sqlite snapshot path colon (#2352)

### DIFF
--- a/core/tests/Unit/Manager/BackupManagerTooltipMarkupTest.php
+++ b/core/tests/Unit/Manager/BackupManagerTooltipMarkupTest.php
@@ -10,3 +10,14 @@ test('backup manager tooltip uses clean plain text lines', function () {
         ->and($backupManager)->toContain("['Server version', 'PHP Version', 'Host']")
         ->and($tooltipCss)->toContain('white-space: pre-line');
 });
+
+test('backup manager snapshot detail parser keeps windows drive colons', function () {
+    $basePath = dirname(__DIR__, 4) . DIRECTORY_SEPARATOR;
+    $backupManager = file_get_contents($basePath . 'manager/actions/bkmanager.static.php');
+
+    expect($backupManager)
+        ->toContain('function parseBackupSnapshotDetailValue')
+        ->toContain('ltrim($value, " \t:")')
+        ->toContain('parseBackupSnapshotDetailValue($line, $fileLabel)')
+        ->not->toContain("str_replace([\n                                                                \$fileLabel,\n                                                                ':'");
+});

--- a/manager/actions/bkmanager.static.php
+++ b/manager/actions/bkmanager.static.php
@@ -25,6 +25,14 @@ if (file_exists($tempFile)) {
 $mode = isset($_POST['mode']) ? $_POST['mode'] : '';
 $driver = EvolutionCMS()->getDatabase()->getConfig('driver');
 
+function parseBackupSnapshotDetailValue(string $line, string $fileLabel): string
+{
+    $value = trim(substr($line, strlen($fileLabel)));
+    $value = ltrim($value, " \t:");
+
+    return trim($value, " \t\n\r\0\x0B`");
+}
+
 if ($mode == 'restore1') {
     if (isset($_POST['textarea']) && !empty($_POST['textarea'])) {
         $source = trim($_POST['textarea']);
@@ -593,11 +601,11 @@ if (isset($_SESSION['result_msg']) && $_SESSION['result_msg'] != '') {
                                                 foreach (['# ', '-- '] as $prefix) {
                                                     $fileLabel = $prefix . $label;
                                                     if (strpos($line, $fileLabel) !== false) {
-                                                        $details[$label] = htmlentities(trim(str_replace([
-                                                                $fileLabel,
-                                                                ':',
-                                                                '`'
-                                                        ], '', $line)), ENT_QUOTES, ManagerTheme::getCharset());
+                                                        $details[$label] = htmlentities(
+                                                            parseBackupSnapshotDetailValue($line, $fileLabel),
+                                                            ENT_QUOTES,
+                                                            ManagerTheme::getCharset()
+                                                        );
                                                         break;
                                                     }
                                                 }


### PR DESCRIPTION
Fixes #2352

## Summary
- stop stripping all colons from Backup snapshot metadata values
- parse snapshot detail rows by removing only the metadata label prefix and wrapping backticks
- keep Windows SQLite database paths such as `D:\OSPanel\...\evo.sqlite` intact in the snapshot list
- extend the backup manager regression test to guard the parser behavior

## Root Cause
The snapshot detail parser used a broad `str_replace()` that removed the metadata label, every colon, and every backtick from the whole line. For SQLite database paths on Windows, that also removed the drive-letter colon from `D:\...`.

## Validation
- issue intake was done through the GitHub API fallback because `gh` is unavailable in this environment
- assigned issue to `MiddleSokilAI`
- applied labels `Type/Bug`, `Area/Manager`, `Status/In-progress`
- `php8.4 -l manager/actions/bkmanager.static.php`
- `php8.4 -l core/tests/Unit/Manager/BackupManagerTooltipMarkupTest.php`
- `git diff --check`
- PHP smoke verified `# Database: `D:\OSPanel\domains\test1.loc\core\database\evo.sqlite`` parses with the drive colon preserved
- targeted Pest was not run because `core/vendor/bin/pest` is missing locally

## Visual Proof
<img src="https://github.com/MiddleSokilAI/evolution/releases/download/proof-assets-2352/evo-2352-sqlite-path-proof.png" width="800" alt="Evolution CMS #2352 SQLite snapshot path proof">

## Risk
Low. The change only affects parsing of snapshot metadata rows before display. Backup/restore behavior and the stored snapshot files are unchanged.