### PR TITLE
fix(manager): sync reported localization keys (#2363)

### DIFF
--- a/core/lang/ru/global.php
+++ b/core/lang/ru/global.php
@@ -1510,6 +1510,8 @@ $_lang["role_tv_msg"] = 'Ниже выводятся параметры, наз�
 $_lang["tmplvar_roles_access_msg"] = 'Укажите роли, которые могут использовать этот Параметр (TV)';
 
 $_lang["setting_from_file"] = '<strong class="text-danger">Значение параметра задано в core/custom/config/cms/settings</strong>';
+$_lang['disable'] = 'Отключить';
+$_lang['enable'] = 'Включить';
 
 $_lang["file_groups_saved"] = 'Права доступа сохранены.';
 $_lang["file_groups_edit"] = 'Редактировать права доступа';

--- a/core/lang/uk/global.php
+++ b/core/lang/uk/global.php
@@ -107,6 +107,11 @@ $_lang["chunk_code"] = 'Код чанку (HTML)';
 $_lang["chunk_multiple_id"] = 'Помилка: Кілька чанків мають однаковий ідентифікатор.';
 $_lang["chunk_no_exist"] = 'Чанк не знайдено.';
 $_lang['chunk_processor'] = 'Клас обробки чанків';
+
+$_lang["permission_title"] = 'Створити / редагувати право доступу';
+$_lang["groups_permission_title"] = 'Створити / редагувати категорію';
+$_lang["lang_key_desc"] = 'Ключ мови з масиву $_lang';
+$_lang["key_desc"] = 'Ключ для перевірки доступу';
 $_lang["cleaningup"] = 'Очищення...';
 $_lang["clean_uploaded_filename"] = 'Використовувати транслітерацію при завантаженні файлів.';
 $_lang["clean_uploaded_filename_message"] = 'Використовувати налаштування плагіна transalias для транслітерації імен файлів, що завантажуються із збереженням крапок і ком.';
@@ -1504,12 +1509,9 @@ $_lang["role_notassigned_tv"] = 'Ці змінні доступні для пр�
 $_lang["role_tv_msg"] = 'Змінні, призначені цій ролі, перераховані нижче.';
 $_lang["tmplvar_roles_access_msg"] = 'Виберіть ролі, яким дозволено доступ до цієї змінної шаблону та її обробка';
 
-$_lang["site_indexing_title"] = 'Індексація сайту';
-$_lang['site_indexing_message'] = 'Керування метатегом robots для індексації сайту пошуковими роботами.';
-$_lang["ignore"] = 'Не враховувати';
-$_lang["indexing_is_allowed"] = 'Індексацію дозволено';
-$_lang["indexing_is_prohibited"] = 'Індексацію заборонено';
 $_lang["setting_from_file"] = '<strong class="text-danger">Значення параметра задано в core/custom/config/cms/settings</strong>';
+$_lang['disable'] = 'Вимкнути';
+$_lang['enable'] = 'Увімкнути';
 
 $_lang["file_groups_saved"] = 'Права доступу збережено.';
 $_lang["file_groups_edit"] = 'Редагувати права доступу';

--- a/core/tests/Unit/Manager/LocalizationKeySyncTest.php
+++ b/core/tests/Unit/Manager/LocalizationKeySyncTest.php
@@ -1,0 +1,45 @@
+<?php
+
+it('keeps reported Ukrainian and Russian manager localization keys in sync', function () {
+    $locales = [];
+    foreach (['en', 'ru', 'uk'] as $locale) {
+        $_lang = [];
+        include dirname(__DIR__, 3) . '/lang/' . $locale . '/global.php';
+        $locales[$locale] = $_lang;
+    }
+
+    foreach (['disable', 'enable'] as $key) {
+        expect($locales['ru'])
+            ->toHaveKey($key)
+            ->and($locales['uk'])
+            ->toHaveKey($key);
+    }
+
+    foreach (['permission_title', 'groups_permission_title', 'lang_key_desc', 'key_desc'] as $key) {
+        expect($locales['uk'])->toHaveKey($key);
+    }
+
+    expect($locales['ru'])
+        ->toHaveKey('chunk_processor')
+        ->and($locales['uk']['permission_title'])
+        ->toBe('Створити / редагувати право доступу')
+        ->and($locales['ru']['disable'])
+        ->toBe('Отключить')
+        ->and($locales['uk']['enable'])
+        ->toBe('Увімкнути');
+});
+
+it('removes Ukrainian-only SEO indexing keys that are not used by the manager', function () {
+    $_lang = [];
+    include dirname(__DIR__, 3) . '/lang/uk/global.php';
+
+    foreach ([
+        'site_indexing_title',
+        'site_indexing_message',
+        'ignore',
+        'indexing_is_allowed',
+        'indexing_is_prohibited',
+    ] as $key) {
+        expect($_lang)->not->toHaveKey($key);
+    }
+});


### PR DESCRIPTION
## Summary
- add the missing Ukrainian permission-management language keys
- add missing `disable` / `enable` toggle labels to Russian and Ukrainian manager language files
- keep the existing Russian `chunk_processor` translation unchanged after verifying it is already present
- remove the Ukrainian-only SEO indexing language keys that have no manager/core usage
- add a focused manager localization key-sync regression test

## Validation
- `git diff --check`
- `wsl -e bash -lc 'cd /mnt/h/PhpstormProjects/Extras/evolution && php8.4 -l core/lang/uk/global.php && php8.4 -l core/lang/ru/global.php && php8.4 -l core/tests/Unit/Manager/LocalizationKeySyncTest.php'`
- Python source smoke check for required key presence and orphan removal

Not available locally:
- Pest/PHPUnit binaries are not present in `core/vendor/bin` or `vendor/bin`

Fixes #2363