### PR TITLE
upd(install): support database host port syntax

### DIFF
--- a/install/src/controllers/connection.php
+++ b/install/src/controllers/connection.php
@@ -155,6 +155,7 @@ $ph['install_language'] = escapeHtmlAttribute($install_language);
 $ph['installMode'] = escapeHtmlAttribute($installMode);
 $ph['checkedChkagree'] = isset($_POST['chkagree']) ? 'checked' : '';
 $ph['databasehost'] = escapeHtmlAttribute(isset($_POST['databasehost']) ? $_POST['databasehost'] : $database_host);
+$ph['databasehost_placeholder'] = escapeHtmlAttribute('localhost:3306');
 $ph['databaseloginname'] = escapeHtmlAttribute(isset($_SESSION['databaseloginname']) ? $_SESSION['databaseloginname'] : '');
 $ph['databaseloginpassword'] = escapeHtmlAttribute(isset($_SESSION['databaseloginpassword']) ? $_SESSION['databaseloginpassword'] : '');
 $ph['MGR_DIR'] = escapeHtmlAttribute(MGR_DIR);

--- a/install/src/controllers/connection/collation.php
+++ b/install/src/controllers/connection/collation.php
@@ -10,12 +10,12 @@ try {
     echo '<span id="database_fail">' . $_lang['status_failed'] . ' ' . $e->getMessage() . '</span>';
 }
 try {
-    $dsn = $driver . ':host=' . $host;
+    $dsn = databaseDsn($driver, $host);
     $output = '<select id="database_collation" name="database_collation">';
 
     switch ($driver) {
         case 'pgsql':
-            $dbh = new PDO($dsn . ";dbname=postgres", $uid, $pwd);
+            $dbh = new PDO(databaseDsn($driver, $host, 'postgres'), $uid, $pwd);
             $sql = "SELECT collname FROM pg_collation ORDER BY collname";
             $_ = [];
 

--- a/install/src/controllers/connection/databasetest.php
+++ b/install/src/controllers/connection/databasetest.php
@@ -8,7 +8,6 @@ $database_name = validateDbName($_POST['database_name']);
 $installMode = (int)$_POST['installMode'];
 
 $output = $_lang['status_checking_database'];
-$h = explode(':', $host, 2);
 $database_collation = $_POST['database_collation'];
 
 $database_charset = getDatabaseCharset($database_collation, $driver);
@@ -16,7 +15,7 @@ try {
     if ($driver === 'sqlite') {
         $dbh = new PDO('sqlite:' . sqliteDbNameToPath($database_name));
     } else {
-        $dbh = new PDO($driver . ':host=' . $host . ';dbname=' . $database_name, $uid, $pwd);
+        $dbh = new PDO(databaseDsn($driver, $host, $database_name), $uid, $pwd);
     }
     switch ($driver) {
         case 'pgsql':
@@ -123,7 +122,7 @@ try {
     if ($driver === 'sqlite') {
         $dbh = new PDO('sqlite:' . sqliteDbNameToPath($database_name));
     } else {
-        $dbh = new PDO($driver . ':host=' . $host . ($driver === 'pgsql' ? ';dbname=postgres' : ''), $uid, $pwd);
+        $dbh = new PDO(databaseDsn($driver, $host, $driver === 'pgsql' ? 'postgres' : null), $uid, $pwd);
     }
     switch ($driver) {
         case 'pgsql':

--- a/install/src/controllers/connection/servertest.php
+++ b/install/src/controllers/connection/servertest.php
@@ -13,7 +13,7 @@ try {
     if ($method === 'sqlite') {
         $dbh = new PDO('sqlite::memory:');
     } else {
-        $dbh = new PDO($method . ':host=' . $host . ($method === 'pgsql' ? ';dbname=postgres' : ''), $uid, $pwd);
+        $dbh = new PDO(databaseDsn($method, $host, $method === 'pgsql' ? 'postgres' : null), $uid, $pwd);
     }
     $output .= '<span id="server_pass"> ' . $_lang['status_passed_server'] . '</span>';
 } catch (Throwable $e) {

--- a/install/src/controllers/install.php
+++ b/install/src/controllers/install.php
@@ -70,16 +70,13 @@ unset ($a);
 $base_url = $url . (substr($url, -1) !== '/' ? '/' : '');
 $base_path = $pth . (substr($pth, -1) !== '/' ? '/' : '');
 
-// connect to the database
-$host = explode(':', $database_server, 2);
-
 global $conn;
 try {
     $pdoOptions = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION];
     if ($database_type === 'sqlite') {
         $dbh = new PDO('sqlite:' . sqliteDbNameToPath($database_name));
     } else {
-        $dbh = new PDO($database_type . ':host=' . $database_server . ';dbname=' . $database_name, $database_user, $database_password, $pdoOptions);
+        $dbh = new PDO(databaseDsn($database_type, $database_server, $database_name), $database_user, $database_password, $pdoOptions);
     }
 
     include dirname(__DIR__) . '/processor/result.php';
@@ -93,7 +90,8 @@ try {
     if ($installLevel === 1) {
         // write the core/config/database/connections/default.php file if new installation
         $confph = [];
-        $confph['database_server'] = addslashes($database_server);
+        $databaseHostParts = databaseHostParts($database_server);
+        $confph['database_server'] = addslashes($databaseHostParts['host']);
         $confph['database_type'] = addslashes($database_type);
         $confph['user_name'] = addslashes($database_user);
         $confph['password'] = addslashes($database_password);
@@ -107,10 +105,10 @@ try {
         $confph['database_engine'] = '';
         switch ($database_type) {
             case 'pgsql':
-                $confph['database_port'] = '5432';
+                $confph['database_port'] = $databaseHostParts['port'] ?? '5432';
                 break;
             case 'mysql':
-                $confph['database_port'] = '3306';
+                $confph['database_port'] = $databaseHostParts['port'] ?? '3306';
                 $serverVersion = $dbh->getAttribute(PDO::ATTR_SERVER_VERSION);
                 if (version_compare($serverVersion, '5.7.6', '<')) {
                     $confph['database_engine'] = ", 'myisam'";

--- a/install/src/controllers/summary.php
+++ b/install/src/controllers/summary.php
@@ -182,6 +182,9 @@ if (!is_writable("../assets/export")) {
 if ($installMode == 1) {
     $db_config = include_once EVO_CORE_PATH . 'config/database/connections/default.php';
     $database_server = $db_config['host'];
+    if (!empty($db_config['port'])) {
+        $database_server .= ':' . $db_config['port'];
+    }
     $database_user = $db_config['username'];
     $database_password = $db_config['password'];
     $database_collation = $db_config['collation'];
@@ -201,19 +204,13 @@ if ($installMode == 1) {
     $table_prefix = validateTablePrefix($_POST['tableprefix']);
 }
 echo '<p>' . $_lang['creating_database_connection'];
-$host = explode(':', $database_server, 2);
 $pdoOptions = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION];
 try {
     $dbh = null;
     if ($database_type === 'sqlite') {
         $dbh = new PDO('sqlite:' . sqliteDbNameToPath($database_name), null, null, $pdoOptions);
     } else {
-        if (count($host) === 1) {
-            $dsn = $database_type . ':host=' . $host[0] . ';dbname=' . $database_name;
-        } else {
-            $dsn = $database_type . ':host=' . $host[0] . ';port=' . $host[1] . ';dbname=' . $database_name;
-        }
-        $dbh = new PDO($dsn, $database_user, $database_password, $pdoOptions);
+        $dbh = new PDO(databaseDsn($database_type, $database_server, $database_name), $database_user, $database_password, $pdoOptions);
     }
     echo '<span class="ok">' . $_lang['ok'] . '</span></p>';
 } catch (PDOException $e) {

--- a/install/src/functions.php
+++ b/install/src/functions.php
@@ -67,11 +67,48 @@ function getDatabaseCharset($database_collation, $driver): string
     return $database_charset;
 }
 
+function databaseHostParts(string $host): array
+{
+    $host = trim($host);
+    $port = null;
+
+    if (preg_match('/^\[([0-9a-f:.]+)\](?::([0-9]{1,5}))?$/i', $host, $matches)) {
+        $host = $matches[1];
+        $port = $matches[2] ?? null;
+    } elseif (substr_count($host, ':') === 1) {
+        [$host, $port] = explode(':', $host, 2);
+    }
+
+    if ($port !== null && ($port === '' || filter_var($port, FILTER_VALIDATE_INT, [
+        'options' => ['min_range' => 1, 'max_range' => 65535],
+    ]) === false)) {
+        throw new InvalidArgumentException('Database port should be a number from 1 to 65535');
+    }
+
+    return ['host' => $host, 'port' => $port];
+}
+
+function databaseDsn(string $driver, string $host, ?string $database = null): string
+{
+    $parts = databaseHostParts($host);
+    $dsn = $driver . ':host=' . $parts['host'];
+
+    if ($parts['port'] !== null) {
+        $dsn .= ';port=' . $parts['port'];
+    }
+
+    if ($database !== null && $database !== '') {
+        $dsn .= ';dbname=' . $database;
+    }
+
+    return $dsn;
+}
+
 function dbConnect(string $driver, string $host, $db, ?string $user = null, ?string $password = null, ?array $pdoOptions = null) {
     if ($driver === 'sqlite') {
         $dbh = new PDO('sqlite:' . EVO_CORE_PATH . "database/$db.sqlite", null, null, $pdoOptions);
     } else {
-        $dbh = new PDO($driver . ':host=' . $host . ($driver === 'pgsql' ? ";dbname=$db" : ''), $user, $password, $pdoOptions);
+        $dbh = new PDO(databaseDsn($driver, $host, $driver === 'pgsql' ? $db : null), $user, $password, $pdoOptions);
     }
     return $dbh;
 }
@@ -204,14 +241,15 @@ function validateDbHost($host, $type)
     if ($type === 'sqlite' && empty($host)) {
         return $host;
     }
-    if (!$ip = filter_var($host, FILTER_VALIDATE_IP)) {
-        if (!$host = filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
+    $parts = databaseHostParts($host);
+    if (!$ip = filter_var($parts['host'], FILTER_VALIDATE_IP)) {
+        if (!$parts['host'] = filter_var($parts['host'], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
             throw new InvalidArgumentException("Database host should be valid IP or hostname");
         }
     } else {
-        $host = $ip;
+        $parts['host'] = $ip;
     }
-    return $host;
+    return $parts['host'] . ($parts['port'] !== null ? ':' . $parts['port'] : '');
 }
 
 function validateTablePrefix($prefix)
@@ -298,11 +336,8 @@ function get_installmode()
         if (!isset($database_name) || empty($database_name)) {
             $installmode = 0;
         } else {
-            $host = explode(':', $database_server, 2);
             try {
-                $port = isset($host[1]) ? ";port={$host[1]}" : '';
-                $dsn = "mysql:host={$host[0]}{$port}";
-                $conn = new PDO($dsn, $database_user, $database_password);
+                $conn = new PDO(databaseDsn('mysql', $database_server), $database_user, $database_password);
                 $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
                 $_SESSION['database_server'] = $database_server;

--- a/install/src/template/actions/connection.tpl
+++ b/install/src/template/actions/connection.tpl
@@ -23,7 +23,7 @@
     </p>
     <p class="labelHolder">
         <label for="databasehost">[%connection_screen_database_host%]</label>
-        <input type="text" id="databasehost" value="[+databasehost+]" name="databasehost" />
+        <input type="text" id="databasehost" value="[+databasehost+]" name="databasehost" placeholder="[+databasehost_placeholder+]" />
         <small class="is-invalid">[%alert_enter_host%]</small>
     </p>
     <p class="labelHolder">


### PR DESCRIPTION
## Summary
- Allow installer database hosts in `host:port` form, such as `localhost:3311` or `127.0.0.1:3311`.
- Build PDO DSNs with explicit `;port=...` when a port is present.
- Persist custom ports into the generated database config while keeping the host value separate.
- Add a `localhost:3306` placeholder to make the supported syntax discoverable.

## Risk
LOW. The existing host-only path remains unchanged; custom ports only add explicit DSN/config handling when provided.

## Validation
- `php8.4 -l` for touched installer PHP files
- `git diff --check`
- Smoke check for `validateDbHost()` and `databaseDsn()` with `localhost`, `localhost:3311`, `127.0.0.1:3311`, and invalid port rejection

Closes #2368