### PR TITLE
Update SqlFormatter.php

### DIFF
--- a/core/src/Support/Formatter/SqlFormatter.php
+++ b/core/src/Support/Formatter/SqlFormatter.php
@@ -1748,7 +1748,11 @@ class SqlFormatter
             if ($binding instanceof DateTime) {
                 return htmlspecialchars('\''.$binding->format('Y-m-d H:i:s').'\'', ENT_NOQUOTES, 'UTF-8');
             }
-
+            
+            if ($binding === null) {
+                    return 'NULL';
+            }
+            
             return htmlspecialchars($binding, ENT_NOQUOTES, 'UTF-8');
         }, $bindings);
         $sql = str_replace(['%', '?'], ['%%', '%s'], $sql);


### PR DESCRIPTION
Додано окрему обробку значення NULL у SqlFormatter::prepare(). Це запобігає передачі null у htmlspecialchars() та усуває попередження Deprecated у PHP 8.5.