### PR TITLE
feat(manager): let CodeMirror editors be resized vertically

### DIFF
--- a/assets/plugins/codemirror/codemirror.plugin.php
+++ b/assets/plugins/codemirror/codemirror.plugin.php
@@ -371,6 +371,15 @@ if(('none' == $rte) && $mode && $elements !== NULL) {
                 if (window.evoElementNameHelper) {
                     window.evoElementNameHelper.installCodeMirror(myCodeMirrors['{$el}']);
                 }
+                // .CodeMirror is resize: vertical (custom.css), so the wrapper
+                // can be dragged taller. CodeMirror renders the lines its last
+                // measurement said would fit, so the new space stays blank
+                // until it is asked to measure again.
+                if (window.ResizeObserver) {
+                    new ResizeObserver(function() {
+                        myCodeMirrors['{$el}'].refresh();
+                    }).observe(myCodeMirrors['{$el}'].getWrapperElement());
+                }
 				{$setHeight}
 				// reset onchange tab
 				var els = document.querySelectorAll('.tab-row .tab');

--- a/manager/media/style/default/css/custom.css
+++ b/manager/media/style/default/css/custom.css
@@ -471,6 +471,12 @@ div.mce-fullscreen { margin-top:2.6rem;	}
 .mceEditor .mceToolbar td { height: 24px; float: left }
 /* codeMirror */
 .CodeMirror { width: 100%; margin: 0 !important; }
+/* Drag the bottom edge to make any editor taller. The wrapper is already
+   overflow: hidden (codemirror.css), which is what lets resize apply to it.
+   CodeMirror only draws the lines its last measurement said would fit, so
+   the instance has to refresh on resize or the new space stays blank - the
+   CodeMirror plugin does that for the editors it creates. */
+.CodeMirror { resize: vertical; }
 .CodeMirror pre { word-break: break-all !important; }
 .CodeMirror > div:first-child > textarea { /*opacity: 0;*/
     z-index: -1; left: -9999rem; }


### PR DESCRIPTION
Every element editor opens at CodeMirror's default 300px and stays there, which is short for a template and far too tall for a one-line chunk.

.CodeMirror is already overflow: hidden (codemirror.css), which is the precondition CSS resize needs, so the affordance is one declaration. The editor then has to be told to measure again: CodeMirror draws the lines its last measurement said would fit, so without a refresh the space gained by dragging stays blank. A ResizeObserver on the wrapper does that for every instance the plugin creates.

Editors created elsewhere get the handle from the same rule and are expected to refresh themselves.
