### PR TITLE
fix(manager): make snapshots consistent (#2353)

### DIFF
--- a/core/src/Services/DatabaseBackupService.php
+++ b/core/src/Services/DatabaseBackupService.php
@@ -167,18 +167,37 @@ class DatabaseBackupService
         $password = isset($config['password']) ? (string) $config['password'] : '';
         $host = isset($config['host']) ? (string) $config['host'] : '';
         $username = isset($config['username']) ? (string) $config['username'] : '';
+        $tempFilePath = $this->buildTempSnapshotFilePath((string) $filePath);
 
-        file_put_contents($filePath, $this->buildSqlHeader('--', (string) $database, $host));
+        file_put_contents($tempFilePath, $this->buildSqlHeader('--', (string) $database, $host));
 
         $command = 'PGPASSWORD=' . escapeshellarg($password)
             . ' pg_dump --host ' . escapeshellarg($host)
             . ' --username ' . escapeshellarg($username)
             . ' --dbname ' . escapeshellarg((string) $database)
-            . ' --clean --inserts --no-owner --no-privileges >> ' . escapeshellarg((string) $filePath);
+            . ' --clean --inserts --no-owner --no-privileges >> ' . escapeshellarg((string) $tempFilePath);
 
         exec($command, $output, $exitCode);
 
-        return (int) $exitCode === 0;
+        if ((int) $exitCode !== 0 || !is_file($tempFilePath) || filesize($tempFilePath) <= 0) {
+            if (is_file($tempFilePath)) {
+                unlink($tempFilePath);
+            }
+
+            return false;
+        }
+
+        if (is_file((string) $filePath)) {
+            unlink((string) $filePath);
+        }
+
+        return rename($tempFilePath, (string) $filePath);
+    }
+
+    protected function buildTempSnapshotFilePath($filePath)
+    {
+        return rtrim(dirname((string) $filePath), '/\\')
+            . '/.' . basename((string) $filePath) . '.' . getmypid() . '.tmp';
     }
 
     protected function buildSqlHeader($commentPrefix, $database, $host)

--- a/core/src/Support/MysqlDumper.php
+++ b/core/src/Support/MysqlDumper.php
@@ -78,15 +78,38 @@ class MysqlDumper implements MysqlDumperInterface
         $modx = evo();
         $createtable = [];
         $dataBaseConfig = $modx->db->getConfig();
+        $pdo = \DB::connection()->getPdo();
+        $transactionStarted = false;
 
+        if ($callBack !== 'snapshot') {
+            return $this->writeDump($callBack, $modx, $createtable, $dataBaseConfig);
+        }
+
+        try {
+            $pdo->exec('START TRANSACTION WITH CONSISTENT SNAPSHOT');
+            $transactionStarted = true;
+
+            $result = $this->writeDump($callBack, $modx, $createtable, $dataBaseConfig);
+
+            $pdo->exec('COMMIT');
+            $transactionStarted = false;
+
+            return $result;
+        } catch (\Throwable $throwable) {
+            if ($transactionStarted) {
+                $pdo->exec('ROLLBACK');
+            }
+
+            throw $throwable;
+        }
+    }
+
+    private function writeDump($callBack, $modx, array $createtable, array $dataBaseConfig): bool
+    {
         $databaseName = $dataBaseConfig['database'];
-
         $sql =  'SELECT table_name AS "table", round(((data_length + index_length) / 1024 / 1024)) "size" FROM information_schema.TABLES WHERE table_schema = "'.$databaseName.'"';
         $tableSizes = array_column($modx->db->makeArray($modx->db->query($sql)), 'size', 'table');
-
-        // Sort tables by foreign key dependencies
         $tables = $this->sortTablesByDependencies($this->_dbtables);
-
         // Set line feed
         $lf = "\n";
         $tempfile_path = EVO_BASE_PATH . 'assets/backup/temp.php';

--- a/core/src/Support/SqliteDumper.php
+++ b/core/src/Support/SqliteDumper.php
@@ -125,7 +125,33 @@ class SqliteDumper
         $modx = evo();
         $config = $modx->getDatabase()->getConfig();
         $pdo = \DB::connection()->getPdo();
+        $transactionStarted = false;
 
+        if ($callBack !== 'snapshot') {
+            return $this->writeDump($callBack, $modx, $config, $pdo);
+        }
+
+        try {
+            $pdo->exec('BEGIN IMMEDIATE TRANSACTION');
+            $transactionStarted = true;
+
+            $result = $this->writeDump($callBack, $modx, $config, $pdo);
+
+            $pdo->exec('COMMIT');
+            $transactionStarted = false;
+
+            return $result;
+        } catch (\Throwable $throwable) {
+            if ($transactionStarted) {
+                $pdo->exec('ROLLBACK');
+            }
+
+            throw $throwable;
+        }
+    }
+
+    private function writeDump($callBack, $modx, array $config, PDO $pdo): bool
+    {
         $lf = "\n";
         $tempfile_path = EVO_BASE_PATH . 'assets/backup/temp.php';
 

--- a/core/tests/Unit/DatabaseBackupServiceConsistencyTest.php
+++ b/core/tests/Unit/DatabaseBackupServiceConsistencyTest.php
@@ -1,0 +1,27 @@
+<?php
+
+test('mysql and sqlite dumpers wrap snapshot reads in database transactions', function () {
+    $mysql = file_get_contents(__DIR__ . '/../../src/Support/MysqlDumper.php');
+    $sqlite = file_get_contents(__DIR__ . '/../../src/Support/SqliteDumper.php');
+
+    expect($mysql)
+        ->toContain('START TRANSACTION WITH CONSISTENT SNAPSHOT')
+        ->toContain("if (\$callBack !== 'snapshot')")
+        ->toContain('$pdo->exec(\'COMMIT\')')
+        ->toContain('$pdo->exec(\'ROLLBACK\')')
+        ->and($sqlite)
+        ->toContain('BEGIN IMMEDIATE TRANSACTION')
+        ->toContain('$pdo->exec(\'COMMIT\')')
+        ->toContain('$pdo->exec(\'ROLLBACK\')');
+});
+
+test('postgres snapshots are written to a temporary file before atomic publish', function () {
+    $source = file_get_contents(__DIR__ . '/../../src/Services/DatabaseBackupService.php');
+
+    expect($source)
+        ->toContain('buildTempSnapshotFilePath')
+        ->toContain('>> \' . escapeshellarg((string) $tempFilePath)')
+        ->toContain('unlink($tempFilePath)')
+        ->toContain('rename($tempFilePath, (string) $filePath)')
+        ->not->toContain('>> \' . escapeshellarg((string) $filePath)');
+});


### PR DESCRIPTION
Fixes #2353

## Summary
- wrap MySQL snapshot dumps in `START TRANSACTION WITH CONSISTENT SNAPSHOT`
- wrap SQLite snapshot dumps in `BEGIN IMMEDIATE TRANSACTION`
- keep non-snapshot download dumps on the previous path because `dumpSql()` streams and exits the request
- write PostgreSQL snapshots to a temporary file first, then publish with `rename()` only after `pg_dump` succeeds
- add regression coverage for the consistency/atomic publish contracts

## Root Cause
MySQL and SQLite snapshot dumps iterated tables with separate reads and no DB-level snapshot/lock, so concurrent writes could make different tables represent different points in time. PostgreSQL uses `pg_dump`, but the service wrote the header and dump output directly to the final snapshot path, leaving a partial `.sql` possible if the dump failed or was interrupted.

## Validation
- issue intake was done through the GitHub API fallback because `gh` is unavailable in this environment
- assigned issue to `MiddleSokilAI`
- applied labels `Type/Bug`, `Area/Manager`, `Status/In-progress`; attempted `Area/Backup`, but that label does not exist and this token cannot create new labels
- `php8.4 -l core/src/Services/DatabaseBackupService.php`
- `php8.4 -l core/src/Support/MysqlDumper.php`
- `php8.4 -l core/src/Support/SqliteDumper.php`
- `php8.4 -l core/tests/Unit/DatabaseBackupServiceConsistencyTest.php`
- `git diff --check`
- PHP smoke verified transaction and temp-file publish contracts in the changed source
- targeted Pest was not run because `core/vendor/bin/pest` is missing locally

## Risk
Medium. This touches backup snapshot creation across database drivers. The transaction wrapper is limited to `snapshot` mode so the existing streamed download path is not held open by a transaction while `dumpSql()` exits the request. PostgreSQL now publishes only complete temp files, reducing the risk of partial final snapshots.