### PR TITLE
fix(update): avoid Composer package updates

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -434,106 +434,24 @@ HELP;
     /**
      * Install Composer dependencies after core files are replaced.
      *
-     * Clean Evolution installs can use the shipped lock file directly. Sites with
-     * core/custom/composer.json need a targeted lock refresh for those packages,
-     * otherwise Composer installs the new core lock and leaves custom providers
-     * registered without their vendor classes.
+     * The updater must not run Composer update here because third-party packages
+     * from custom Composer layers can receive untested version changes as a side
+     * effect of a core update. Composer install restores the vendor/autoload state
+     * from the lock file, then package discovery refreshes registered providers.
      *
      * @since 3.5.7
      * @return void
      */
     protected function installComposerDependencies(): void
     {
-        $customPackages = $this->resolveCustomComposerPackages();
-
-        if ($customPackages !== []) {
-            $this->line('<fg=green>Update Composer dependencies with custom packages</>');
-            $this->runCoreShellCommand($this->buildCustomComposerUpdateCommand($customPackages));
-        } else {
-            $this->line('<fg=green>Install Composer dependencies</>');
-            $this->runCoreShellCommand($this->composerInstallCommand());
-        }
+        $this->line('<fg=green>Install Composer dependencies</>');
+        $this->runCoreShellCommand($this->composerInstallCommand());
 
         $this->line('<fg=green>Rebuild optimized autoload</>');
         $this->runCoreShellCommand($this->composerDumpAutoloadCommand());
 
         $this->line('<fg=green>Discover Composer packages</>');
         $this->runCoreShellCommand('php artisan package:discover');
-    }
-
-    /**
-     * Resolve package names from the local custom Composer layer.
-     *
-     * Platform requirements such as php/ext-json are intentionally ignored because
-     * Composer cannot update them as packages. The merged root composer.json still
-     * validates those constraints during install/update.
-     *
-     * @since 3.5.7
-     * @return array<int, string>
-     */
-    protected function resolveCustomComposerPackages(): array
-    {
-        $customComposer = EVO_CORE_PATH . 'custom/composer.json';
-        if (!is_file($customComposer)) {
-            return [];
-        }
-
-        $composer = json_decode((string) file_get_contents($customComposer), true);
-        if (!is_array($composer)) {
-            throw new \RuntimeException('Invalid custom composer.json.');
-        }
-
-        $requires = $composer['require'] ?? [];
-        if (!is_array($requires)) {
-            return [];
-        }
-
-        return $this->normalizeComposerPackageNames(array_keys($requires));
-    }
-
-    /**
-     * Keep only updateable Composer package names.
-     *
-     * @since 3.5.7
-     * @param array<int, mixed> $packages Raw Composer requirement names.
-     * @return array<int, string>
-     */
-    protected function normalizeComposerPackageNames(array $packages): array
-    {
-        $normalized = [];
-        foreach ($packages as $package) {
-            $package = trim((string) $package);
-            if ($package === '') {
-                continue;
-            }
-
-            if (preg_match('~^[a-z0-9][a-z0-9_.-]*/[a-z0-9][a-z0-9_.-]*$~i', $package) !== 1) {
-                continue;
-            }
-
-            $normalized[] = strtolower($package);
-        }
-
-        return array_values(array_unique($normalized));
-    }
-
-    /**
-     * Build a constrained Composer update command for custom packages.
-     *
-     * @since 3.5.7
-     * @param array<int, string> $packages Package names from core/custom/composer.json.
-     * @return string
-     */
-    protected function buildCustomComposerUpdateCommand(array $packages): string
-    {
-        $packages = $this->normalizeComposerPackageNames($packages);
-        if ($packages === []) {
-            throw new \RuntimeException('Custom Composer packages are missing.');
-        }
-
-        return 'composer update '
-            . implode(' ', array_map('escapeshellarg', $packages))
-            . ' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
     }
 
     protected function composerInstallCommand(): string

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -64,42 +64,23 @@ test('site updater repairs composer vendor state before artisan commands', funct
 
     expect($source)
         ->toContain('$this->composerInstallCommand()')
-        ->toContain('buildCustomComposerUpdateCommand')
         ->toContain('$this->composerDumpAutoloadCommand()')
         ->toContain("runCoreShellCommand('php artisan package:discover')")
         ->toContain('--no-scripts')
         ->toContain('return self::FAILURE')
         ->toContain('catch (\Throwable $exception)')
         ->not->toContain('new Application()')
-        ->not->toContain("runCoreShellCommand('composer update')");
+        ->not->toContain("runCoreShellCommand('composer update')")
+        ->not->toContain('buildCustomComposerUpdateCommand')
+        ->not->toContain('resolveCustomComposerPackages');
 
     expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
-    expect(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'))->toBeLessThan(strpos($source, '$this->composerDumpAutoloadCommand()'));
+    expect(strpos($source, '$this->composerInstallCommand()'))->toBeLessThan(strpos($source, '$this->composerDumpAutoloadCommand()'));
     expect(strpos($source, '$this->composerDumpAutoloadCommand()'))->toBeLessThan(strpos($source, "runCoreShellCommand('php artisan package:discover')"));
     expect(invokeSiteUpdateMethod($this->command, 'composerInstallCommand'))
         ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts');
     expect(invokeSiteUpdateMethod($this->command, 'composerDumpAutoloadCommand'))
         ->toBe('composer dump-autoload -o --no-dev --classmap-authoritative --no-scripts');
-});
-
-test('site updater builds constrained composer update for custom packages', function () {
-    $command = invokeSiteUpdateMethod($this->command, 'buildCustomComposerUpdateCommand', [[
-        'evolution-cms/eai',
-        'php',
-        'ext-json',
-        'Seiger/sTask',
-        'bad package',
-        'evolution-cms/eai',
-    ]]);
-
-    expect($command)
-        ->toBe("composer update 'evolution-cms/eai' 'seiger/stask' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts");
-});
-
-test('site updater updates custom packages before install-only path', function () {
-    $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/SiteUpdateCommand.php');
-
-    expect(strpos($source, 'buildCustomComposerUpdateCommand($customPackages)'))->toBeLessThan(strpos($source, '$this->composerInstallCommand()'));
 });
 
 test('site updater can read bundled extras installer metadata', function () {


### PR DESCRIPTION
## Summary
- Change `php artisan make:site update` to always repair Composer state with lock-based `composer install`.
- Remove the custom-package `composer update` path so core updates do not pull untested third-party package versions.
- Keep the optimized autoload rebuild and package discovery steps after install.
- Update the command unit coverage to guard against reintroducing Composer update in this flow.

## Root Cause
The CLI updater refreshed Composer dependencies with `composer update` when `core/custom/composer.json` declared packages. That can modify third-party package versions during a core update, which makes the update flow unpredictable and can trigger errors from package/version drift. The updater only needs to restore vendor/autoload state from the lock file before running artisan commands.

## Validation
- `php -l src/Console/SiteUpdateCommand.php`
- `php -l tests/Unit/Console/SiteUpdateCommandTest.php`
- `git diff --check`

Could not run the focused Pest/PHPUnit test locally because `core/vendor/bin/pest` and `core/vendor/bin/phpunit` are not installed in this checkout. `composer validate --no-check-publish --no-check-all` reports an existing lock-file mismatch and version-field warning.

Closes #2373