### PR TITLE
Update config_check.inc.php

### DIFF
--- a/manager/includes/config_check.inc.php
+++ b/manager/includes/config_check.inc.php
@@ -147,7 +147,7 @@ if (!empty($warnings)) {
 
     for ($i=0;$i<count($warnings);$i++) {
         switch ($warnings[$i][0]) {
-            case $_lang['configcheck_configinc'];
+            case $_lang['configcheck_configinc']:
                 $warnings[$i][1] = $_lang['configcheck_configinc_msg'];
                 if(empty($_SESSION["mgrConfigCheck"])) EvolutionCMS()->logEvent(0,3,$warnings[$i][1],$_lang['configcheck_configinc']);
                 break;


### PR DESCRIPTION
Виправлено використання `case ...;` у конструкціях `switch`.

Починаючи з PHP 8.5 така конструкція позначена як `deprecated`. Замість крапки з комою (`;`) після `case` тепер використовується двокрапка (`:`), що відповідає сучасному синтаксису PHP.

Зміна не впливає на логіку роботи CMS та усуває відповідне попередження.