### PR TITLE
fix(packages): report remove require results

### DIFF
--- a/core/src/Console/Packages/InstallPackageRequireCommand.php
+++ b/core/src/Console/Packages/InstallPackageRequireCommand.php
@@ -49,7 +49,9 @@ class InstallPackageRequireCommand extends Command
         $originalComposerContents = $composerExisted ? file_get_contents($this->composer) : null;
 
         $this->checkFile();
-        $this->updateArray();
+        if ($this->updateArray() === false) {
+            return self::FAILURE;
+        }
         $this->putComposer();
         if ($this->argument('composer_run') == 1) {
             $exitCode = $this->runComposer();
@@ -94,10 +96,10 @@ class InstallPackageRequireCommand extends Command
     {
         putenv('COMPOSER_HOME=' . EVO_CORE_PATH . 'composer');
         $arguments = ['command' => 'update'];
-        if ($this->option('no-dev')) {
+        if ($this->hasCommandOption('no-dev') && $this->option('no-dev')) {
             $arguments['--no-dev'] = true;
         }
-        if ($this->option('optimize-autoloader')) {
+        if ($this->hasCommandOption('optimize-autoloader') && $this->option('optimize-autoloader')) {
             $arguments['--optimize-autoloader'] = true;
         }
         $input = new ArrayInput($arguments);
@@ -117,6 +119,11 @@ class InstallPackageRequireCommand extends Command
             }
         }
 
+    }
+
+    protected function hasCommandOption(string $name): bool
+    {
+        return $this->getDefinition()->hasOption($name);
     }
 
     protected function restoreComposerState($composerExisted, $originalComposerContents)

--- a/core/src/Console/Packages/RemovePackageRequireCommand.php
+++ b/core/src/Console/Packages/RemovePackageRequireCommand.php
@@ -20,13 +20,31 @@ class RemovePackageRequireCommand extends InstallPackageRequireCommand
 
         $target = strtolower(trim((string) $this->argument('key')));
         if ($target === '') {
-            return;
+            $this->error('Package requirement name is empty.');
+            return false;
         }
 
         foreach (array_keys($this->composerArray['require']) as $requireKey) {
-            if (strtolower(trim((string) $requireKey)) === $target) {
+            if ($this->matchesRequirementKey((string) $requireKey, $target)) {
                 unset($this->composerArray['require'][$requireKey]);
+                $this->info('Removed package requirement: ' . $requireKey);
+                return true;
             }
         }
+
+        $this->error('Package requirement not found: ' . $this->argument('key'));
+        return false;
+    }
+
+    protected function matchesRequirementKey(string $requireKey, string $target): bool
+    {
+        $requireKey = strtolower(trim($requireKey));
+        if ($requireKey === $target) {
+            return true;
+        }
+
+        $packageName = basename(str_replace('\\', '/', $requireKey));
+
+        return $packageName === $target;
     }
 }

--- a/core/tests/Unit/Console/PackageRequireCommandTest.php
+++ b/core/tests/Unit/Console/PackageRequireCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use EvolutionCMS\Console\Packages\InstallPackageRequireCommand;
+use EvolutionCMS\Console\Packages\RemovePackageRequireCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+if (!defined('EVO_CORE_PATH')) {
+    define('EVO_CORE_PATH', dirname(__DIR__, 3) . '/');
+}
+
+function setPackageRequireComposerPath(InstallPackageRequireCommand $command, string $path): void
+{
+    $reflection = new ReflectionClass(InstallPackageRequireCommand::class);
+    $property = $reflection->getProperty('composer');
+    $property->setAccessible(true);
+    $property->setValue($command, $path);
+}
+
+test('package remove require reports missing requirements', function () {
+    $composer = tempnam(sys_get_temp_dir(), 'evo-composer-');
+    file_put_contents($composer, json_encode([
+        'name' => 'evolutioncms/custom',
+        'require' => [
+            'seiger/stask' => '*',
+        ],
+    ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+    $command = new RemovePackageRequireCommand();
+    setPackageRequireComposerPath($command, $composer);
+
+    $tester = new CommandTester($command);
+    $exitCode = $tester->execute([
+        'key' => 'sCommerce',
+        'composer_run' => '0',
+    ]);
+
+    $composerData = json_decode((string) file_get_contents($composer), true);
+
+    expect($exitCode)->toBe(1)
+        ->and($tester->getDisplay())->toContain('Package requirement not found: sCommerce')
+        ->and($composerData['require'])->toHaveKey('seiger/stask');
+
+    @unlink($composer);
+});
+
+test('package remove require reports removed requirements', function () {
+    $composer = tempnam(sys_get_temp_dir(), 'evo-composer-');
+    file_put_contents($composer, json_encode([
+        'name' => 'evolutioncms/custom',
+        'require' => [
+            'Seiger/sCommerce' => '*',
+            'seiger/stask' => '*',
+        ],
+    ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+    $command = new RemovePackageRequireCommand();
+    setPackageRequireComposerPath($command, $composer);
+
+    $tester = new CommandTester($command);
+    $exitCode = $tester->execute([
+        'key' => 'sCommerce',
+        'composer_run' => '0',
+    ]);
+
+    $composerData = json_decode((string) file_get_contents($composer), true);
+
+    expect($exitCode)->toBe(0)
+        ->and($tester->getDisplay())->toContain('Removed package requirement: Seiger/sCommerce')
+        ->and($composerData['require'])->not->toHaveKey('Seiger/sCommerce')
+        ->and($composerData['require'])->toHaveKey('seiger/stask');
+
+    @unlink($composer);
+});
+
+test('composer option handling is guarded by command signature', function () {
+    $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Console/Packages/InstallPackageRequireCommand.php');
+
+    expect($source)
+        ->toContain("hasCommandOption('no-dev')")
+        ->toContain("hasCommandOption('optimize-autoloader')");
+});


### PR DESCRIPTION
## Summary
- Guard inherited Composer option access so `package:removerequire` no longer fails with `The "no-dev" option does not exist.`
- Report explicit remove results: successful removal, empty package key, or package requirement not found.
- Allow direct CLI removal by package basename, so `package:removerequire sCommerce 0` can remove `Seiger/sCommerce` / `seiger/scommerce` from `core/custom/composer.json`.
- Add focused command tests for missing and removed requirements plus the Composer option guard.

## Validation
- `git diff --check`

Local PHP validation could not be executed in this session: WSL fails to start with `Wsl/Service/CreateInstance/CreateVm/HCS/ERROR_FILE_NOT_FOUND`, and Windows `php` is not available in PATH.

## Risk
Low. The change is scoped to package require/remove console commands and keeps `package:installrequire` behavior unchanged except for safely checking whether optional Composer flags exist before reading them.

Fixes #2400