### PR TITLE
fix(manager): reject empty hash login (#2407)

### DIFF
--- a/core/src/Controllers/Users/LogInOut.php
+++ b/core/src/Controllers/Users/LogInOut.php
@@ -121,6 +121,15 @@ class LogInOut extends AbstractController implements ManagerTheme\PageController
 
     public function loginFromHash()
     {
+        $hash = trim((string)($_GET['hash'] ?? ''));
+
+        if ($hash === '') {
+            jsAlert(\Lang::get('global.login_processor_unknown_user'));
+            exit();
+        }
+
+        $_GET['hash'] = $hash;
+
         try {
             \UserManager::hashLogin($_GET);
         } catch (ServiceActionException $exception) {

--- a/core/tests/Unit/Controllers/ManagerEmptyHashLoginTest.php
+++ b/core/tests/Unit/Controllers/ManagerEmptyHashLoginTest.php
@@ -1,0 +1,16 @@
+<?php
+
+test('manager hash login rejects empty hashes before user lookup', function () {
+    $source = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controllers/Users/LogInOut.php');
+
+    $emptyHashGuard = strpos($source, "\$hash === ''");
+    $hashLogin = strpos($source, '\\UserManager::hashLogin($_GET)');
+
+    expect($source)
+        ->toContain("\$hash = trim((string)(\$_GET['hash'] ?? ''));")
+        ->toContain("jsAlert(\\Lang::get('global.login_processor_unknown_user'))")
+        ->toContain("\$_GET['hash'] = \$hash;")
+        ->and($emptyHashGuard)->not->toBeFalse()
+        ->and($hashLogin)->not->toBeFalse()
+        ->and($emptyHashGuard)->toBeLessThan($hashLogin);
+});


### PR DESCRIPTION
## Problem
Guest requests to `/manager/?a=0&hash=` enter the hash-login flow with an empty password reset hash. That can reach the user lookup path for empty `cachepwd` values and trigger a 500 instead of a controlled login failure.

## Branch Reason
The fix belongs in the manager login controller because `a=0` is the public login action and the invalid hash must be rejected before `UserManager::hashLogin()` is called.

## Change Summary
- trim the incoming reset hash before hash login
- reject empty or whitespace-only hashes with the existing unknown-user login alert
- normalize the hash value before passing the request data to `UserManager::hashLogin()`
- add regression coverage to keep the empty-hash guard before the user lookup call

## Landing Surfaces
- `core/src/Controllers/Users/LogInOut.php`
- `core/tests/Unit/Controllers/ManagerEmptyHashLoginTest.php`

## Verification
- `git diff --check`
- source-level regression test added

PHP lint/Pest runtime was not available locally: Windows `php` is not on PATH and WSL fails with `Wsl/Service/CreateInstance/CreateVm/HCS/ERROR_FILE_NOT_FOUND`.

## Remaining Open Items
None.