### PR TITLE
feat(core): add compact count helper

### DIFF
--- a/core/functions/helper.php
+++ b/core/functions/helper.php
@@ -160,6 +160,62 @@ if (!function_exists('nicesize')) {
     }
 }
 
+if (!function_exists('niceCount')) {
+    /**
+     * Format a quantity using compact SI suffixes.
+     *
+     * Values below one thousand are returned without a suffix. Larger values
+     * are scaled through K, M, B, T, and Q while insignificant trailing zeroes
+     * are removed. This keeps counters compact without changing their numeric
+     * source value.
+     *
+     * @param int|float $count Quantity to format
+     * @param int $precision Maximum decimal places for a scaled value
+     * @return string Compact human-readable quantity
+     * @since 3.6.0
+     *
+     * @example
+     * niceCount(999); // "999"
+     * niceCount(1500); // "1.5K"
+     * niceCount(5000000); // "5M"
+     */
+    function niceCount(int|float $count, int $precision = 1): string
+    {
+        $value = (float)$count;
+        if (!is_finite($value)) {
+            return '0';
+        }
+
+        $precision = max(0, min(3, $precision));
+        $units = ['', 'K', 'M', 'B', 'T', 'Q'];
+        $unitIndex = 0;
+
+        while (abs($value) >= 1000 && $unitIndex < count($units) - 1) {
+            $value /= 1000;
+            $unitIndex++;
+        }
+
+        if ($unitIndex === 0) {
+            $formatted = number_format($value, $precision, '.', '');
+
+            return $precision > 0 ? rtrim(rtrim($formatted, '0'), '.') : $formatted;
+        }
+
+        $decimals = $precision;
+        if (abs(round($value, $decimals)) >= 1000 && $unitIndex < count($units) - 1) {
+            $value /= 1000;
+            $unitIndex++;
+        }
+
+        $formatted = number_format($value, $decimals, '.', '');
+        if ($decimals > 0) {
+            $formatted = rtrim(rtrim($formatted, '0'), '.');
+        }
+
+        return $formatted . $units[$unitIndex];
+    }
+}
+
 if (!function_exists('niceEta')) {
     /**
      * Format ETA seconds into human-readable format.

--- a/core/tests/Unit/NiceCountHelperTest.php
+++ b/core/tests/Unit/NiceCountHelperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+test('niceCount keeps small quantities readable', function () {
+    expect(niceCount(0))->toBe('0')
+        ->and(niceCount(999))->toBe('999')
+        ->and(niceCount(-42))->toBe('-42');
+});
+
+test('niceCount compacts large quantities with SI suffixes', function () {
+    expect(niceCount(1000))->toBe('1K')
+        ->and(niceCount(1500))->toBe('1.5K')
+        ->and(niceCount(100000))->toBe('100K')
+        ->and(niceCount(125000))->toBe('125K')
+        ->and(niceCount(125500))->toBe('125.5K')
+        ->and(niceCount(999999))->toBe('1M')
+        ->and(niceCount(5000000))->toBe('5M')
+        ->and(niceCount(2500000000))->toBe('2.5B');
+});
+
+test('niceCount supports configurable precision', function () {
+    expect(niceCount(1234567, 2))->toBe('1.23M')
+        ->and(niceCount(1234567, 0))->toBe('1M');
+});


### PR DESCRIPTION
## Що змінено

- додано глобальний helper `niceCount(int|float $count, int $precision = 1): string`
- значення від 1000 скорочуються через SI-суфікси `K`, `M`, `B`, `T`, `Q`
- незначущі нулі прибираються: `1500 → 1.5K`, `5000000 → 5M`
- коректно оброблено перехід після округлення: `999999 → 1M`
- додано unit-тести для малих, великих, від’ємних значень і керованої точності

## Навіщо

Helper призначений для компактного відображення лічильників у manager UI без зміни сирого числового значення, яке використовується для сортування та обчислень.

## Перевірка

- `php -l core/functions/helper.php`
- `php -l core/tests/Unit/NiceCountHelperTest.php`
- ручні runtime assertions для boundary-значень — успішно
- Pest binary у checkout не встановлений, тому повний test runner локально не запускався
- `git diff --check`