### PR TITLE
Update plugin.updater.php

### DIFF
--- a/assets/plugins/updater/plugin.updater.php
+++ b/assets/plugins/updater/plugin.updater.php
@@ -165,7 +165,9 @@ if (!function_exists('updaterFetchReleasePublishedAt')) {
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_HTTPHEADER, ['User-Agent: updateNotify widget']);
             $response = curl_exec($ch);
-            curl_close($ch);
+            if (PHP_VERSION_ID < 80500) {
+                curl_close($ch);
+            }
 
             if (!is_string($response) || $response === '' || strpos(ltrim($response), '{') !== 0) {
                 continue;
@@ -948,7 +950,9 @@ if ($role != 1 && $wdgVisibility == 'AdminOnly') {
                     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
                     curl_setopt($ch, CURLOPT_HTTPHEADER, ['User-Agent: updateNotify widget']);
                     $info = curl_exec($ch);
-                    curl_close($ch);
+                    if (PHP_VERSION_ID < 80500) {
+                        curl_close($ch);
+                    }
                     if (substr($info, 0, 1) != '[') {
                         return;
                     }


### PR DESCRIPTION
Виправлено використання `curl_close()` у плагіні `Updater` для сумісності з PHP 8.5.

Починаючи з PHP 8.5, функція `curl_close()` позначена як `Deprecated`, оскільки починаючи з PHP 8.0 вона більше не має функціонального ефекту.

### Що змінено

Виклики `curl_close()` обгорнуто перевіркою версії PHP:

if (PHP_VERSION_ID < 80500) {
    curl_close($ch);
}

Зміни внесено в обидва місця використання `curl_close()` у `Updater`.

### Сумісність

- PHP < 8.5 — `curl_close()` продовжує виконуватися.
- PHP 8.5+ — `curl_close()` не виконується, тому `Deprecated` більше не виникає.

Інша логіка роботи `Updater` не змінюється.