### PR TITLE
Fix site updater Composer binary resolution

### DIFF
--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -561,7 +561,7 @@ HELP;
             throw new \RuntimeException('Custom Composer packages are missing.');
         }
 
-        return 'composer update '
+        return $this->composerBinaryCommand() . ' update '
             . implode(' ', array_map('escapeshellarg', array_values(array_unique($packages))))
             . ' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
     }
@@ -573,12 +573,108 @@ HELP;
 
     protected function composerInstallCommand(): string
     {
-        return 'composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
+        return $this->composerBinaryCommand() . ' install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts';
     }
 
     protected function composerDumpAutoloadCommand(): string
     {
-        return 'composer dump-autoload -o --no-dev --classmap-authoritative --no-scripts';
+        return $this->composerBinaryCommand() . ' dump-autoload -o --no-dev --classmap-authoritative --no-scripts';
+    }
+
+    /**
+     * Resolve a Composer executable command for shell calls.
+     *
+     * Some shared-hosting environments expose Composer only as a shell alias such
+     * as ~/.composer/composer. PHP executes update commands through /bin/sh, where
+     * interactive bash aliases are not available, so we need a real executable path.
+     *
+     * @since 3.5.7
+     * @return string Composer command safe for shell usage.
+     */
+    protected function composerBinaryCommand(): string
+    {
+        foreach (['COMPOSER_BINARY', 'COMPOSER_BIN'] as $envName) {
+            $configured = trim((string) getenv($envName));
+            if ($configured !== '') {
+                return escapeshellarg($configured);
+            }
+        }
+
+        if ($this->shellCommandExists('composer')) {
+            return 'composer';
+        }
+
+        foreach ($this->composerBinaryCandidates() as $candidate) {
+            if (is_file($candidate) && is_executable($candidate)) {
+                return escapeshellarg($candidate);
+            }
+        }
+
+        return 'composer';
+    }
+
+    /**
+     * Build fallback Composer executable candidates.
+     *
+     * @since 3.5.7
+     * @return array<int, string>
+     */
+    protected function composerBinaryCandidates(): array
+    {
+        $candidates = [
+            '/usr/local/bin/composer',
+            '/usr/bin/composer',
+        ];
+
+        foreach ($this->homeDirectories() as $home) {
+            $candidates[] = $home . '/.composer/composer';
+        }
+
+        return array_values(array_unique($candidates));
+    }
+
+    /**
+     * Resolve possible home directories without relying on shell "~" expansion.
+     *
+     * @since 3.5.7
+     * @return array<int, string>
+     */
+    protected function homeDirectories(): array
+    {
+        $homes = [];
+
+        foreach (['HOME', 'USERPROFILE'] as $envName) {
+            $home = trim((string) getenv($envName));
+            if ($home !== '') {
+                $homes[] = rtrim(str_replace('\\', '/', $home), '/');
+            }
+        }
+
+        if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
+            $user = posix_getpwuid(posix_getuid());
+            if (is_array($user) && !empty($user['dir'])) {
+                $homes[] = rtrim(str_replace('\\', '/', (string) $user['dir']), '/');
+            }
+        }
+
+        return array_values(array_unique(array_filter($homes)));
+    }
+
+    /**
+     * Check whether a command is available to the non-interactive shell.
+     *
+     * @since 3.5.7
+     * @param string $command Command name.
+     * @return bool
+     */
+    protected function shellCommandExists(string $command): bool
+    {
+        $output = [];
+        $exitCode = 1;
+
+        exec('command -v ' . escapeshellarg($command) . ' >/dev/null 2>&1', $output, $exitCode);
+
+        return (int) $exitCode === 0;
     }
 
     protected function normalizeUpdateRepository(string $repository): string

--- a/core/tests/Unit/Console/SiteUpdateCommandTest.php
+++ b/core/tests/Unit/Console/SiteUpdateCommandTest.php
@@ -61,6 +61,11 @@ test('site updater runs core migrations during updates', function () {
 
 test('site updater repairs composer vendor state before artisan commands', function () {
     $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/SiteUpdateCommand.php');
+    $composerBinary = getenv('COMPOSER_BINARY');
+    $composerBin = getenv('COMPOSER_BIN');
+
+    putenv('COMPOSER_BINARY');
+    putenv('COMPOSER_BIN');
 
     expect($source)
         ->toContain('$this->composerInstallCommand()')
@@ -82,6 +87,9 @@ test('site updater repairs composer vendor state before artisan commands', funct
         ->toBe('composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts');
     expect(invokeSiteUpdateMethod($this->command, 'composerDumpAutoloadCommand'))
         ->toBe('composer dump-autoload -o --no-dev --classmap-authoritative --no-scripts');
+
+    $composerBinary === false ? putenv('COMPOSER_BINARY') : putenv('COMPOSER_BINARY=' . $composerBinary);
+    $composerBin === false ? putenv('COMPOSER_BIN') : putenv('COMPOSER_BIN=' . $composerBin);
 });
 
 test('site updater accepts only real composer package names for scoped updates', function () {
@@ -93,6 +101,12 @@ test('site updater accepts only real composer package names for scoped updates',
 });
 
 test('site updater builds scoped composer update for custom packages', function () {
+    $composerBinary = getenv('COMPOSER_BINARY');
+    $composerBin = getenv('COMPOSER_BIN');
+
+    putenv('COMPOSER_BINARY');
+    putenv('COMPOSER_BIN');
+
     $command = invokeSiteUpdateMethod($this->command, 'buildCustomComposerUpdateCommand', [
         [
             'evolution-cms/eai' => '^1.0',
@@ -110,6 +124,33 @@ test('site updater builds scoped composer update for custom packages', function 
 
     expect($command)
         ->toBe("composer update 'evolution-cms/eai:1.2.3' 'seiger/stask:1.0.10' 'seiger/scommerce' --with-all-dependencies --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts");
+
+    $composerBinary === false ? putenv('COMPOSER_BINARY') : putenv('COMPOSER_BINARY=' . $composerBinary);
+    $composerBin === false ? putenv('COMPOSER_BIN') : putenv('COMPOSER_BIN=' . $composerBin);
+});
+
+test('site updater accepts configured composer binary', function () {
+    $composerBinary = getenv('COMPOSER_BINARY');
+
+    putenv('COMPOSER_BINARY=/home/evo/.composer/composer');
+
+    expect(invokeSiteUpdateMethod($this->command, 'composerInstallCommand'))
+        ->toBe("'/home/evo/.composer/composer' install --no-dev --no-interaction --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts");
+    expect(invokeSiteUpdateMethod($this->command, 'composerDumpAutoloadCommand'))
+        ->toBe("'/home/evo/.composer/composer' dump-autoload -o --no-dev --classmap-authoritative --no-scripts");
+
+    $composerBinary === false ? putenv('COMPOSER_BINARY') : putenv('COMPOSER_BINARY=' . $composerBinary);
+});
+
+test('site updater checks user local composer path as a fallback', function () {
+    $home = getenv('HOME');
+
+    putenv('HOME=/home/evo');
+
+    expect(invokeSiteUpdateMethod($this->command, 'composerBinaryCandidates'))
+        ->toContain('/home/evo/.composer/composer');
+
+    $home === false ? putenv('HOME') : putenv('HOME=' . $home);
 });
 
 test('site updater can read bundled extras installer metadata', function () {


### PR DESCRIPTION
## Summary
- resolve Composer through a dedicated helper before building site-update shell commands
- keep the existing `composer` command when it is available to the non-interactive shell
- add fallbacks for explicitly configured `COMPOSER_BINARY` / `COMPOSER_BIN` and user-local `$HOME/.composer/composer`

## Why
On some shared-hosting installs Composer is available only as an interactive shell alias, for example:

```bash
composer is aliased to `/home/evo/.composer/composer`
```

The site updater runs Composer commands from PHP through `/bin/sh`, where that bash alias is not available. The update then fails with `sh: 1: composer: not found` even though `composer --version` works in the user's SSH session.

## Changed files
- `core/src/Console/SiteUpdateCommand.php` — Composer command generation now resolves a real executable or configured binary before running update/install/dump-autoload.
- `core/tests/Unit/Console/SiteUpdateCommandTest.php` — added coverage for configured Composer binary and `$HOME/.composer/composer` fallback candidates.

## Validation
- `php8.4 -l core/src/Console/SiteUpdateCommand.php`
- `php8.4 -l core/tests/Unit/Console/SiteUpdateCommandTest.php`
- `git diff --check`
- manual reflection smoke check for `COMPOSER_BINARY=/home/evo/.composer/composer`

## Notes
The full Pest suite was not run in this checkout because `core/vendor/bin/pest` is missing.