### PR TITLE
fix(tests): load CoreTest autoload from core vendor

### DIFF
--- a/core/tests/Unit/CoreTest.php
+++ b/core/tests/Unit/CoreTest.php
@@ -45,7 +45,7 @@ beforeEach(function () {
         define('EVO_CLASS', 'Tests\Mocks\MockDocumentParser');
     }
 
-    $autoload = EVO_BASE_PATH . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+    $autoload = EVO_CORE_PATH . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
     if (!file_exists($autoload)) {
         throw new \RuntimeException("Run: composer install");
     }


### PR DESCRIPTION
## Problem

The new CI test job installs Composer dependencies from `core/`, so test dependencies and `autoload.php` are available under `core/vendor`.

`CoreTest` bootstrapped `EVO_BASE_PATH` as the repository root but still looked for `vendor/autoload.php` directly under that root, which makes the `getTagsFromContent` test group fail with `Run: composer install` in CI.

## Root Cause

The test mixed the public repository root path with the core Composer vendor path. `EVO_CORE_PATH` already points at `core/`, so the test should use it for the Composer autoloader.

## Change Summary

- Load `CoreTest` autoload from `EVO_CORE_PATH . 'vendor/autoload.php'`.
- Keep the existing `EVO_BASE_PATH`, `EVO_CORE_PATH`, storage, manager, and site URL constants unchanged.

## Validation

- `git diff --check`

Local runtime checks were limited because PHP/Composer are not available in this Windows shell, WSL failed to start, and Docker Desktop is not running. The change directly matches the CI install layout from `.github/workflows/ci.yml`.

## Risk

Low. The change is scoped to one unit test bootstrap path and does not affect runtime code.
