### PR TITLE
[FIX] Fix in_array() type error by converting collection to array

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -3591,13 +3591,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
         $timeout = 20 * 60; // Delete multiple user-sessions after 20min
         $validSessionTimeLimit = $this->time - $timeout;
 
-        $activeUserSids = [];
-        $activeUserSids = ActiveUserSession::all();
-        if ($activeUserSids->count() > 0) {
-            $activeUserSids = $activeUserSids->pluck('sid');
-        } else {
-            $activeUserSids = [];
-        }
+        $activeUserSids = ActiveUserSession::pluck('sid')->toArray();
 
         $activeUsers = ActiveUser::query()->orderBy('lasthit', 'DESC')->get();
 


### PR DESCRIPTION
And simplify retrieval of active user session IDs.

Refactor active user session retrieval to use pluck directly.   

Replaced verbose `ActiveUserSession::all()` + `pluck` + conditional logic with a single `ActiveUserSession::pluck('sid')->toArray()` call. This fixes a TypeError caused by passing a Laravel Collection to `in_array()`, which requires a plain PHP array.  

`$activeUserSids = $activeUserSids->pluck('sid');` returned collection then `in_array($row['sid'], $activeUserSids)` failed.

« Evolution CMS Parse Error »
in_array(): Argument #2 ($haystack) must be of type array, Illuminate\Support\Collection given