### PR TITLE
fix(core): keep resource date round trips timezone-stable (#2431)

### DIFF
--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -5036,7 +5036,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
             $M = 0;
             $S = 0;
         }
-        $timeStamp = mktime($H, $M, $S, $m, $d, $Y);
+        $timeStamp = gmmktime($H, $M, $S, $m, $d, $Y);
         $timeStamp = (int) $timeStamp;
         return $timeStamp;
     }

--- a/core/tests/Unit/CoreTest.php
+++ b/core/tests/Unit/CoreTest.php
@@ -73,6 +73,24 @@ afterEach(function () {
     Mockery::close();
 });
 
+test('date conversion round trips without runtime timezone drift', function () {
+    $originalTimezone = date_default_timezone_get();
+
+    try {
+        date_default_timezone_set('Asia/Tokyo');
+        $this->parser->config['datetime_format'] = 'YYYY/mm/dd';
+
+        $date = '2026/09/01 10:00:00';
+        $timestamp = $this->parser->toTimeStamp($date);
+
+        expect($this->parser->toDateFormat($timestamp))->toBe($date)
+            ->and($this->parser->toDateFormat($this->parser->toTimeStamp($this->parser->toDateFormat($timestamp))))
+            ->toBe($date);
+    } finally {
+        date_default_timezone_set($originalTimezone);
+    }
+});
+
 describe('getTagsFromContent', function () {
 
     test('it extracts basic placeholders correctly', function () {


### PR DESCRIPTION
## Repro

With PHP `date.timezone=Asia/Tokyo`, a resource date entered as `2026/09/01 10:00:00` is displayed again as `2026/09/01 01:00:00` after save/reopen. Saving again compounds the offset.

## Root Cause

`toDateFormat()` formats stored timestamps in UTC through `Carbon::createFromTimestamp($timestamp, 'UTC')`, while `toTimeStamp()` parsed manager date fields through `mktime()`, which uses PHP's runtime timezone. Non-UTC environments therefore shifted the timestamp on every manager round trip.

## Change Summary

- Parse manager date strings with `gmmktime()` so `toTimeStamp()` uses the same UTC basis as `toDateFormat()`.
- Add a regression test covering an `Asia/Tokyo` open/save/open round trip.

## Validation

- `git diff --check`
- `wsl php -l core/src/Core.php`
- `wsl php -l core/tests/Unit/CoreTest.php`
- WSL smoke test: `Asia/Tokyo` `2026/09/01 10:00:00` round-trips through `toTimeStamp()` and `toDateFormat()` without changing on the second conversion.

`vendor/bin/pest` is not available in the current local `core/vendor`, so the full Pest suite was not run locally.

## Risk

Low. The fix is scoped to the shared date parser and aligns it with the existing UTC display path. It affects manager date strings that already round-trip through `toDateFormat()` / `toTimeStamp()`.
