### PR TITLE
fix(install): write manager_theme and site_id on a CLI install

### DIFF
--- a/install/cli-install.php
+++ b/install/cli-install.php
@@ -598,6 +598,13 @@ class InstallEvo
         $systemSettings[] = ['setting_name' => 'auto_template_logic', 'setting_value' => 1];
         $systemSettings[] = ['setting_name' => 'emailsender', 'setting_value' => $this->cmsAdminEmail];
         $systemSettings[] = ['setting_name' => 'fe_editor_lang', 'setting_value' => $this->language];
+        // The web installer writes these two at installLevel 4
+        // (install/src/controllers/install.php); this path never reached them,
+        // so a CLI-installed site had no manager_theme and the manager built
+        // its stylesheet URL as media/style//style.css - a 404, leaving the
+        // whole manager unstyled.
+        $systemSettings[] = ['setting_name' => 'manager_theme', 'setting_value' => 'default'];
+        $systemSettings[] = ['setting_name' => 'site_id', 'setting_value' => uniqid('')];
         \EvolutionCMS\Models\SystemSetting::insert($systemSettings);
         // Apply core-only migrations (core/database/migrations) not present in the
         // install/stubs chain, e.g. the system task tables. Runs after seeding so the


### PR DESCRIPTION
The web installer writes both at installLevel 4
(install/src/controllers/install.php), and cli-install.php never reached that code: its whole install is realInstall() -> migrationAndSeed(), which inserts four settings and stops.

Without manager_theme the manager builds its stylesheet URL as 'media/style/' . $config['manager_theme'] . '/style.css', which becomes media/style//style.css, 404s, and leaves the manager with no CSS at all - so every site installed from the command line, and every image built that way, looks broken before anything else is tried.

Only the install path is touched; an existing site installed by the old CLI still has neither row.
