### PR TITLE
fix(store): keep version options readable in dark theme

### DIFF
--- a/assets/modules/store/css/style.css
+++ b/assets/modules/store/css/style.css
@@ -431,6 +431,8 @@ nav ul li {
   inset: 0;
   width: 100%;
   height: 100%;
+  color: #212529;
+  color-scheme: light;
   opacity: 0;
   z-index: 3;
   cursor: pointer;
@@ -441,6 +443,11 @@ nav ul li {
   border: 0 !important;
   margin: 0;
   padding: 0;
+}
+
+.install_extras select[name="link"] option {
+  color: #212529;
+  background-color: #ffffff;
 }
 
 .catalog_item.liststyle .install_extras select[name="link"] {
@@ -2040,6 +2047,13 @@ body.darkness {
 
 .darkness .install_extras select[name="link"] {
   background: transparent !important;
+  color: #212529;
+  color-scheme: light;
+}
+
+.darkness .install_extras select[name="link"] option {
+  color: #212529;
+  background-color: #ffffff;
 }
 
 .darkness .install_extras .store-version-wrap {


### PR DESCRIPTION
## Summary
- Keep the Extras package version native dropdown readable in dark theme.
- Force the hidden version select popup/options to use a light color scheme with dark text, while leaving the custom dark wrapper styling intact.

## Risk
LOW. The change is scoped to the Extras install version selector (`.install_extras select[name="link"]`) and its native options.

## Validation
- `git diff --check`
- Confirmed the dark-theme CSS override now preserves dark option text for the native version dropdown.

## Visual Proof

![Visual proof for #2382](https://github.com/MiddleSokilAI/evolution/releases/download/proof-assets-2382/evo-2382-dark-select-proof.png)

The proof fixture uses the Store module CSS and demonstrates the native version dropdown/options before and after the dark-theme option color fix.

Closes #2382