### PR TITLE
fix(update): preserve custom packages on repeated updates

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -150,6 +150,8 @@ HELP;
             }
         }
         if ($git['version'] != '') {
+            $customPackageConstraints = $this->resolveCustomComposerPackageConstraints();
+            $lockedCustomPackageVersions = $this->resolveLockedComposerPackageVersions(array_keys($customPackageConstraints));
             $url = $this->buildArchiveUrl($updateRepository, $git['version']);
             $this->line('<fg=green>Start download Evolution CMS</>');
             $url = file_get_contents($url);
@@ -222,7 +224,7 @@ HELP;
                 }
             }
             putenv('COMPOSER_HOME=' . EVO_CORE_PATH . 'composer');
-            $this->installComposerDependencies();
+            $this->installComposerDependencies($customPackageConstraints, $lockedCustomPackageVersions);
             $this->runCoreMigrations();
             $this->updateBundledExtrasModule();
 
@@ -434,16 +436,25 @@ HELP;
     /**
      * Install Composer dependencies after core files are replaced.
      *
-     * The updater must not run Composer update here because third-party packages
-     * from custom Composer layers can receive untested version changes as a side
-     * effect of a core update. Composer install restores the vendor/autoload state
-     * from the lock file, then package discovery refreshes registered providers.
+     * Core dependencies are restored from the shipped lock file. Custom Composer
+     * packages need a scoped lock refresh first because the updated core lock does
+     * not contain packages merged from core/custom/composer.json.
      *
      * @since 3.5.7
+     * @param array<string, string> $customPackageConstraints Package constraints from core/custom/composer.json.
+     * @param array<string, string> $lockedCustomPackageVersions Package versions from the pre-update composer.lock.
      * @return void
      */
-    protected function installComposerDependencies(): void
+    protected function installComposerDependencies(array $customPackageConstraints = [], array $lockedCustomPackageVersions = []): void
     {
+        if ($customPackageConstraints !== []) {
+            $this->line('<fg=green>Restore Composer lock with custom packages</>');
+            $this->runCoreShellCommand($this->buildCustomComposerUpdateCommand(
+                $customPackageConstraints,
+                $lockedCustomPackageVersions
+            ));
+        }
+
         $this->line('<fg=green>Install Composer dependencies</>');
         $this->runCoreShellCommand($this->composerInstallCommand());
 
@@ -452,6 +463,112 @@ HELP;
 
         $this->line('<fg=green>Discover Composer packages</>');
         $this->runCoreShellCommand('php artisan package:discover');
+    }
+
+    /**
+     * Resolve Composer package constraints from the local custom Composer layer.
+     *
+     * Platform requirements such as php/ext-json are intentionally ignored because
+     * Composer cannot update them as packages.
+     *
+     * @since 3.5.7
+     * @return array<string, string>
+     */
+    protected function resolveCustomComposerPackageConstraints(): array
+    {
+        $customComposer = EVO_CORE_PATH . 'custom/composer.json';
+        if (!is_file($customComposer)) {
+            return [];
+        }
+
+        $composer = json_decode((string) file_get_contents($customComposer), true);
+        if (!is_array($composer)) {
+            throw new \RuntimeException('Invalid custom composer.json.');
+        }
+
+        $requires = $composer['require'] ?? [];
+        if (!is_array($requires)) {
+            return [];
+        }
+
+        $packages = [];
+        foreach ($requires as $package => $constraint) {
+            $package = trim((string) $package);
+            if ($this->isComposerPackageName($package)) {
+                $packages[strtolower($package)] = trim((string) $constraint);
+            }
+        }
+
+        return $packages;
+    }
+
+    /**
+     * Resolve currently locked versions for custom packages before core files are replaced.
+     *
+     * @since 3.5.7
+     * @param array<int, string> $packages Composer package names.
+     * @return array<string, string>
+     */
+    protected function resolveLockedComposerPackageVersions(array $packages): array
+    {
+        $lockFile = EVO_CORE_PATH . 'composer.lock';
+        if (!is_file($lockFile)) {
+            return [];
+        }
+
+        $lock = json_decode((string) file_get_contents($lockFile), true);
+        if (!is_array($lock)) {
+            return [];
+        }
+
+        $packageMap = array_fill_keys(array_map('strtolower', $packages), true);
+        $versions = [];
+
+        foreach (['packages', 'packages-dev'] as $section) {
+            foreach (($lock[$section] ?? []) as $package) {
+                $name = strtolower((string) ($package['name'] ?? ''));
+                if ($name !== '' && isset($packageMap[$name]) && !empty($package['version'])) {
+                    $versions[$name] = (string) $package['version'];
+                }
+            }
+        }
+
+        return $versions;
+    }
+
+    /**
+     * Build a scoped Composer update command for packages from core/custom/composer.json.
+     *
+     * @since 3.5.7
+     * @param array<string, string> $customPackageConstraints Package constraints from core/custom/composer.json.
+     * @param array<string, string> $lockedCustomPackageVersions Package versions from the pre-update composer.lock.
+     * @return string
+     */
+    protected function buildCustomComposerUpdateCommand(array $customPackageConstraints, array $lockedCustomPackageVersions = []): string
+    {
+        $packages = [];
+        foreach ($customPackageConstraints as $package => $constraint) {
+            if (!$this->isComposerPackageName($package)) {
+                continue;
+            }
+
+            $package = strtolower($package);
+            $version = trim((string) ($lockedCustomPackageVersions[$package] ?? ''));
+            $packages[] = $version !== '' ? $package . ':' . $version : $package;
+        }
+
+        if ($packages === []) {
+            throw new \RuntimeException('Custom Composer packages are missing.');
+        }
+
+        return 'composer update '
+            . implode(' ', array_map('escapeshellarg', array_values(array_unique($packages))))
+            . ' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
+    }
+
+    protected function isComposerPackageName(string $package): bool
+    {
+        return preg_match('~^[a-z0-9][a-z0-9_.-]*/[a-z0-9][a-z0-9_.-]*$~i', $package) === 1;
     }
 
     protected function composerInstallCommand(): string

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -64,23 +64,52 @@ test('site updater repairs composer vendor state before artisan commands', funct
 
     expect($source)
         ->toContain('$this->composerInstallCommand()')
+        ->toContain('buildCustomComposerUpdateCommand')
         ->toContain('$this->composerDumpAutoloadCommand()')
         ->toContain("runCoreShellCommand('php artisan package:discover')")
         ->toContain('--no-scripts')
         ->toContain('return self::FAILURE')
         ->toContain('catch (\Throwable $exception)')
         ->not->toContain('new Application()')
-        ->not->toContain("runCoreShellCommand('composer update')")
-        ->not->toContain('buildCustomComposerUpdateCommand')
-        ->not->toContain('resolveCustomComposerPackages');
+        ->not->toContain("runCoreShellCommand('composer update')");
 
-    expect(strpos($source, 'installComposerDependencies();'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
+    expect($source)->toContain('$this->installComposerDependencies($customPackageConstraints, $lockedCustomPackageVersions);');
+    expect(strpos($source, '$this->installComposerDependencies($customPackageConstraints, $lockedCustomPackageVersions);'))->toBeLessThan(strpos($source, '$this->runCoreMigrations();'));
+    expect(strpos($source, 'buildCustomComposerUpdateCommand'))->toBeLessThan(strpos($source, '$this->composerInstallCommand()'));
     expect(strpos($source, '$this->composerInstallCommand()'))->toBeLessThan(strpos($source, '$this->composerDumpAutoloadCommand()'));
     expect(strpos($source, '$this->composerDumpAutoloadCommand()'))->toBeLessThan(strpos($source, "runCoreShellCommand('php artisan package:discover')"));
     expect(invokeSiteUpdateMethod($this->command, 'composerInstallCommand'))
         ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts');
     expect(invokeSiteUpdateMethod($this->command, 'composerDumpAutoloadCommand'))
         ->toBe('composer dump-autoload -o --no-dev --classmap-authoritative --no-scripts');
+});
+
+test('site updater accepts only real composer package names for scoped updates', function () {
+    expect(invokeSiteUpdateMethod($this->command, 'isComposerPackageName', ['seiger/scommerce']))->toBeTrue();
+    expect(invokeSiteUpdateMethod($this->command, 'isComposerPackageName', ['evolution-cms/eai']))->toBeTrue();
+    expect(invokeSiteUpdateMethod($this->command, 'isComposerPackageName', ['php']))->toBeFalse();
+    expect(invokeSiteUpdateMethod($this->command, 'isComposerPackageName', ['ext-json']))->toBeFalse();
+    expect(invokeSiteUpdateMethod($this->command, 'isComposerPackageName', ['bad package']))->toBeFalse();
+});
+
+test('site updater builds scoped composer update for custom packages', function () {
+    $command = invokeSiteUpdateMethod($this->command, 'buildCustomComposerUpdateCommand', [
+        [
+            'evolution-cms/eai' => '^1.0',
+            'php' => '^8.3',
+            'ext-json' => '*',
+            'Seiger/sTask' => '*',
+            'bad package' => '*',
+            'seiger/scommerce' => '*',
+        ],
+        [
+            'evolution-cms/eai' => '1.2.3',
+            'seiger/stask' => '1.0.10',
+        ],
+    ]);
+
+    expect($command)
+        ->toBe("composer update 'evolution-cms/eai:1.2.3' 'seiger/stask:1.0.10' 'seiger/scommerce' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts");
 });
 
 test('site updater can read bundled extras installer metadata', function () {


### PR DESCRIPTION
## Summary
- Snapshot packages declared in `core/custom/composer.json` before replacing core files.
- Refresh the new Composer lock/vendor state only for those custom packages, using their pre-update locked versions when available.
- Keep core dependencies on the shipped lock by running `composer install` after the scoped custom package lock refresh.
- Add coverage for the scoped Composer update command.

## Root Cause
After the updater replaces the core with a fresh 3.5.x archive, the shipped `composer.lock` does not contain packages merged from `core/custom/composer.json`. A plain `composer install` then fails because custom package requirements are present through the merge plugin but absent from the lock. On the next run, package providers can already be missing from `vendor`, causing artisan bootstrap failures before the updater can repair the site.

## Validation
- `php -l src/Console/SiteUpdateCommand.php`
- `php -l tests/Unit/Console/SiteUpdateCommandTest.php`
- `git diff --check`

Could not run focused Pest/PHPUnit because `core/vendor/bin/pest` and `core/vendor/bin/phpunit` are not installed in this checkout. `composer validate --no-check-publish --no-check-all` reports the existing lock-file mismatch and version-field warning.

Closes #2378