### PR TITLE
fix(core): clean stale resource locks

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -3677,7 +3677,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
             foreach ($rs as $row) {
                 $userSids[] = $row['sid'];
             }
-            ActiveUserSession::whereNotIn('sid', $userSids)->delete();
+            ActiveUserLock::whereNotIn('sid', $userSids)->delete();
         } else {
             ActiveUserLock::query()->truncate();
         }

--- a/core/tests/Unit/Manager/StaleLockCleanupTest.php
+++ b/core/tests/Unit/Manager/StaleLockCleanupTest.php
@@ -1,0 +1,8 @@
+<?php
+
+test('expired lock cleanup removes locks for inactive session ids', function () {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Core.php');
+
+    expect($source)->toContain("ActiveUserLock::whereNotIn('sid', \$userSids)->delete();")
+        ->and($source)->not->toContain("ActiveUserSession::whereNotIn('sid', \$userSids)->delete();");
+});


### PR DESCRIPTION
## Summary
- fix stale resource-lock cleanup so expired lock rows are removed from `active_user_locks`
- keep active session cleanup behavior intact
- add a small regression test guarding the cleanup target

## Issue
Fixes #2390.

## Validation
- `wsl php -l /mnt/h/PhpstormProjects/Extras/evolution/core/src/Core.php`
- `wsl php -l /mnt/h/PhpstormProjects/Extras/evolution/core/tests/Unit/Manager/StaleLockCleanupTest.php`
- `git diff --check`
- `composer validate --no-check-publish --no-check-all` reports the existing lock-file freshness warning only

Pest is not installed in this checkout under `core/vendor/bin`, so the new Pest test was not run locally.

## Risk
Low. The change only redirects stale-lock cleanup from the session table to the lock table that the surrounding code comment and behavior already target.