### PR TITLE
fix(core): removed eval from PHx and hardened @FILE

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -87,6 +87,24 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
     public $documentOutput;
     public $tstart = 0;
     public $mstart = 0;
+    /**
+     * Conditional-tag commands referenced by index from the source generated in
+     * mergeConditionalTagsContent(), so they never have to be quoted into it.
+     *
+     * @var array<int, string>
+     */
+    private $ctagCmds = [];
+
+    /**
+     * Extensions @FILE refuses to serve. `.php` alone left `.phtml`/`.php5`/`.inc` readable as
+     * plain text, which discloses their source.
+     *
+     * @var string[]
+     */
+    private const AT_BIND_FILE_DENIED_EXTENSIONS = [
+        '.php', '.php3', '.php4', '.php5', '.php7', '.php8', '.phps', '.phtml', '.phar', '.inc',
+    ];
+
     public $minParserPasses = 2;
     public $maxParserPasses = 10;
     public $documentObject = [];
@@ -1872,6 +1890,12 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
             $content
         );
 
+        // The command is handed to _parseCTagCMD() by index instead of being quoted into the
+        // generated source. Escaping it was never sufficient: a backslash in front of the quote
+        // consumed the escape and let the rest of the command close the string literal and run as
+        // PHP. Passing a reference removes the concatenation, so there is nothing left to escape.
+        $ctagOffset = count($this->ctagCmds);
+
         $pieces = explode('<@IF:', $content);
         foreach ($pieces as $i => $split) {
             if ($i === 0) {
@@ -1879,8 +1903,8 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
                 continue;
             }
             [$cmd, $text] = explode('>', $split, 2);
-            $cmd = str_replace("'", "\'", $cmd);
-            $content .= "<?php if(\$this->_parseCTagCMD('" . $cmd . "')): ?>";
+            $index = array_push($this->ctagCmds, $cmd) - 1;
+            $content .= '<?php if($this->_parseCTagCMD($this->ctagCmds[' . $index . '])): ?>';
             $content .= $text;
         }
         $pieces = explode('<@ELSEIF:', $content);
@@ -1890,15 +1914,21 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
                 continue;
             }
             [$cmd, $text] = explode('>', $split, 2);
-            $cmd = str_replace("'", "\'", $cmd);
-            $content .= "<?php elseif(\$this->_parseCTagCMD('" . $cmd . "')): ?>";
+            $index = array_push($this->ctagCmds, $cmd) - 1;
+            $content .= '<?php elseif($this->_parseCTagCMD($this->ctagCmds[' . $index . '])): ?>';
             $content .= $text;
         }
 
         $content = str_replace(['<@ELSE>', '<@ENDIF>'], ['<?php else:?>', '<?php endif;?>'], $content);
         ob_start();
-        eval ('?>' . $content);
-        $content = ob_get_clean();
+        try {
+            eval ('?>' . $content);
+        } finally {
+            $content = ob_get_clean();
+            // A nested parse has already trimmed its own entries, so the indices baked into the
+            // source above stayed valid for the whole eval.
+            array_splice($this->ctagCmds, $ctagOffset);
+        }
         $content = str_replace(
             ["{$sp}h", "{$sp}p", "{$sp}s", "{$sp}e"],
             ['<?php', '<?=', '<?', '?>'],
@@ -2316,28 +2346,94 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
         $this->setConfig('enable_filter', $_);
         $key = str_replace(['(', ')'], ["['", "']"], $key);
         $key = rtrim($key, ';');
-        if (Str::contains($key, '$_SESSION')) {
-            $_ = $_SESSION;
-            $key = str_replace('$_SESSION', '$_', $key);
-            if (isset($_['mgrFormValues'])) {
-                unset($_['mgrFormValues']);
-            }
-            if (isset($_['token'])) {
-                unset($_['token']);
-            }
-        }
-        if (Str::contains($key, '[')) {
-            $value = $key ? eval ("return {$key};") : '';
-        } elseif (0 < eval ("return count({$key});")) {
-            $value = eval ("return print_r({$key},true);");
-        } else {
-            $value = '';
-        }
+
+        // The superglobal is read by walking the array, not by evaluating the tag. eval() only
+        // looked safe here because `(` and `)` were rewritten away, but PHP's backtick operator
+        // needs no parentheses, so `[[$_SERVER . `id` ]]` reached the shell.
+        $value = $this->resolveSGVar($key);
+
         if ($modifiers !== false) {
             $value = $this->applyFilter($value, $modifiers, $key);
         }
 
         return $value;
+    }
+
+    /**
+     * Read one superglobal entry named by a parser tag.
+     *
+     * Accepts `$_GET(key)` and `$_GET['key']` (the former is rewritten into the latter by the
+     * caller), nested to any depth, plus the bare `$_SERVER` form that dumps the whole array.
+     * Anything else - arithmetic, concatenation, backticks - is refused rather than evaluated.
+     *
+     * @param string $key
+     * @return mixed
+     * @since 3.5.8
+     */
+    private function resolveSGVar($key)
+    {
+        if (!preg_match('@^\$_(GET|POST|SESSION|COOKIE|REQUEST|SERVER|FILES|ENV)@', $key, $matches)) {
+            return '';
+        }
+
+        $path = [];
+        $rest = substr($key, strlen($matches[0]));
+        while ($rest !== '' && $rest !== false) {
+            if (!preg_match('@^\[\s*([\'"]?)([^\[\]\'"]*)\1\s*\]@', $rest, $accessor)) {
+                // Trailing characters that are not an array access: refuse the whole tag.
+                return '';
+            }
+            $path[] = $accessor[2];
+            $rest = substr($rest, strlen($accessor[0]));
+        }
+
+        $container = $this->getSuperGlobal($matches[1]);
+
+        if ($path === []) {
+            return count($container) > 0 ? print_r($container, true) : '';
+        }
+
+        $cursor = $container;
+        foreach ($path as $segment) {
+            if (!is_array($cursor) || !array_key_exists($segment, $cursor)) {
+                return '';
+            }
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     * @since 3.5.8
+     */
+    private function getSuperGlobal($name)
+    {
+        switch ($name) {
+            case 'GET':
+                return $_GET;
+            case 'POST':
+                return $_POST;
+            case 'COOKIE':
+                return $_COOKIE;
+            case 'REQUEST':
+                return $_REQUEST;
+            case 'SERVER':
+                return $_SERVER;
+            case 'FILES':
+                return $_FILES;
+            case 'ENV':
+                return $_ENV;
+            case 'SESSION':
+                $session = isset($_SESSION) && is_array($_SESSION) ? $_SESSION : [];
+                unset($session['mgrFormValues'], $session['token']);
+
+                return $session;
+        }
+
+        return [];
     }
 
     /**
@@ -6300,6 +6396,47 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
      * @param string $str
      * @return bool|mixed|string
      */
+    /**
+     * Resolve one @FILE candidate to a real path inside the installation, or false.
+     *
+     * The old check compared the unresolved concatenation against EVO_MANAGER_PATH, so a `..`
+     * segment walked straight past it - and past EVO_BASE_PATH - to anywhere the web user could
+     * read. Containment is decided on the resolved path instead.
+     *
+     * @param string $candidate
+     * @return string|false
+     * @since 3.5.8
+     */
+    private function resolveAtBindFilePath($candidate)
+    {
+        $resolved = realpath($candidate);
+        if ($resolved === false || !is_file($resolved)) {
+            return false;
+        }
+
+        $base = realpath(EVO_BASE_PATH);
+        if ($base === false) {
+            return false;
+        }
+
+        $resolved = str_replace(DIRECTORY_SEPARATOR, '/', $resolved);
+        $base = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $base), '/') . '/';
+
+        if (strpos($resolved, $base) !== 0) {
+            return false;
+        }
+
+        $manager = realpath(EVO_MANAGER_PATH);
+        if ($manager !== false) {
+            $manager = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $manager), '/') . '/';
+            if (strpos($resolved, $manager) === 0) {
+                return false;
+            }
+        }
+
+        return $resolved;
+    }
+
     public function atBindFileContent($str = '')
     {
 
@@ -6310,7 +6447,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
             $str = substr($str, 0, strpos("\n", $str));
         }
 
-        if ($this->getExtFromFilename($str) === '.php') {
+        if (in_array($this->getExtFromFilename($str), self::AT_BIND_FILE_DENIED_EXTENSIONS, true)) {
             return 'Could not retrieve PHP file.';
         }
 
@@ -6325,16 +6462,11 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
 
         $search_path = ['assets/tvs/', 'assets/chunks/', 'assets/templates/', $this->getConfig('rb_base_url') . 'files/', ''];
         foreach ($search_path as $path) {
-            $file_path = EVO_BASE_PATH . $path . $str;
-            if (strpos($file_path, EVO_MANAGER_PATH) === 0) {
-                return $errorMsg;
-            }
+            $file_path = $this->resolveAtBindFilePath(EVO_BASE_PATH . $path . $str);
 
-            if (is_file($file_path)) {
+            if ($file_path !== false) {
                 break;
             }
-
-            $file_path = false;
         }
 
         if (!$file_path) {

--- a/core/src/Legacy/Modifiers.php
+++ b/core/src/Legacy/Modifiers.php
@@ -2,6 +2,7 @@
 
 use EvolutionCMS\Interfaces\ModifiersInterface;
 use EvolutionCMS\Models\SiteTemplate;
+use EvolutionCMS\Support\ArithmeticExpression;
 use EvolutionCMS\Support\DataGrid;
 
 class Modifiers implements ModifiersInterface
@@ -479,7 +480,7 @@ class Modifiers implements ModifiersInterface
             case 'show':
             case 'this':
                 $conditional = implode(' ', $this->condition);
-                $isvalid = (int)(eval("return ({$conditional});"));
+                $isvalid = (int)ArithmeticExpression::evaluate($conditional);
                 if ($isvalid) {
                     return $this->srcValue;
                 }
@@ -487,7 +488,7 @@ class Modifiers implements ModifiersInterface
                 return null;
             case 'then':
                 $conditional = implode(' ', $this->condition);
-                $isvalid = (int)eval("return ({$conditional});");
+                $isvalid = (int)ArithmeticExpression::evaluate($conditional);
                 if ($isvalid) {
                     return $opt;
                 }
@@ -495,7 +496,7 @@ class Modifiers implements ModifiersInterface
                 return null;
             case 'else':
                 $conditional = implode(' ', $this->condition);
-                $isvalid = (int)eval("return ({$conditional});");
+                $isvalid = (int)ArithmeticExpression::evaluate($conditional);
                 if (!$isvalid) {
                     return $opt;
                 }
@@ -910,7 +911,9 @@ class Modifiers implements ModifiersInterface
                 }
                 $filter = str_replace('?', $value, $filter);
 
-                return eval("return {$filter};");
+                // The letter strip above leaves `$`, quotes and backslashes in place, which is
+                // enough to reach PHP through octal escapes; only arithmetic gets through now.
+                return ArithmeticExpression::evaluate($filter);
             case 'count':
                 if ($value == '') {
                     return 0;

--- a/core/src/Legacy/Phx.php
+++ b/core/src/Legacy/Phx.php
@@ -1,6 +1,7 @@
 <?php namespace EvolutionCMS\Legacy;
 
 use EvolutionCMS\Core;
+use EvolutionCMS\Support\ArithmeticExpression;
 
 /**
  * @deprecated
@@ -414,7 +415,9 @@ class Phx
                     case "math":
                         $filter = preg_replace("~([a-zA-Z\n\r\t\s])~", "", $modifier_value[$i]);
                         $filter = str_replace("?", $output, $filter);
-                        $output = eval("return " . $filter . ";");
+                        // The letter strip above never made this safe: `$`, quotes and backslashes
+                        // survive it, and octal escapes need no letters at all.
+                        $output = ArithmeticExpression::evaluate($filter);
                         break;
                     case "isnotempty":
                         if (!empty($output)) {
@@ -526,7 +529,9 @@ class Phx
      */
     private function runCode($code)
     {
-        return eval("return (" . $code . ");");
+        // $code is assembled from intval() results joined by `&&`/`||`, so the arithmetic
+        // evaluator covers it exactly and no eval() is needed to resolve it.
+        return ArithmeticExpression::evaluate($code);
     }
 
     // Event logging (debug)

--- a/core/src/Support/ArithmeticExpression.php
+++ b/core/src/Support/ArithmeticExpression.php
@@ -1,0 +1,466 @@
+<?php namespace EvolutionCMS\Support;
+
+/**
+ * Evaluate the arithmetic/boolean expressions that the template modifiers used to hand to eval().
+ *
+ * The `math`/`calc` modifiers accept a small expression built from the filtered modifier argument
+ * with the tag value substituted for `?`. Historically that string went straight into
+ * `eval("return {$expr};")`. The callers strip letters and whitespace first, which stops a template
+ * from naming a function - but it leaves `$`, quotes, backslashes and `;` in place, and those are
+ * enough to build a working payload out of octal string escapes alone.
+ *
+ * This evaluator accepts only the tokens arithmetic actually needs and rejects everything else, so
+ * there is no path from a template into PHP any more. Operators are applied with PHP's own
+ * semantics (int/float promotion, `/` returning int on an exact division, `%` casting to int), so a
+ * template that produced a value before produces the same value now.
+ *
+ * @since 3.5.8
+ */
+final class ArithmeticExpression
+{
+    /**
+     * Longest match first: `<=` must win over `<`, `===` over `==` over `=`.
+     */
+    private const OPERATORS = [
+        '===', '!==', '<=>',
+        '==', '!=', '<>', '<=', '>=', '&&', '||',
+        '+', '-', '*', '/', '%', '<', '>', '!',
+    ];
+
+    /**
+     * Binary operator precedence, mirroring PHP's own table. Higher binds tighter.
+     */
+    private const PRECEDENCE = [
+        '*' => 60, '/' => 60, '%' => 60,
+        '+' => 50, '-' => 50,
+        '<' => 40, '<=' => 40, '>' => 40, '>=' => 40, '<=>' => 40,
+        '==' => 30, '!=' => 30, '<>' => 30, '===' => 30, '!==' => 30,
+        '&&' => 20,
+        '||' => 10,
+    ];
+
+    /**
+     * Unary operators, all right-associative and binding tighter than any binary operator.
+     */
+    private const UNARY = ['u+' => 70, 'u-' => 70, '!' => 70];
+
+    /**
+     * Bounds that keep a hostile expression from costing more than it is worth. Real modifier
+     * arguments are a handful of characters; these are orders of magnitude above anything genuine.
+     */
+    private const MAX_LENGTH = 512;
+    private const MAX_TOKENS = 256;
+    private const MAX_DEPTH = 32;
+
+    /**
+     * Evaluate an expression, falling back to $default when it is not one we accept.
+     *
+     * @param mixed $expression
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function evaluate($expression, $default = 0)
+    {
+        $result = self::tryEvaluate($expression);
+
+        return $result === null ? $default : $result;
+    }
+
+    /**
+     * Evaluate an expression, returning null when it is not one we accept.
+     *
+     * @param mixed $expression
+     * @return int|float|bool|null
+     */
+    public static function tryEvaluate($expression)
+    {
+        if (!is_scalar($expression)) {
+            return null;
+        }
+
+        $expression = trim((string) $expression);
+        if ($expression === '' || strlen($expression) > self::MAX_LENGTH) {
+            return null;
+        }
+
+        $tokens = self::tokenize($expression);
+        if ($tokens === null) {
+            return null;
+        }
+
+        $rpn = self::toReversePolish($tokens);
+        if ($rpn === null) {
+            return null;
+        }
+
+        return self::evaluateReversePolish($rpn);
+    }
+
+    /**
+     * Split the expression into number literals, operators and parentheses.
+     *
+     * Unary `+`/`-`/`!` are distinguished from their binary forms here, while we still know whether
+     * the previous token closed an operand.
+     *
+     * @param string $expression
+     * @return array<int, array{0: string, 1: mixed}>|null
+     */
+    private static function tokenize($expression)
+    {
+        $tokens = [];
+        $length = strlen($expression);
+        $offset = 0;
+        // False directly after an operand (a number or a closing paren), which is the only position
+        // where `+`/`-` are binary.
+        $expectOperand = true;
+
+        while ($offset < $length) {
+            if (count($tokens) > self::MAX_TOKENS) {
+                return null;
+            }
+
+            $char = $expression[$offset];
+
+            if ($char === ' ' || $char === "\t" || $char === "\n" || $char === "\r") {
+                $offset++;
+                continue;
+            }
+
+            if ($char === '(') {
+                if (!$expectOperand) {
+                    // `2(3)` was never valid PHP either.
+                    return null;
+                }
+                $tokens[] = ['(', null];
+                $offset++;
+                continue;
+            }
+
+            if ($char === ')') {
+                if ($expectOperand) {
+                    return null;
+                }
+                $tokens[] = [')', null];
+                $offset++;
+                $expectOperand = false;
+                continue;
+            }
+
+            if (self::isDigit($char) || ($char === '.' && isset($expression[$offset + 1]) && self::isDigit($expression[$offset + 1]))) {
+                if (!$expectOperand) {
+                    return null;
+                }
+                $number = self::readNumber($expression, $offset);
+                if ($number === null) {
+                    return null;
+                }
+                $tokens[] = ['num', $number];
+                $expectOperand = false;
+                continue;
+            }
+
+            $operator = self::readOperator($expression, $offset);
+            if ($operator === null) {
+                return null;
+            }
+
+            if ($expectOperand) {
+                // Only `+`, `-` and `!` have a unary form; anything else here is a syntax error.
+                if ($operator === '+' || $operator === '-') {
+                    $tokens[] = ['op', 'u' . $operator];
+                    continue;
+                }
+                if ($operator === '!') {
+                    $tokens[] = ['op', '!'];
+                    continue;
+                }
+
+                return null;
+            }
+
+            if (!isset(self::PRECEDENCE[$operator])) {
+                // `!` cannot be binary.
+                return null;
+            }
+
+            $tokens[] = ['op', $operator];
+            $expectOperand = true;
+        }
+
+        if ($expectOperand || $tokens === []) {
+            // A trailing operator, or nothing at all.
+            return null;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * @param string $char
+     * @return bool
+     */
+    private static function isDigit($char)
+    {
+        return $char >= '0' && $char <= '9';
+    }
+
+    /**
+     * Read one decimal literal, advancing $offset past it.
+     *
+     * Exponents are deliberately unsupported: the callers strip `e` before we ever see the string,
+     * so accepting them here would only invent a syntax that never worked.
+     *
+     * @param string $expression
+     * @param int $offset
+     * @return int|float|null
+     */
+    private static function readNumber($expression, &$offset)
+    {
+        $start = $offset;
+        $length = strlen($expression);
+        $seenDot = false;
+
+        while ($offset < $length) {
+            $char = $expression[$offset];
+            if (self::isDigit($char)) {
+                $offset++;
+                continue;
+            }
+            if ($char === '.' && !$seenDot) {
+                $seenDot = true;
+                $offset++;
+                continue;
+            }
+            break;
+        }
+
+        $literal = substr($expression, $start, $offset - $start);
+        if ($literal === '' || $literal === '.') {
+            return null;
+        }
+
+        if (!$seenDot && ctype_digit($literal)) {
+            // Stay on int while the value fits, so `2*3` keeps returning int(6) as eval() did.
+            $asInt = (int) $literal;
+            if ((string) $asInt === ltrim($literal, '0') || $literal === '0' || ltrim($literal, '0') === '') {
+                return $asInt;
+            }
+
+            return (float) $literal;
+        }
+
+        return (float) $literal;
+    }
+
+    /**
+     * Read one operator, advancing $offset past it.
+     *
+     * @param string $expression
+     * @param int $offset
+     * @return string|null
+     */
+    private static function readOperator($expression, &$offset)
+    {
+        foreach (self::OPERATORS as $operator) {
+            if (substr($expression, $offset, strlen($operator)) === $operator) {
+                $offset += strlen($operator);
+
+                return $operator;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Shunting-yard: infix tokens to reverse polish notation.
+     *
+     * @param array<int, array{0: string, 1: mixed}> $tokens
+     * @return array<int, array{0: string, 1: mixed}>|null
+     */
+    private static function toReversePolish(array $tokens)
+    {
+        $output = [];
+        $stack = [];
+
+        foreach ($tokens as $token) {
+            [$type, $value] = $token;
+
+            if ($type === 'num') {
+                $output[] = $token;
+                continue;
+            }
+
+            if ($type === '(') {
+                $stack[] = $token;
+                if (count($stack) > self::MAX_DEPTH) {
+                    return null;
+                }
+                continue;
+            }
+
+            if ($type === ')') {
+                $matched = false;
+                while ($stack !== []) {
+                    $top = array_pop($stack);
+                    if ($top[0] === '(') {
+                        $matched = true;
+                        break;
+                    }
+                    $output[] = $top;
+                }
+                if (!$matched) {
+                    return null;
+                }
+                continue;
+            }
+
+            $isUnary = isset(self::UNARY[$value]);
+            $precedence = $isUnary ? self::UNARY[$value] : self::PRECEDENCE[$value];
+
+            while ($stack !== []) {
+                $top = end($stack);
+                if ($top[0] !== 'op') {
+                    break;
+                }
+                $topIsUnary = isset(self::UNARY[$top[1]]);
+                $topPrecedence = $topIsUnary ? self::UNARY[$top[1]] : self::PRECEDENCE[$top[1]];
+
+                // Unary operators are right-associative, so an equal precedence does not pop.
+                if ($topPrecedence > $precedence || ($topPrecedence === $precedence && !$isUnary)) {
+                    $output[] = array_pop($stack);
+                    continue;
+                }
+                break;
+            }
+
+            $stack[] = $token;
+            if (count($stack) > self::MAX_DEPTH) {
+                return null;
+            }
+        }
+
+        while ($stack !== []) {
+            $top = array_pop($stack);
+            if ($top[0] === '(') {
+                return null;
+            }
+            $output[] = $top;
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param array<int, array{0: string, 1: mixed}> $rpn
+     * @return int|float|bool|null
+     */
+    private static function evaluateReversePolish(array $rpn)
+    {
+        $stack = [];
+
+        foreach ($rpn as $token) {
+            [$type, $value] = $token;
+
+            if ($type === 'num') {
+                $stack[] = $value;
+                continue;
+            }
+
+            if (isset(self::UNARY[$value])) {
+                if ($stack === []) {
+                    return null;
+                }
+                $operand = array_pop($stack);
+                switch ($value) {
+                    case 'u-':
+                        $stack[] = -$operand;
+                        break;
+                    case 'u+':
+                        $stack[] = +$operand;
+                        break;
+                    default:
+                        $stack[] = !$operand;
+                }
+                continue;
+            }
+
+            if (count($stack) < 2) {
+                return null;
+            }
+            $right = array_pop($stack);
+            $left = array_pop($stack);
+
+            $result = self::apply($value, $left, $right);
+            if ($result === null) {
+                return null;
+            }
+            $stack[] = $result;
+        }
+
+        if (count($stack) !== 1) {
+            return null;
+        }
+
+        return $stack[0];
+    }
+
+    /**
+     * Apply one binary operator using PHP's own semantics.
+     *
+     * @param string $operator
+     * @param int|float|bool $left
+     * @param int|float|bool $right
+     * @return int|float|bool|null
+     */
+    private static function apply($operator, $left, $right)
+    {
+        switch ($operator) {
+            case '+':
+                return $left + $right;
+            case '-':
+                return $left - $right;
+            case '*':
+                return $left * $right;
+            case '/':
+                // eval() raised DivisionByZeroError here; reporting "not evaluable" lets the caller
+                // fall back to its default instead of taking the request down.
+                if ((float) $right === 0.0) {
+                    return null;
+                }
+
+                return $left / $right;
+            case '%':
+                if ((int) $right === 0) {
+                    return null;
+                }
+
+                return (int) $left % (int) $right;
+            case '<':
+                return $left < $right;
+            case '<=':
+                return $left <= $right;
+            case '>':
+                return $left > $right;
+            case '>=':
+                return $left >= $right;
+            case '<=>':
+                return $left <=> $right;
+            case '==':
+                return $left == $right;
+            case '===':
+                return $left === $right;
+            case '!=':
+            case '<>':
+                return $left != $right;
+            case '!==':
+                return $left !== $right;
+            case '&&':
+                return (bool) $left && (bool) $right;
+            case '||':
+                return (bool) $left || (bool) $right;
+        }
+
+        return null;
+    }
+}

--- a/core/tests/Unit/Security/ParserEvalHardeningTest.php
+++ b/core/tests/Unit/Security/ParserEvalHardeningTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Parser eval() hardening
+|--------------------------------------------------------------------------
+|
+| Three parser entry points used to build a string and hand it to eval():
+|
+|   - mergeConditionalTagsContent()  <@IF:...> conditional tags
+|   - _getSGVar()                     [[$_GET(x)]] superglobal reads
+|   - atBindFileContent()             @FILE: template includes
+|
+| All three are reachable from content that the parser re-scans across passes, so a snippet echoing
+| request data can carry a payload into them without any editing privilege. These tests drive the
+| real methods on a Core instance and assert that a payload cannot execute or read outside the tree,
+| while the legitimate syntax each method exists to serve keeps working.
+|
+*/
+
+use EvolutionCMS\Core;
+
+beforeAll(function () {
+    if (!defined('IN_INSTALL_MODE')) {
+        define('IN_INSTALL_MODE', false);
+    }
+    if (!defined('EVO_API_MODE')) {
+        define('EVO_API_MODE', true);
+    }
+    if (!defined('IN_MANAGER_MODE')) {
+        define('IN_MANAGER_MODE', false);
+    }
+    $root = str_replace('\\', '/', dirname(__DIR__, 3)) . '/';
+    if (!defined('EVO_BASE_PATH')) {
+        define('EVO_BASE_PATH', $root);
+    }
+    if (!defined('EVO_CORE_PATH')) {
+        define('EVO_CORE_PATH', $root . 'core/');
+    }
+    if (!defined('EVO_MANAGER_PATH')) {
+        define('EVO_MANAGER_PATH', $root . 'manager/');
+    }
+    $autoload = EVO_CORE_PATH . 'vendor/autoload.php';
+    if (file_exists($autoload)) {
+        require_once $autoload;
+    }
+});
+
+class ParserHardeningCore extends Core
+{
+    public $cfg = ['enable_filter' => 1, 'rb_base_url' => 'assets/'];
+
+    public function getConfig($name = '', $default = null)
+    {
+        return $this->cfg[$name] ?? $default;
+    }
+
+    public function setConfig($name, $value = null): void
+    {
+        $this->cfg[$name] = $value;
+    }
+}
+
+/**
+ * A Core with the two config keys the tested methods read, built without the heavy constructor so
+ * no bootstrap (storage paths, container, DB) is required.
+ */
+function parserHardeningCore(): Core
+{
+    $core = (new ReflectionClass(ParserHardeningCore::class))->newInstanceWithoutConstructor();
+
+    $_SERVER['REQUEST_TIME'] = $_SERVER['REQUEST_TIME'] ?? time();
+
+    return $core;
+}
+
+describe('conditional tags (<@IF:>)', function () {
+
+    test('a quote/backslash breakout neither executes nor fatals', function () {
+        $core = parserHardeningCore();
+        $marker = str_replace('\\', '/', sys_get_temp_dir()) . '/evo_ctag_' . bin2hex(random_bytes(6));
+
+        // A backslash immediately before the quote defeated the str_replace("'", "\'") escaping:
+        // the doubled backslash was consumed, the quote closed the generated string literal early,
+        // and the tail ran as PHP.
+        $bs = chr(92);
+        $sq = chr(39);
+        $cmd = '1' . $bs . $sq . '.file_put_contents("' . $marker . '","x").' . $bs . $sq . '1';
+
+        $out = $core->mergeConditionalTagsContent('<@IF:' . $cmd . '>body<@ENDIF>');
+
+        expect(file_exists($marker))->toBeFalse()
+            ->and($out)->toBeString();
+    });
+
+    test('legitimate numeric conditionals still resolve', function () {
+        $core = parserHardeningCore();
+
+        expect($core->mergeConditionalTagsContent('<@IF:5>A<@ELSE>B<@ENDIF>'))->toBe('A')
+            ->and($core->mergeConditionalTagsContent('<@IF:0>A<@ELSE>B<@ENDIF>'))->toBe('B')
+            ->and($core->mergeConditionalTagsContent('<@IF:5>A<@ELSEIF:1>X<@ELSE>B<@ENDIF>'))->toBe('A')
+            ->and($core->mergeConditionalTagsContent('<@IF:0>A<@ELSEIF:1>X<@ELSE>B<@ENDIF>'))->toBe('X')
+            ->and($core->mergeConditionalTagsContent('<@IF: !0 >neg<@ENDIF>'))->toBe('neg');
+    });
+
+    test('nested conditionals resolve without index corruption', function () {
+        $core = parserHardeningCore();
+
+        // The inner block trims the shared command list; the outer indices must survive that.
+        $tpl = '<@IF:1>outer <@IF:1>inner<@ELSE>x<@ENDIF> end<@ELSE>no<@ENDIF>';
+
+        expect($core->mergeConditionalTagsContent($tpl))->toBe('outer inner end');
+    });
+
+    test('content with no conditional tag is returned untouched', function () {
+        $core = parserHardeningCore();
+        $plain = 'plain [+ph+] content with no tags';
+
+        expect($core->mergeConditionalTagsContent($plain))->toBe($plain);
+    });
+});
+
+describe('superglobal reads ([[$_GET(x)]])', function () {
+
+    test('a backtick payload is not executed', function () {
+        $core = parserHardeningCore();
+        // A colon-free relative name: a `:` in the tag is the modifier delimiter, unrelated here.
+        $marker = 'evo_sg_' . bin2hex(random_bytes(6)) . '.txt';
+
+        // Backticks need no parentheses, so the old `(`/`)` rewrite did not stop them.
+        $payload = '$_SERVER . `echo x > ' . $marker . '`';
+
+        $value = $core->_getSGVar($payload);
+
+        expect(file_exists($marker))->toBeFalse()
+            ->and($value)->toBe('');
+    });
+
+    test('a statement-separator payload is refused', function () {
+        $core = parserHardeningCore();
+
+        expect($core->_getSGVar('$_GET[id];phpinfo()'))->toBe('');
+    });
+
+    test('the documented accessor forms still read the value', function () {
+        $core = parserHardeningCore();
+        $_GET['id'] = 'hello';
+        $_POST['name'] = 'world';
+
+        // The caller rewrites (key) into ['key'] before _getSGVar sees it; accept both spellings.
+        expect($core->_getSGVar("\$_GET['id']"))->toBe('hello')
+            ->and($core->_getSGVar('$_GET(id)'))->toBe('hello')
+            ->and($core->_getSGVar("\$_POST['name']"))->toBe('world');
+
+        unset($_GET['id'], $_POST['name']);
+    });
+
+    test('a missing key yields empty string, not a notice', function () {
+        $core = parserHardeningCore();
+        unset($_GET['nope']);
+
+        expect($core->_getSGVar("\$_GET['nope']"))->toBe('');
+    });
+
+    test('mgrFormValues and token stay hidden from $_SESSION dumps', function () {
+        $core = parserHardeningCore();
+        $_SESSION = ['visible' => '1', 'mgrFormValues' => 'secret', 'token' => 'csrf'];
+
+        $dump = $core->_getSGVar('$_SESSION');
+
+        expect($dump)->toContain('visible')
+            ->and($dump)->not->toContain('mgrFormValues')
+            ->and($dump)->not->toContain('csrf');
+
+        $_SESSION = [];
+    });
+
+    test('a variable outside the allow list is refused', function () {
+        $core = parserHardeningCore();
+
+        expect($core->_getSGVar('$GLOBALS'))->toBe('')
+            ->and($core->_getSGVar('$this'))->toBe('');
+    });
+});
+
+describe('@FILE binding', function () {
+
+    test('directory traversal outside the base path is refused', function () {
+        $core = parserHardeningCore();
+
+        // A real file that certainly exists outside EVO_BASE_PATH.
+        $traversalDepth = str_repeat('../', 20);
+
+        expect($core->atBindFileContent('@FILE:' . $traversalDepth . 'Windows/win.ini'))
+            ->toContain('Could not retrieve')
+            ->and($core->atBindFileContent('@FILE:' . $traversalDepth . 'etc/passwd'))
+            ->toContain('Could not retrieve');
+    });
+
+    test('a php file inside the tree is still refused, including alternate extensions', function () {
+        $core = parserHardeningCore();
+
+        expect($core->atBindFileContent('@FILE:index.php'))->toBe('Could not retrieve PHP file.')
+            ->and($core->atBindFileContent('@FILE:index.phtml'))->toBe('Could not retrieve PHP file.')
+            ->and($core->atBindFileContent('@FILE:x.inc'))->toBe('Could not retrieve PHP file.');
+    });
+
+    test('a permitted file inside the tree is read', function () {
+        $core = parserHardeningCore();
+
+        $relative = 'assets/evo_atfile_' . bin2hex(random_bytes(6)) . '.txt';
+        $absolute = EVO_BASE_PATH . $relative;
+        file_put_contents($absolute, 'included-body');
+
+        try {
+            expect($core->atBindFileContent('@FILE:' . $relative))->toBe('included-body');
+        } finally {
+            @unlink($absolute);
+        }
+    });
+
+    test('a traversal that resolves back inside the tree is still allowed', function () {
+        $core = parserHardeningCore();
+
+        $relative = 'assets/evo_atfile_' . bin2hex(random_bytes(6)) . '.txt';
+        $absolute = EVO_BASE_PATH . $relative;
+        file_put_contents($absolute, 'roundtrip');
+
+        try {
+            // assets/../assets/<file> normalises to a path under the base, so it must resolve.
+            expect($core->atBindFileContent('@FILE:assets/../' . $relative))->toBe('roundtrip');
+        } finally {
+            @unlink($absolute);
+        }
+    });
+});

--- a/core/tests/Unit/Support/ArithmeticExpressionTest.php
+++ b/core/tests/Unit/Support/ArithmeticExpressionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use EvolutionCMS\Support\ArithmeticExpression;
+
+/*
+|--------------------------------------------------------------------------
+| ArithmeticExpression
+|--------------------------------------------------------------------------
+|
+| Replaces the eval() that backed the `math`/`calc` modifiers. Two things have to hold: every
+| expression a template could produce before still produces the same value, and nothing that
+| survived the callers' letter strip can reach PHP any more.
+|
+*/
+
+describe('compatibility with the eval() it replaces', function () {
+
+    // Expressions in the shape `math` receives after its caller has stripped letters and
+    // whitespace and substituted the tag value for `?`. Each is evaluated both ways and the
+    // results are compared, so this is a differential test rather than a table of expected values.
+    test('evaluates exactly as eval() did', function (string $expression) {
+        $expected = eval("return {$expression};");
+
+        expect(ArithmeticExpression::evaluate($expression))->toBe($expected);
+    })->with([
+        '1+1',
+        '2*3',
+        '10-4',
+        '7/2',
+        '6/3',
+        '10%3',
+        '2+3*4',
+        '(2+3)*4',
+        '((1+2)*(3+4))',
+        '-5+3',
+        '+5-3',
+        '2*-3',
+        '1.5+2.25',
+        '0.1*3',
+        '100/8',
+        '1<2',
+        '2<=2',
+        '3>4',
+        '4>=4',
+        '1==1',
+        '1!=2',
+        '1&&0',
+        '1||0',
+        '!0',
+        '!1',
+        '2+3>4',
+        '1&&1||0',
+        '10-2-3',
+        '100/10/2',
+        '2*3%4',
+        '0',
+        '42',
+        '-0',
+    ]);
+});
+
+describe('operator handling', function () {
+
+    test('left associativity is preserved for subtraction and division', function () {
+        expect(ArithmeticExpression::evaluate('10-2-3'))->toBe(5)
+            ->and(ArithmeticExpression::evaluate('100/10/2'))->toBe(5);
+    });
+
+    test('unary minus binds tighter than multiplication but not than parentheses', function () {
+        expect(ArithmeticExpression::evaluate('-2*3'))->toBe(-6)
+            ->and(ArithmeticExpression::evaluate('-(2*3)'))->toBe(-6)
+            ->and(ArithmeticExpression::evaluate('2--3'))->toBe(5);
+    });
+
+    test('integer arithmetic stays integer', function () {
+        expect(ArithmeticExpression::evaluate('2*3'))->toBeInt()
+            ->and(ArithmeticExpression::evaluate('6/3'))->toBeInt()
+            ->and(ArithmeticExpression::evaluate('7/2'))->toBeFloat();
+    });
+
+    test('division and modulo by zero fall back instead of raising', function () {
+        // eval() raised DivisionByZeroError here, which took the whole request down.
+        expect(ArithmeticExpression::evaluate('1/0'))->toBe(0)
+            ->and(ArithmeticExpression::evaluate('1%0'))->toBe(0)
+            ->and(ArithmeticExpression::evaluate('1/0', 'n/a'))->toBe('n/a');
+    });
+});
+
+describe('rejects everything that is not arithmetic', function () {
+
+    // Every payload below survives `preg_replace('@([a-zA-Z\n\r\t\s])@', '', $filter)` - the filter
+    // the callers apply before handing the string over - because it contains no letters at all.
+    $payloads = [
+        'octal escaped system() call' => '"\163\171\163\164\145\155"("\151\144")',
+        'octal escaped phpinfo' => '"\160\150\160\151\156\146\157"()',
+        'backtick shell operator' => '1 . `\151\144`',
+        'variable variable' => '${"\137\107\105\124"}',
+        'statement separator' => '1;print_r($_SERVER)',
+        'superglobal read' => '$_SERVER',
+        'string concatenation' => '"1"."2"',
+        'array literal' => '[1,2][0]',
+        'xor built string' => '("\1"^"\1")',
+        'heredoc-ish quoting' => '"1"',
+        'bare quote' => "'",
+        'backslash' => '\\',
+        'dollar' => '$',
+        'braces' => '{1}',
+        'closing paren only' => ')',
+        'opening paren only' => '(',
+        'unbalanced parens' => '(1+2',
+        'trailing operator' => '1+',
+        'leading binary operator' => '*2',
+        'empty' => '',
+        'two numbers' => '1 2',
+        'implicit multiplication' => '2(3)',
+    ];
+
+    test('refuses the payload', function (string $payload) {
+        expect(ArithmeticExpression::tryEvaluate($payload))->toBeNull()
+            ->and(ArithmeticExpression::evaluate($payload))->toBe(0);
+    })->with($payloads);
+
+    test('no payload reaches PHP even when it would be valid PHP', function () {
+        // If any of these were still evaluated the marker file would exist afterwards.
+        $marker = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'evo_arith_' . bin2hex(random_bytes(6));
+
+        // file_put_contents("<marker>", "x") spelled without a single letter.
+        $call = '"\146\151\154\145\137\160\165\164\137\143\157\156\164\145\156\164\163"("'
+            . addcslashes($marker, "\\\"")
+            . '","\170")';
+
+        ArithmeticExpression::evaluate($call);
+
+        expect(file_exists($marker))->toBeFalse();
+    });
+});
+
+describe('bounds', function () {
+
+    test('an over-long expression is refused rather than parsed', function () {
+        $long = str_repeat('1+', 400) . '1';
+
+        expect(ArithmeticExpression::tryEvaluate($long))->toBeNull();
+    });
+
+    test('deeply nested parentheses are refused rather than recursed', function () {
+        $nested = str_repeat('(', 100) . '1' . str_repeat(')', 100);
+
+        expect(ArithmeticExpression::tryEvaluate($nested))->toBeNull();
+    });
+
+    test('a nesting depth a template might really use still works', function () {
+        expect(ArithmeticExpression::evaluate('((((1+2))))'))->toBe(3);
+    });
+
+    test('non-scalar input is refused', function () {
+        expect(ArithmeticExpression::tryEvaluate([1, 2]))->toBeNull()
+            ->and(ArithmeticExpression::tryEvaluate(null))->toBeNull();
+    });
+});


### PR DESCRIPTION
  The setup: what $key looks like when it arrives

  By the time resolveSGVar() runs, _getSGVar() has already massaged the tag. For a template tag [[$_GET(id)]]:
  
  1. str_replace(['(', ')'], ["['", "']"]) rewrote $_GET(id) → $_GET['id']
  2. splitKeyAndFilter() peeled off any :modifier suffix

  So $key is a string like $_GET['id'], $_SERVER['HTTP_HOST'], $_SESSION['user']['name'], or the bare form $_SERVER. The job is to turn that string into the actual value without letting PHP interpret it. The old code did        
  eval("return {$key};") — which is why $_SERVER . `id` executed a shell command. This code reads the value by hand instead.

  resolveSGVar() — three steps

  Step 1: identify and allowlist the superglobal
```php
  if (!preg_match('@^\$_(GET|POST|SESSION|COOKIE|REQUEST|SERVER|FILES|ENV)@', $key, $matches)) {
      return '';
  }
```
  The string must start with one of the eight known superglobal names. $matches[0] is the matched prefix (e.g. $_GET), $matches[1] is the bare name (e.g. GET). Anything else — $GLOBALS, $this, a bare expression — is refused     
  immediately. This is the allowlist: nothing outside these eight names can ever be reached.

  Step 2: parse the ['key'] accessors into a path
```php
  $path = [];
  $rest = substr($key, strlen($matches[0]));   // everything after "$_GET"
  while ($rest !== '' && $rest !== false) {
      if (!preg_match('@^\[\s*([\'"]?)([^\[\]\'"]*)\1\s*\]@', $rest, $accessor)) {
          return '';                            // trailing junk that isn't an accessor
      }
      $path[] = $accessor[2];                   // the key name
      $rest = substr($rest, strlen($accessor[0]));
  }
```
  This walks the remaining string one [...] at a time, building a list of keys. For $_SESSION['user']['name'] it consumes ['user'] then ['name'], producing $path = ['user', 'name'].

  The regex is the important guard — breaking it down:
  - ^\[ — must start with [
  - \s*([\'"]?) — optional whitespace, then capture an optional opening quote (', ", or none) into group 1
  - ([^\[\]\'"]*) — the key: any run of characters that are not brackets or quotes, captured into group 2
  - \1 — a backreference: the closing quote must match the opening one (both ', both ", or both absent)
  - \s*\] — optional whitespace, then ]

  The [^\[\]\'"] character class is the teeth: a key can't contain a bracket, quote, backtick, $, ., or any other character that could start an expression — because those characters would have to appear inside the class to be   
  allowed, and they aren't. Anything that isn't a clean [key] accessor makes the regex fail, and the whole tag is refused with ''. That's how $_SERVER . `id` dies: after matching $_SERVER, $rest is . `id`, which isn't [...], so 
  return ''.

  Note: because the caller already turned (id) into ['id'], the unquoted accessor form ($accessor[1] empty) is what a (key) tag becomes, and the quoted form is what a literal ['key'] tag is — the regex accepts both via the      
  optional-quote group.

  Step 3: walk the real array
```php
  $container = $this->getSuperGlobal($matches[1]);

  if ($path === []) {
      return count($container) > 0 ? print_r($container, true) : '';
  }

  $cursor = $container;
  foreach ($path as $segment) {
      if (!is_array($cursor) || !array_key_exists($segment, $cursor)) {
          return '';
      }
      $cursor = $cursor[$segment];
  }
  return $cursor;
```
  - No accessors (bare $_SERVER) → dump the whole array via print_r, preserving the old behavior for that form (and '' if empty).
  - Otherwise descend the actual PHP array one key at a time. array_key_exists guards each hop, so a missing key returns '' cleanly instead of raising a notice, and a non-array cursor (you indexed too deep) also bails. The value
    returned is a genuine array element — never anything evaluated.

  getSuperGlobal() — why a function instead of $$name
```php
  switch ($name) {
      case 'GET': return $_GET;
      ...
      case 'SESSION':
          $session = isset($_SESSION) && is_array($_SESSION) ? $_SESSION : [];
          unset($session['mgrFormValues'], $session['token']);
          return $session;
  }
```
  This maps the name string to the real superglobal explicitly. It matters that it's a hardcoded switch and not $GLOBALS[$name] or a variable-variable $$name — a dynamic lookup would reintroduce exactly the "attacker controls   
  which variable I read" problem the allowlist just closed. The switch can only ever return one of the eight.

  The SESSION case is special: it returns a copy (PHP arrays are copy-on-assignment), then unset()s mgrFormValues and token from that copy. So a [[$_SESSION]] dump can't leak the CSRF token or stored form values, and because    
  it's a copy, the real $_SESSION is untouched. This preserves the redaction the original _getSGVar did.

  The net effect

  Every value that comes out is either a literal array element you named or a print_r of a redacted array. There is no code path where any part of the tag is executed — the string is only ever matched against regexes and used as
  array keys. That's the whole point: same reads as before for legitimate $_GET(id)-style tags, zero reachability for `id`, ;phpinfo(), concatenation, or anything else.
