### PR TITLE
fix(migrations): make all ways of running migrations consistent on update [WIP]

### DIFF
--- a/core/database/migrations/2026_01_17_000000_fix_columns.php
+++ b/core/database/migrations/2026_01_17_000000_fix_columns.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('active_user_locks', function (Blueprint $table) {
+            $table->string('sid', 128)->change();
+        });
+        Schema::table('active_user_sessions', function (Blueprint $table) {
+            $table->string('sid', 128)->change();
+        });
+        Schema::table('active_users', function (Blueprint $table) {
+            $table->string('sid', 128)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('active_user_locks', function (Blueprint $table) {
+            $table->string('sid', 32)->change();
+        });
+        Schema::table('active_user_sessions', function (Blueprint $table) {
+            $table->string('sid', 32)->change();
+        });
+        Schema::table('active_users', function (Blueprint $table) {
+            $table->string('sid', 32)->change();
+        });
+    }
+};

--- a/core/src/Console/SiteUpdateCommand.php
+++ b/core/src/Console/SiteUpdateCommand.php
@@ -227,6 +227,7 @@ HELP;
             putenv('COMPOSER_HOME=' . EVO_CORE_PATH . 'composer');
             $this->installComposerDependencies($customPackageConstraints, $lockedCustomPackageVersions);
             $this->runCoreMigrations();
+            $this->runUpdateSeeders();
             $this->updateBundledExtrasModule();
 
             $this->line('<fg=green>Remove Install Directory</>');
@@ -248,6 +249,36 @@ HELP;
     {
         $this->line('<fg=green>Run Core Migrations</>');
         $this->runCoreShellCommand('php artisan migrate --force');
+    }
+
+    /**
+     * Apply the version update seeders shipped in the install directory.
+     *
+     * The web installer and install-folder CLI updater run seed('update') to apply
+     * data fixes such as permission renames. "php artisan make:site update" replaces
+     * files directly and used to skip this step, so manager/CLI updates drifted from
+     * the installer. The seeders use only the DB facade and are idempotent, so running
+     * them here before the install directory is removed keeps every path consistent.
+     *
+     * @since 3.5.7
+     * @return void
+     */
+    protected function runUpdateSeeders(): void
+    {
+        $seedDir = EVO_BASE_PATH . 'install/stubs/seeds/update';
+        if (!is_dir($seedDir)) {
+            return;
+        }
+
+        $this->line('<fg=green>Apply update seeders</>');
+
+        foreach (glob($seedDir . '/*.php') as $filename) {
+            require_once $filename;
+            $class = 'EvolutionCMS\\Installer\\Update\\' . basename($filename, '.php');
+            if (class_exists($class) && is_subclass_of($class, \Illuminate\Database\Seeder::class)) {
+                (new $class())->run();
+            }
+        }
     }
 
     /**

--- a/core/tests/Feature/SiteUpdateE2ETest.php
+++ b/core/tests/Feature/SiteUpdateE2ETest.php
@@ -1,0 +1,269 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Tier 2 update e2e: install "version N" then update to "N+1"
+|--------------------------------------------------------------------------
+|
+| This exercises the real database side of an Evolution CMS update without
+| network or Composer. It builds a populated "version N" SQLite database that
+| looks like a site installed before the system task feature existed, then runs
+| the same code the "php artisan make:site update" / manager update path runs:
+|
+|   - the core-only migration that creates the system task tables
+|   - SiteUpdateCommand::runUpdateSeeders() (the install update seeders)
+|   - SiteUpdateCommand::updateBundledExtrasModule()
+|
+| and asserts the resulting schema/data deltas. The file-replacement mechanics
+| (download/extract/move) are covered separately via the static helpers, since
+| the full command run mutates EVO_BASE_PATH and belongs to the Tier 3 sandbox.
+*/
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Facade;
+
+if (!defined('EVO_BASE_PATH')) {
+    define('EVO_BASE_PATH', str_replace('\\', '/', dirname(__DIR__, 3)) . '/');
+}
+if (!defined('EVO_CORE_PATH')) {
+    define('EVO_CORE_PATH', EVO_BASE_PATH . 'core/');
+}
+
+/**
+ * Boot a standalone SQLite database with the DB/Schema facades wired so real
+ * migrations and seeders (which use facades) can run inside the bare PHPUnit harness.
+ */
+function bootSiteUpdateDatabase(): Capsule
+{
+    $capsule = new Capsule();
+    $capsule->addConnection([
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+    $capsule->setAsGlobal();
+    $capsule->bootEloquent();
+
+    $container = $capsule->getContainer();
+    $container->instance('db', $capsule->getDatabaseManager());
+    $container->bind('db.schema', fn () => $capsule->getConnection()->getSchemaBuilder());
+    Facade::setFacadeApplication($container);
+    Model::setConnectionResolver($capsule->getDatabaseManager());
+
+    // The global \DB / \Schema aliases are normally registered by Laravel's
+    // AliasLoader; the bare test harness has no app, so register them for the
+    // migrations that reference \DB::getTablePrefix() etc.
+    if (!class_exists('DB', false)) {
+        class_alias(\Illuminate\Support\Facades\DB::class, 'DB');
+    }
+    if (!class_exists('Schema', false)) {
+        class_alias(\Illuminate\Support\Facades\Schema::class, 'Schema');
+    }
+
+    return $capsule;
+}
+
+/**
+ * Create and seed a database that mirrors a site installed at "version N":
+ * a healthy ACL baseline, legacy permission keys that the update seeder renames,
+ * and an existing (outdated) bundled Extras module — but no system task tables.
+ */
+function seedVersionNDatabase(Capsule $capsule): void
+{
+    $schema = $capsule->getConnection()->getSchemaBuilder();
+
+    $schema->create('permissions_groups', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->nullable();
+        $table->string('lang_key')->nullable();
+        $table->dateTime('created_at')->nullable();
+        $table->dateTime('updated_at')->nullable();
+    });
+    $schema->create('permissions', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->nullable();
+        $table->string('key')->nullable();
+        $table->string('lang_key')->nullable();
+        $table->integer('disabled')->default(0);
+        $table->integer('group_id')->default(0);
+        $table->dateTime('created_at')->nullable();
+        $table->dateTime('updated_at')->nullable();
+    });
+    $schema->create('user_roles', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->nullable();
+    });
+    $schema->create('role_permissions', function (Blueprint $table) {
+        $table->increments('id');
+        $table->integer('role_id');
+        $table->string('permission')->nullable();
+        $table->dateTime('created_at')->nullable();
+        $table->dateTime('updated_at')->nullable();
+    });
+    $schema->create('categories', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('category')->nullable();
+        $table->integer('rank')->default(0);
+    });
+    $schema->create('site_modules', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->nullable();
+        $table->text('description')->nullable();
+        $table->longText('modulecode')->nullable();
+        $table->longText('properties')->nullable();
+        $table->string('guid')->nullable();
+        $table->integer('enable_sharedparams')->default(0);
+        $table->integer('category')->default(0);
+        $table->integer('disabled')->default(0);
+        $table->dateTime('createdon')->nullable();
+        $table->dateTime('editedon')->nullable();
+    });
+    // Present-but-empty so the migration's updater wiring guard returns cleanly.
+    $schema->create('site_plugins', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->nullable();
+        $table->text('description')->nullable();
+        $table->longText('plugincode')->nullable();
+        $table->longText('properties')->nullable();
+        $table->integer('disabled')->default(0);
+    });
+    $schema->create('site_plugin_events', function (Blueprint $table) {
+        $table->increments('id');
+        $table->integer('pluginid');
+        $table->integer('evtid');
+        $table->integer('priority')->default(0);
+    });
+    $schema->create('system_eventnames', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name')->nullable();
+    });
+
+    $db = $capsule->getConnection();
+
+    // Healthy ACL baseline so the migration's repair self-skips (14 groups, role 1,
+    // access_permissions assigned to role 1).
+    for ($id = 1; $id <= 14; $id++) {
+        $db->table('permissions_groups')->insert(['id' => $id, 'name' => 'Group ' . $id, 'lang_key' => 'group_' . $id]);
+    }
+    $db->table('user_roles')->insert(['id' => 1, 'name' => 'Administrator']);
+    $db->table('permissions')->insert([
+        ['name' => 'Manager access permissions', 'key' => 'access_permissions', 'lang_key' => 'manager_access_permissions', 'group_id' => 11],
+        // Legacy keys the update seeder must rename.
+        ['name' => 'Logout', 'key' => 'logout', 'lang_key' => 'role_logout', 'group_id' => 1],
+        ['name' => 'Web access permissions', 'key' => 'web_access_permissions', 'lang_key' => 'role_web_access_permissions', 'group_id' => 11],
+    ]);
+    $db->table('role_permissions')->insert([
+        ['role_id' => 1, 'permission' => 'access_permissions'],
+        ['role_id' => 1, 'permission' => 'logout'],
+        ['role_id' => 1, 'permission' => 'web_access_permissions'],
+    ]);
+
+    // An outdated bundled Extras module that the update should refresh.
+    $db->table('site_modules')->insert([
+        'name' => 'Extras',
+        'description' => '<strong>0.1.0</strong> outdated',
+        'modulecode' => 'OUTDATED MODULE CODE',
+        'properties' => '',
+        'guid' => 'store435243542tf542t5t',
+        'enable_sharedparams' => 1,
+        'category' => 0,
+    ]);
+}
+
+/**
+ * Run the database-affecting steps of an update, exactly as the update command does.
+ */
+function runSiteUpdateDatabaseSteps(): void
+{
+    // 1. Core-only migration that ships the system task tables and permissions.
+    (new \CreateSystemCliTasksTables())->up();
+
+    // 2 + 3. The real update command steps, with console output suppressed.
+    $command = new class extends \EvolutionCMS\Console\SiteUpdateCommand {
+        public function line($string, $style = null, $verbosity = null)
+        {
+            // Suppress: there is no console output bound in the test harness.
+        }
+
+        public function applyUpdateSeeders(): void
+        {
+            $this->runUpdateSeeders();
+        }
+
+        public function applyExtrasModule(): void
+        {
+            $this->updateBundledExtrasModule();
+        }
+    };
+
+    $command->applyUpdateSeeders();
+    $command->applyExtrasModule();
+}
+
+test('update from version N to N+1 applies migrations, update seeders and refreshes Extras', function () {
+    $capsule = bootSiteUpdateDatabase();
+    seedVersionNDatabase($capsule);
+    $db = $capsule->getConnection();
+
+    // Pre-state sanity: version "N" has no system task tables and legacy permission keys.
+    expect($db->getSchemaBuilder()->hasTable('system_cli_tasks'))->toBeFalse()
+        ->and($db->table('permissions')->where('key', 'logout')->exists())->toBeTrue();
+
+    runSiteUpdateDatabaseSteps();
+
+    // Migration created the system task tables.
+    expect($db->getSchemaBuilder()->hasTable('system_cli_tasks'))->toBeTrue()
+        ->and($db->getSchemaBuilder()->hasTable('system_cli_task_logs'))->toBeTrue()
+        ->and($db->getSchemaBuilder()->hasTable('system_scheduler_health'))->toBeTrue()
+        ->and($db->getSchemaBuilder()->hasTable('system_worker_health'))->toBeTrue();
+
+    // Migration registered + granted the system task permissions to the admin role.
+    expect($db->table('permissions')->where('key', 'system_tasks.site_update')->exists())->toBeTrue()
+        ->and($db->table('role_permissions')->where('role_id', 1)->where('permission', 'system_tasks.view')->exists())->toBeTrue();
+
+    // Update seeder renamed the legacy permission keys (both definitions and grants).
+    expect($db->table('permissions')->where('key', 'logout')->exists())->toBeFalse()
+        ->and($db->table('permissions')->where('key', 'widget_recent_info')->exists())->toBeTrue()
+        ->and($db->table('permissions')->where('key', 'web_access_permissions')->exists())->toBeFalse()
+        ->and($db->table('permissions')->where('key', 'manage_groups')->exists())->toBeTrue()
+        ->and($db->table('permissions')->where('key', 'manage_document_permissions')->exists())->toBeTrue()
+        ->and($db->table('role_permissions')->where('permission', 'logout')->exists())->toBeFalse()
+        ->and($db->table('role_permissions')->where('permission', 'widget_recent_info')->exists())->toBeTrue()
+        ->and($db->table('role_permissions')->where('permission', 'manage_groups')->exists())->toBeTrue();
+
+    // Bundled Extras module refreshed from install/assets/modules/store.tpl.
+    $extras = $db->table('site_modules')->where('name', 'Extras')->first();
+    expect($extras->description)->toContain('<strong>0.2.0</strong>')
+        ->and($extras->modulecode)->toContain('store/core.php')
+        ->and($extras->modulecode)->not->toBe('OUTDATED MODULE CODE');
+});
+
+test('moveFiles replaces files into the destination tree', function () {
+    $base = sys_get_temp_dir() . '/evo_update_' . uniqid();
+    $src = $base . '/src';
+    $dest = $base . '/dest';
+    mkdir($src . '/core', 0777, true);
+    mkdir($dest . '/core', 0777, true);
+    file_put_contents($src . '/index.php', 'NEW');
+    file_put_contents($src . '/core/file.php', 'NEW CORE');
+    file_put_contents($dest . '/index.php', 'OLD');
+
+    \EvolutionCMS\Console\SiteUpdateCommand::moveFiles($src, $dest);
+
+    expect(file_get_contents($dest . '/index.php'))->toBe('NEW')
+        ->and(file_get_contents($dest . '/core/file.php'))->toBe('NEW CORE');
+
+    \EvolutionCMS\Console\SiteUpdateCommand::rmdirs($base);
+});
+
+test('rmdirs removes a directory tree recursively', function () {
+    $dir = sys_get_temp_dir() . '/evo_rmdirs_' . uniqid();
+    mkdir($dir . '/nested', 0777, true);
+    file_put_contents($dir . '/nested/leaf.txt', 'x');
+
+    \EvolutionCMS\Console\SiteUpdateCommand::rmdirs($dir);
+
+    expect(is_dir($dir))->toBeFalse();
+});

--- a/core/tests/Unit/Install/UpdatePathConsistencyTest.php
+++ b/core/tests/Unit/Install/UpdatePathConsistencyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Guards that the four update entry points stay consistent:
+ *  - web installer (install/src/controllers/install.php)
+ *  - install-folder CLI installer (install/cli-install.php)
+ *  - "php artisan make:site update" (core/src/Console/SiteUpdateCommand.php)
+ *  - manager / CMS update (delegates to make:site update)
+ *
+ * The core migration set (core/database/migrations) is authoritative. Every path
+ * must end up applying the same migrations and the same update seeders.
+ */
+
+$baseline = '2025_12_25_000000_initial_schema';
+$coreMigrationsDir = dirname(__DIR__, 3) . '/database/migrations';
+$stubMigrationsDir = dirname(__DIR__, 4) . '/install/stubs/migrations';
+
+$migrationNames = static function (string $dir): array {
+    return array_map(
+        static fn ($file) => basename($file, '.php'),
+        (array) glob($dir . '/*.php')
+    );
+};
+
+test('post-baseline install migrations are mirrored into core', function () use ($baseline, $coreMigrationsDir, $stubMigrationsDir, $migrationNames) {
+    // The core path (make:site update / CMS) only runs core/database/migrations, so
+    // any post-baseline migration shipped in install/stubs must also live in core or
+    // that path would silently skip it.
+    $coreNames = $migrationNames($coreMigrationsDir);
+    $postBaselineStub = array_filter(
+        $migrationNames($stubMigrationsDir),
+        static fn ($name) => strcmp($name, $baseline) > 0
+    );
+
+    $missingFromCore = array_values(array_diff($postBaselineStub, $coreNames));
+
+    expect($missingFromCore)->toBe([]);
+});
+
+test('the sid column fix is part of the authoritative core migration set', function () use ($coreMigrationsDir) {
+    expect(is_file($coreMigrationsDir . '/2026_01_17_000000_fix_columns.php'))->toBeTrue();
+});
+
+test('installer paths run the core migrate after seeding', function () {
+    // So core-only migrations (e.g. the system task tables) reach installer-based sites.
+    $webInstaller = (string) file_get_contents(dirname(__DIR__, 4) . '/install/src/controllers/install.php');
+    $cliInstaller = (string) file_get_contents(dirname(__DIR__, 4) . '/install/cli-install.php');
+
+    expect($webInstaller)->toContain("Console::call('migrate', ['--force' => true])")
+        ->and($cliInstaller)->toContain("Console::call('migrate', ['--force' => true])");
+});
+
+test('make:site update applies the update seeders', function () {
+    $command = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/SiteUpdateCommand.php');
+
+    expect($command)->toContain('protected function runUpdateSeeders')
+        ->and($command)->toContain('$this->runUpdateSeeders();')
+        ->and($command)->toContain('install/stubs/seeds/update');
+});

--- a/install/cli-install.php
+++ b/install/cli-install.php
@@ -169,6 +169,10 @@ class InstallEvo
         bootstrapInstallMigrationHistory($installMigrationsPath);
         Console::call('migrate', ['--path' => $installMigrationsPath, '--realpath' => true, '--force' => true]);
         seed('update');
+        // Apply core-only migrations (core/database/migrations) not present in the
+        // install/stubs chain, e.g. the system task tables. Runs after seeding so the
+        // guarded ACL repairs inside those migrations detect a healthy baseline.
+        Console::call('migrate', ['--force' => true]);
         echo 'Evolution CMS updated!' . "\n";
         $this->checkRemoveInstall();
         $this->removeInstall();
@@ -534,6 +538,10 @@ class InstallEvo
         $systemSettings[] = ['setting_name' => 'emailsender', 'setting_value' => $this->cmsAdminEmail];
         $systemSettings[] = ['setting_name' => 'fe_editor_lang', 'setting_value' => $this->language];
         \EvolutionCMS\Models\SystemSetting::insert($systemSettings);
+        // Apply core-only migrations (core/database/migrations) not present in the
+        // install/stubs chain, e.g. the system task tables. Runs after seeding so the
+        // guarded ACL repairs inside those migrations detect a healthy baseline.
+        Console::call('migrate', ['--force' => true]);
         success('✔ All migrations is done!');
     }
 

--- a/install/src/controllers/install.php
+++ b/install/src/controllers/install.php
@@ -238,6 +238,13 @@ try {
         } else {
             seed('update');
         }
+
+        // Apply core-only migrations (core/database/migrations) that are not part
+        // of the install/stubs incremental chain, e.g. the system task tables. This
+        // runs after seeding so the ACL baseline is already populated and the guarded
+        // repairs inside those migrations detect a healthy baseline and skip.
+        Console::call('migrate', ['--force' => true]);
+
         $installLevel = 4;
     }
 


### PR DESCRIPTION
 Changes

 1 — every path applies the same migrations

  1. core/database/migrations/2026_01_17_000000_fix_columns.php (new) — copy of the install-stub migration that widens active_user*.sid to 128. Previously make:site update/CMS (which run the core migrate) never applied it.      
  Idempotent (->change()), anonymous class.
  2. install/src/controllers/install.php and install/cli-install.php (update() + migrationAndSeed()) — run the core migrate (Console::call('migrate', ['--force' => true])) after seeding. This is the "have every path run the same
  migrate" option: installer-based installs/updates now pick up core-only migrations like 2026_04_12_..._create_system_cli_tasks_tables (the scheduler/worker tables the in-manager updater depends on), which they never created   
  before.

  I deliberately did not copy create_system_cli_tasks_tables verbatim into install/stubs: I verified its ACL-baseline repair would fire against the empty permission tables during a fresh installer migrate and then collide with  
  seed('install')'s explicit-id inserts. Running it after seeding (healthy baseline → repair self-skips) avoids that. Confirmed safe re: class redeclaration — Migrator::run (vendor/.../Migrator.php:131) only requires pending    
  migrations, so the shared CreateFileGroupsTable class is never declared twice in one process.

2 — make:site update runs the update seeders

3. core/src/Console/SiteUpdateCommand.php — new runUpdateSeeders() called after runCoreMigrations(), before the install dir is removed. It mirrors the installer's seed('update') (the permission renames in
  install/stubs/seeds/update/*), which the manager/CLI path previously skipped entirely.

  Regression guard

  4. core/tests/Unit/Install/UpdatePathConsistencyTest.php (new, 4 tests, all passing) — asserts post-baseline install migrations are mirrored into core, that fix_columns is in core, that both installers run the core migrate,   
  and that the command applies the update seeders.

  Test status

  - My new test: 4/4 pass; FileGroupsSchemaAndModelTest: pass.
  - Pre-existing failures unrelated to my diff (verified untouched vs HEAD): ManagerAclBaselineRepairTest (asserts a non-namespaced seeder string the migration doesn't use) and 3 SiteUpdateCommandTest cases (two are Windows     
  escapeshellarg quoting "..." vs '...'; one is Undefined constant EVO_BASE_PATH in updatePlaceholderFilePairs(), a method I didn't modify, invoked without the constant defined). These fail on the unmodified tree too.
  
  TBD
e2e update test - sandboxed update with local zip fixtures. Deterministic, no network, exercises the real migrate + seed + Extras logic. Requires adding test seams to the command:
  - extract the three network calls into overridable methods — fetchTags(), downloadArchive($url), fetchReleases() — so a test subclass returns local fixtures (the command already favors many small protected methods, so this    
  fits the style);
  - override installComposerDependencies() to a no-op in the test (vendor is already present in the sandbox).

  Flow: copy a minimal tree to a temp dir representing version N → install it against a temp SQLite DB → run the update with a N+1 zip fixture → assert. Fixtures only need the files the update touches (factory/version.php,      
  install/stubs/migrations + seeds/update, install/assets/modules/store.tpl, a couple of core files). Runs in seconds.

