### PR TITLE
Update Modifiers.php

### DIFF
--- a/core/src/Legacy/Modifiers.php
+++ b/core/src/Legacy/Modifiers.php
@@ -1018,20 +1018,20 @@ class Modifiers implements ModifiersInterface
                 $where = [];
                 foreach ($_ as $opt) {
                     switch (trim($opt)) {
-                        case 'page';
-                        case '!folder';
+                        case 'page':
+                        case '!folder':
                         case '!isfolder':
                             $where[] = 'sc.isfolder=0';
                             break;
-                        case 'folder';
+                        case 'folder':
                         case 'isfolder':
                             $where[] = 'sc.isfolder=1';
                             break;
-                        case  'menu';
+                        case  'menu':
                         case  'show_menu':
                             $where[] = 'sc.hidemenu=0';
                             break;
-                        case '!menu';
+                        case '!menu':
                         case '!show_menu':
                             $where[] = 'sc.hidemenu=1';
                             break;


### PR DESCRIPTION
Виправлено застарілий синтаксис case у Legacy/Modifiers

Замінено використання крапки з комою (;) після операторів case на стандартний синтаксис із двокрапкою (:).

Це усуває Deprecated-попередження у PHP 8.5
та не змінює логіку роботи коду.