### PR TITLE
fix(timezone): restore site timezone helper

### DIFF
--- a/core/src/Support/SiteTimezone.php
+++ b/core/src/Support/SiteTimezone.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace EvolutionCMS\Support;
+
+use DateTimeZone;
+use Throwable;
+
+/**
+ * Resolves and applies the site's IANA timezone without making bootstrap fragile.
+ */
+final class SiteTimezone
+{
+    /**
+     * Return the IANA timezone identifiers accepted by the system setting.
+     *
+     * Backward-compatible aliases are intentionally excluded so the manager
+     * offers only current PHP timezone identifiers.
+     *
+     * @since 3.5.8
+     */
+    public static function identifiers(): array
+    {
+        return DateTimeZone::listIdentifiers(DateTimeZone::ALL);
+    }
+
+    /**
+     * Determine whether a value is a supported IANA timezone identifier.
+     *
+     * @since 3.5.8
+     */
+    public static function isValid(mixed $timezone): bool
+    {
+        return is_string($timezone)
+            && $timezone !== ''
+            && in_array($timezone, self::identifiers(), true);
+    }
+
+    /**
+     * Resolve a saved timezone, falling back to PHP's configured server timezone.
+     *
+     * UTC is the final safety fallback for an invalid server configuration.
+     *
+     * @since 3.5.8
+     */
+    public static function resolve(mixed $timezone, ?string $serverTimezone = null): string
+    {
+        $serverTimezone ??= date_default_timezone_get();
+
+        if (self::isValid($timezone)) {
+            return $timezone;
+        }
+
+        return self::isValid($serverTimezone) ? $serverTimezone : 'UTC';
+    }
+
+    /**
+     * Apply the resolved timezone to PHP and return the applied identifier.
+     *
+     * @since 3.5.8
+     */
+    public static function apply(mixed $timezone, ?string $serverTimezone = null): string
+    {
+        $resolved = self::resolve($timezone, $serverTimezone);
+
+        try {
+            if (date_default_timezone_set($resolved)) {
+                return $resolved;
+            }
+        } catch (Throwable) {
+            // Keep bootstrap operational even when PHP rejects a saved value.
+        }
+
+        date_default_timezone_set('UTC');
+
+        return 'UTC';
+    }
+}

--- a/core/tests/Unit/SiteTimezoneTest.php
+++ b/core/tests/Unit/SiteTimezoneTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use EvolutionCMS\Support\SiteTimezone;
+
+test('it lists selectable php timezone identifiers', function () {
+    expect(SiteTimezone::identifiers())
+        ->toContain('UTC')
+        ->toContain('Europe/Kyiv')
+        ->not->toContain('Europe/Kiev');
+});
+
+test('it resolves invalid site timezone to the server timezone', function () {
+    expect(SiteTimezone::resolve('', 'Europe/Kyiv'))->toBe('Europe/Kyiv');
+    expect(SiteTimezone::resolve('Europe/Kiev', 'Europe/Kyiv'))->toBe('Europe/Kyiv');
+    expect(SiteTimezone::resolve('Invalid/Timezone', 'UTC'))->toBe('UTC');
+});
+
+test('it applies the resolved timezone without breaking bootstrap', function () {
+    $previousTimezone = date_default_timezone_get();
+
+    try {
+        expect(SiteTimezone::apply('Europe/Kyiv'))->toBe('Europe/Kyiv');
+        expect(date_default_timezone_get())->toBe('Europe/Kyiv');
+
+        expect(SiteTimezone::apply('Invalid/Timezone', 'UTC'))->toBe('UTC');
+        expect(date_default_timezone_get())->toBe('UTC');
+    } finally {
+        date_default_timezone_set($previousTimezone);
+    }
+});


### PR DESCRIPTION
## Summary
- Restore the missing `EvolutionCMS\Support\SiteTimezone` helper required during core bootstrap.
- Use current PHP timezone identifiers from `DateTimeZone::ALL`, so `Europe/Kyiv` is selectable and legacy `Europe/Kiev` is not offered.
- Add unit coverage for `identifiers()`, `resolve()`, and `apply()`.

## Validation
- `php -l core/src/Support/SiteTimezone.php`
- `php -l core/tests/Unit/SiteTimezoneTest.php`
- PHP smoke check for `Europe/Kyiv`, legacy `Europe/Kiev` fallback, and invalid timezone fallback to `UTC`

`vendor/bin/pest` is not available in this checkout, so the focused Pest test could not be executed locally.

## Risk
Low. The change restores a missing support class already referenced by core call sites and keeps invalid timezone values from breaking bootstrap.

Fixes #2397