### PR TITLE
[FIX] preserve web user session across login redirect

### DIFF
--- a/core/functions/session_proxy.php
+++ b/core/functions/session_proxy.php
@@ -5,17 +5,23 @@ class EvoSessionProxy
     /**
      * @var bool
      */
-    private static $initialized = false;
+    private static bool $initialized = false;
 
     /**
      * @var bool
      */
-    private static $synced = false;
+    private static bool $synced = false;
 
     /**
      * @var bool
      */
-    private static $shutdownRegistered = false;
+    private static bool $shutdownRegistered = false;
+
+    /**
+     * @var bool  Tracks whether saveAndEmitCookie() already ran, so the shutdown handler does not attempt a second save/emit.
+     */
+    private static bool $cookieEmitted = false;
+
 
     /**
      * Early init - before Laravel middleware.
@@ -272,6 +278,64 @@ class EvoSessionProxy
     }
 
     /**
+     * Sync $_SESSION to the Laravel session store and emit the session cookie header.
+     *
+     * Must be called BEFORE any header() / exit() that bypasses the middleware stack
+     * (e.g. sendRedirect on a fresh session where the browser has no evo_session cookie yet).
+     */
+    public static function saveAndEmitCookie(): void {
+        if (!self::$initialized) {
+            return;
+        }
+
+        // Sync data first (marks self::$synced = true so shutdown won't double-save).
+        if (!self::$cookieEmitted) {
+            self::syncBack();
+        }
+
+        $store = self::getLaravelSessionStore();
+        if ($store === null) {
+            return;
+        }
+
+        $cookieName = self::getLaravelSessionCookieName();
+        $sessionId  = $store->getId();
+
+        if (!$cookieName || !$sessionId || headers_sent()) {
+            return;
+        }
+
+        // Only emit when the browser does not already carry this exact session id,
+        // or when it carries a different one (session was regenerated).
+        if (isset($_COOKIE[$cookieName]) && $_COOKIE[$cookieName] === $sessionId) {
+            return;
+        }
+
+        $config   = function_exists('config') ? (array) config('session', []) : [];
+        $lifetime = isset($config['lifetime']) ? (int) $config['lifetime'] * 60 : 0;
+
+        $secure = (bool) ($config['secure'] ?? (
+            (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ||
+            (isset($_SERVER['SERVER_PORT']) && (int) $_SERVER['SERVER_PORT'] === 443)
+        ));
+
+        setcookie(
+            $cookieName,
+            $sessionId,
+            [
+                'expires'  => $lifetime ? time() + $lifetime : 0,
+                'path'     => $config['path']      ?? '/',
+                'domain'   => $config['domain']    ?? '',
+                'secure'   => $secure,
+                'httponly' => (bool) ($config['http_only'] ?? true),
+                'samesite' => $config['same_site'] ?? 'Lax',
+            ]
+        );
+
+        self::$cookieEmitted = true;
+    }
+
+    /**
      * @return string
      */
     private static function getLaravelSessionCookieName(): string
@@ -301,6 +365,6 @@ class EvoSessionProxy
      */
     private static function isInternalKey(string $key): bool
     {
-        return strncmp($key, '_', 1) === 0;
+        return str_starts_with($key, '_');
     }
 }

--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -505,6 +505,13 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
             $code = 302;
         }
 
+        // Persist session data and emit the session cookie before exit() so the
+        // browser receives the Set-Cookie header even when the redirect bypasses
+        // Laravel's StartSession middleware response phase (e.g. after login).
+        if (defined('EVO_SESSION') && EVO_SESSION) {
+            \EvoSessionProxy::saveAndEmitCookie();
+        }
+
         header('HTTP/1.1 ' . $code . ' ' . $responseCodes[$code]);
 
         // Set redirection header if applicable


### PR DESCRIPTION
## Summary

Fixes an issue where web user authentication was lost immediately after login when starting from a fresh browser session with no existing `evo_session` cookie.

## Root Cause

On a fresh login, the authentication POST request created a new Laravel session and stored authentication data (`webValidated`, etc.) in it. The login flow then called `sendRedirect()`, which performs a `header()` redirect followed by `exit()`.

Because `exit()` bypassed Laravel's normal `StartSession` middleware response phase, the session cookie was never written to the response. As a result, the browser followed the redirect without an `evo_session` cookie and received a new empty session, causing the user to appear unauthenticated.

This issue was not visible when already logged into the manager because a valid `evo_session` cookie already existed and the web user data was merged into that session.

## Changes

### session_proxy.php

* Added `EvoSessionProxy::saveAndEmitCookie()`
* Synchronizes `$_SESSION` data with the Laravel session store
* Explicitly emits the `evo_session` cookie using `setcookie()` before any redirect output

### Core.php

* Updated `sendRedirect()` to call `saveAndEmitCookie()` before executing the redirect
* Ensures the session cookie is included in redirect responses even when execution terminates immediately via `exit()`

## Result

Web user authentication now persists correctly after login, including on fresh browser sessions where no existing `evo_session` cookie is present.
