### PR TITLE
fix(security): resolve @FILE and @INCLUDE paths before trusting them

### DIFF
--- a/core/functions/actions/mutate_content.php
+++ b/core/functions/actions/mutate_content.php
@@ -540,29 +540,34 @@ if (! function_exists('getTVDisplayFormat')) {
                 $widget_output = '';
                 $o = '';
                 /* If we are loading a file */
-                if (substr($params['output'], 0, 5) == "@FILE") {
-                    $file_name = EVO_BASE_PATH . trim(substr($params['output'], 6));
-                    if (!file_exists($file_name)) {
-                        $widget_output = $file_name . ' does not exist';
+                $output = (string) get_by_key($params, 'output', '');
+                /* Both paths are resolved and checked for containment before
+                   they are used - @INCLUDE runs the file, and the output
+                   options this comes from are edited under a permission of
+                   their own, not the one that grants arbitrary PHP. */
+                if (substr($output, 0, 5) == "@FILE") {
+                    $file_name = $modx->atBindFilePath(substr($output, 6));
+                    if ($file_name === false) {
+                        $widget_output = 'Could not retrieve file for TV ' . $name . '.';
                     } else {
                         $widget_output = file_get_contents($file_name);
                     }
-                } elseif (substr($params['output'], 0, 8) == '@INCLUDE') {
-                    $file_name = EVO_BASE_PATH . trim(substr($params['output'], 9));
-                    if (!file_exists($file_name)) {
-                        $widget_output = $file_name . ' does not exist';
+                } elseif (substr($output, 0, 8) == '@INCLUDE') {
+                    $file_name = $modx->atBindFilePath(substr($output, 9));
+                    if ($file_name === false) {
+                        $widget_output = 'Could not retrieve file for TV ' . $name . '.';
                     } else {
                         /* The included file needs to set $widget_output. Can be string, array, object */
                         include $file_name;
                     }
-                } elseif (substr($params['output'], 0, 6) == '@CHUNK' && $value !== '') {
-                    $chunk_name = trim(substr($params['output'], 7));
+                } elseif (substr($output, 0, 6) == '@CHUNK' && $value !== '') {
+                    $chunk_name = trim(substr($output, 7));
                     $widget_output = $modx->getChunk($chunk_name);
-                } elseif (substr($params['output'], 0, 5) == '@EVAL' && $value !== '') {
-                    $eval_str = trim(substr($params['output'], 6));
+                } elseif (substr($output, 0, 5) == '@EVAL' && $value !== '') {
+                    $eval_str = trim(substr($output, 6));
                     $widget_output = eval($eval_str);
                 } elseif ($value !== '') {
-                    $widget_output = $params['output'];
+                    $widget_output = $output;
                 } else {
                     $widget_output = '';
                 }
@@ -899,16 +904,16 @@ if (! function_exists('renderFormElement')) {
                     $custom_output = '';
                     /* If we are loading a file */
                     if (substr($field_elements, 0, 5) == "@FILE") {
-                        $file_name = EVO_BASE_PATH . trim(substr($field_elements, 6));
-                        if (!file_exists($file_name)) {
-                            $custom_output = $file_name . ' does not exist';
+                        $file_name = $modx->atBindFilePath(substr($field_elements, 6));
+                        if ($file_name === false) {
+                            $custom_output = 'Could not retrieve file for this TV.';
                         } else {
                             $custom_output = file_get_contents($file_name);
                         }
                     } elseif (substr($field_elements, 0, 8) == '@INCLUDE') {
-                        $file_name = EVO_BASE_PATH . trim(substr($field_elements, 9));
-                        if (!file_exists($file_name)) {
-                            $custom_output = $file_name . ' does not exist';
+                        $file_name = $modx->atBindFilePath(substr($field_elements, 9));
+                        if ($file_name === false) {
+                            $custom_output = 'Could not retrieve file for this TV.';
                         } else {
                             ob_start();
                             include $file_name;
@@ -950,9 +955,15 @@ if (! function_exists('renderFormElement')) {
         } else {
             $custom = explode(":", $field_type);
             $custom_output = '';
-            $file_name = EVO_BASE_PATH . 'assets/tvs/' . $custom['1'] . '/' . $custom['1'] . '.customtv.php';
-            if (!file_exists($file_name)) {
-                $custom_output = $file_name . ' does not exist';
+            // The widget name comes out of the TV's type column and lands in a
+            // path that is then included, so it goes through the same
+            // containment rule as every other binding.
+            $widget = (string) get_by_key($custom, 1, '');
+            $file_name = $widget === ''
+                ? false
+                : $modx->atBindFilePath('assets/tvs/' . $widget . '/' . $widget . '.customtv.php');
+            if ($file_name === false) {
+                $custom_output = 'Could not retrieve the custom TV widget.';
             } else {
                 ob_start();
                 include $file_name;

--- a/core/functions/tv.php
+++ b/core/functions/tv.php
@@ -516,30 +516,35 @@ if (!function_exists('getTVDisplayFormat')) {
             case 'custom_widget':
                 $widget_output = '';
                 /* If we are loading a file */
-                if (strpos($params['output'], '@FILE') === 0) {
-                    $file_name = EVO_BASE_PATH . trim(substr($params['output'], 6));
-                    if (!is_file($file_name)) {
-                        $widget_output = $file_name . ' does not exist';
+                $output = (string) get_by_key($params, 'output', '');
+                /* Both paths are resolved and checked for containment before
+                   they are used - @INCLUDE runs the file, and the output
+                   options this comes from are edited under a permission of
+                   their own, not the one that grants arbitrary PHP. */
+                if (strpos($output, '@FILE') === 0) {
+                    $file_name = $modx->atBindFilePath(substr($output, 6));
+                    if ($file_name === false) {
+                        $widget_output = 'Could not retrieve file for TV ' . $name . '.';
                     } else {
                         $widget_output = file_get_contents($file_name);
                     }
-                } elseif (strpos($params['output'], '@INCLUDE') === 0) {
-                    $file_name = EVO_BASE_PATH . trim(substr($params['output'], 9));
-                    if (!is_file($file_name)) {
-                        $widget_output = $file_name . ' does not exist';
+                } elseif (strpos($output, '@INCLUDE') === 0) {
+                    $file_name = $modx->atBindFilePath(substr($output, 9));
+                    if ($file_name === false) {
+                        $widget_output = 'Could not retrieve file for TV ' . $name . '.';
                     } else {
                         /* The included file needs to set $widget_output. Can be string, array, object */
                         include $file_name;
                     }
                 } elseif ($value !== '') {
-                    if (strpos($params['output'], '@CHUNK') === 0) {
-                        $chunk_name = trim(substr($params['output'], 7));
+                    if (strpos($output, '@CHUNK') === 0) {
+                        $chunk_name = trim(substr($output, 7));
                         $widget_output = $modx->getChunk($chunk_name);
-                    } elseif (strpos($params['output'], '@EVAL') === 0) {
-                        $eval_str = trim(substr($params['output'], 6));
+                    } elseif (strpos($output, '@EVAL') === 0) {
+                        $eval_str = trim(substr($output, 6));
                         $widget_output = eval($eval_str);
                     } else {
-                        $widget_output = $params['output'];
+                        $widget_output = $output;
                     }
                 } else {
                     $widget_output = '';
@@ -893,16 +898,16 @@ if (!function_exists('renderFormElement')) {
                     $custom_output = '';
                     /* If we are loading a file */
                     if (strpos($field_elements, '@FILE') === 0) {
-                        $file_name = EVO_BASE_PATH . trim(substr($field_elements, 6));
-                        if (!file_exists($file_name)) {
-                            $custom_output = $file_name . ' does not exist';
+                        $file_name = $modx->atBindFilePath(substr($field_elements, 6));
+                        if ($file_name === false) {
+                            $custom_output = 'Could not retrieve file for this TV.';
                         } else {
                             $custom_output = file_get_contents($file_name);
                         }
                     } elseif (strpos($field_elements, '@INCLUDE') === 0) {
-                        $file_name = EVO_BASE_PATH . trim(substr($field_elements, 9));
-                        if (!file_exists($file_name)) {
-                            $custom_output = $file_name . ' does not exist';
+                        $file_name = $modx->atBindFilePath(substr($field_elements, 9));
+                        if ($file_name === false) {
+                            $custom_output = 'Could not retrieve file for this TV.';
                         } else {
                             ob_start();
                             include $file_name;
@@ -942,9 +947,15 @@ if (!function_exists('renderFormElement')) {
             } // end switch statement
         } else {
             $custom = explode(':', $field_type);
-            $file_name = EVO_BASE_PATH.'assets/tvs/'.$custom['1'].'/'.$custom['1'].'.customtv.php';
-            if (!is_file($file_name)) {
-                $custom_output = $file_name . ' does not exist';
+            // The widget name comes out of the TV's type column and lands in a
+            // path that is then included, so it goes through the same
+            // containment rule as every other binding.
+            $widget = (string) get_by_key($custom, 1, '');
+            $file_name = $widget === ''
+                ? false
+                : $modx->atBindFilePath('assets/tvs/' . $widget . '/' . $widget . '.customtv.php');
+            if ($file_name === false) {
+                $custom_output = 'Could not retrieve the custom TV widget.';
             } else {
                 ob_start();
                 include $file_name;

--- a/core/src/Core.php
+++ b/core/src/Core.php
@@ -6433,7 +6433,7 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
      * @return string|false
      * @since 3.5.8
      */
-    private function resolveAtBindFilePath($candidate)
+    public function resolveAtBindFilePath($candidate)
     {
         $resolved = realpath($candidate);
         if ($resolved === false || !is_file($resolved)) {
@@ -6463,6 +6463,37 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
         return $resolved;
     }
 
+    /**
+     * The file an @FILE or @INCLUDE binding names, or false.
+     *
+     * One containment rule for every binding. It used to be four, and only one
+     * of them resolved the path before checking it.
+     *
+     * @param string $relative the binding's argument, as typed
+     * @param string[] $searchPaths prefixes below EVO_BASE_PATH, in order
+     * @return string|false
+     * @since 3.5.8
+     */
+    public function atBindFilePath($relative, array $searchPaths = [''])
+    {
+        $relative = trim((string) $relative);
+        $relative = ltrim(str_replace(chr(92), '/', $relative), '/');
+
+        if ($relative === '') {
+            return false;
+        }
+
+        foreach ($searchPaths as $path) {
+            $resolved = $this->resolveAtBindFilePath(EVO_BASE_PATH . $path . $relative);
+
+            if ($resolved !== false) {
+                return $resolved;
+            }
+        }
+
+        return false;
+    }
+
     public function atBindFileContent($str = '')
     {
 
@@ -6486,16 +6517,15 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
 
         $errorMsg = "Could not retrieve string '" . $str . "'.";
 
-        $search_path = ['assets/tvs/', 'assets/chunks/', 'assets/templates/', $this->getConfig('rb_base_url') . 'files/', ''];
-        foreach ($search_path as $path) {
-            $file_path = $this->resolveAtBindFilePath(EVO_BASE_PATH . $path . $str);
+        $file_path = $this->atBindFilePath($str, [
+            'assets/tvs/',
+            'assets/chunks/',
+            'assets/templates/',
+            $this->getConfig('rb_base_url') . 'files/',
+            ''
+        ]);
 
-            if ($file_path !== false) {
-                break;
-            }
-        }
-
-        if (!$file_path) {
+        if ($file_path === false) {
             return $errorMsg;
         }
 
@@ -6830,25 +6860,13 @@ class Core extends AbstractLaravel implements Interfaces\CoreInterface
         }
 
         $str = substr($str, 9);
-        $str = trim($str);
-        $str = str_replace('\\', '/', $str);
-        $str = ltrim($str, '/');
 
-        $tpl_dir = 'assets/templates/';
+        // This includes rather than reads, so the path settles on is the
+        // path PHP executes. The old check ran on the string as typed, which
+        // a `..` walked straight past.
+        $file_path = $this->atBindFilePath($str, ['', 'assets/templates/']);
 
-        if (strpos($str, EVO_MANAGER_PATH) === 0) {
-            return false;
-        }
-
-        if (is_file(EVO_BASE_PATH . $str)) {
-            $file_path = EVO_BASE_PATH . $str;
-        } elseif (is_file(EVO_BASE_PATH . "{$tpl_dir}{$str}")) {
-            $file_path = EVO_BASE_PATH . $tpl_dir . $str;
-        } else {
-            return false;
-        }
-
-        if (!$file_path || !is_file($file_path)) {
+        if ($file_path === false) {
             return false;
         }
 

--- a/core/tests/Unit/Security/ParserEvalHardeningTest.php
+++ b/core/tests/Unit/Security/ParserEvalHardeningTest.php
@@ -10,6 +10,7 @@
 |   - mergeConditionalTagsContent()  <@IF:...> conditional tags
 |   - _getSGVar()                     [[$_GET(x)]] superglobal reads
 |   - atBindFileContent()             @FILE: template includes
+|   - atBindInclude()                 @INCLUDE: template includes, which run the file
 |
 | All three are reachable from content that the parser re-scans across passes, so a snippet echoing
 | request data can carry a payload into them without any editing privilege. These tests drive the
@@ -232,5 +233,91 @@ describe('@FILE binding', function () {
         } finally {
             @unlink($absolute);
         }
+    });
+});
+
+describe('@INCLUDE binding', function () {
+
+    test('directory traversal outside the base path is refused', function () {
+        $core = parserHardeningCore();
+
+        // This one does not read the file, it includes it - so a path that
+        // escapes the tree is arbitrary code execution, not a disclosure.
+        expect($core->atBindInclude('@INCLUDE ' . str_repeat('../', 20) . 'Windows/win.ini'))->toBeFalse()
+            ->and($core->atBindInclude('@INCLUDE ' . str_repeat('../', 20) . 'etc/passwd'))->toBeFalse();
+    });
+
+    test('a traversal back into the manager directory is refused', function () {
+        $core = parserHardeningCore();
+
+        // The old check asked whether the string as typed started with the
+        // manager path, so anything reaching it by way of `..` walked past.
+        expect($core->atBindInclude('@INCLUDE assets/../manager/index.php'))->toBeFalse()
+            ->and($core->atBindInclude('@INCLUDE manager/index.php'))->toBeFalse();
+    });
+
+    test('a file inside the tree is still included', function () {
+        $core = parserHardeningCore();
+
+        $relative = 'evo_atinclude_' . bin2hex(random_bytes(6)) . '.php';
+        $absolute = EVO_BASE_PATH . $relative;
+        file_put_contents($absolute, '<?php echo "included-body";');
+
+        try {
+            expect($core->atBindInclude('@INCLUDE ' . $relative))->toBe('included-body')
+                // A traversal that normalises back inside the tree still resolves.
+                ->and($core->atBindInclude('@INCLUDE assets/../' . $relative))->toBe('included-body');
+        } finally {
+            @unlink($absolute);
+        }
+    });
+
+    test('a missing file is refused rather than fatal', function () {
+        $core = parserHardeningCore();
+
+        expect($core->atBindInclude('@INCLUDE assets/evo_no_such_' . bin2hex(random_bytes(6)) . '.php'))
+            ->toBeFalse()
+            ->and($core->atBindInclude('@INCLUDE '))->toBeFalse();
+    });
+
+    test('content with no binding is returned untouched', function () {
+        $core = parserHardeningCore();
+
+        expect($core->atBindInclude('plain content'))->toBe('plain content');
+    });
+});
+
+describe('the shared binding path resolver', function () {
+
+    test('a directory is not a file a binding may name', function () {
+        $core = parserHardeningCore();
+
+        expect($core->atBindFilePath('.'))->toBeFalse()
+            ->and($core->atBindFilePath(''))->toBeFalse()
+            ->and($core->atBindFilePath('   '))->toBeFalse();
+    });
+
+    test('search path prefixes are tried in order', function () {
+        $core = parserHardeningCore();
+
+        $name = 'evo_bindpath_' . bin2hex(random_bytes(6)) . '.txt';
+        $absolute = EVO_BASE_PATH . $name;
+        file_put_contents($absolute, 'x');
+
+        try {
+            expect($core->atBindFilePath($name, ['']))->toBe(str_replace(chr(92), '/', realpath($absolute)))
+                // A prefix the file is not under does not find it.
+                ->and($core->atBindFilePath($name, ['assets/']))->toBeFalse();
+        } finally {
+            @unlink($absolute);
+        }
+    });
+
+    test('a backslash separator is accepted and still contained', function () {
+        $core = parserHardeningCore();
+
+        // Windows style separators reach this from hand written bindings.
+        expect($core->atBindFilePath(str_repeat('..' . chr(92), 20) . 'Windows' . chr(92) . 'win.ini'))
+            ->toBeFalse();
     });
 });

--- a/core/tests/Unit/Security/TvBindingFilePathTest.php
+++ b/core/tests/Unit/Security/TvBindingFilePathTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| @FILE / @INCLUDE bindings in template variables
+|--------------------------------------------------------------------------
+|
+| The custom_widget output format (front end, via getTVDisplayFormat) and the
+| custom_tv form element (manager, via renderFormElement) each built a path by
+| concatenating EVO_BASE_PATH with the binding as typed, and used it with no
+| containment check at all - so a `..` segment read, or with @INCLUDE ran, any
+| file the web user could reach. Both functions are defined twice, in
+| functions/tv.php and again in functions/actions/mutate_content.php, so both
+| copies have to be checked.
+|
+| These are source level assertions: the functions need a booted manager
+| request to call, while the rule they must follow - Core::atBindFilePath() -
+| is exercised directly in ParserEvalHardeningTest.
+|
+*/
+
+$read = static fn (string $file): string => str_replace(
+    "\r",
+    '',
+    (string) file_get_contents(dirname(__DIR__, 4) . '/' . $file)
+);
+
+$copies = [
+    'core/functions/tv.php',
+    'core/functions/actions/mutate_content.php',
+];
+
+test('no TV binding builds a path by concatenation any more', function () use ($read, $copies) {
+    foreach ($copies as $file) {
+        expect($read($file))->not->toContain('EVO_BASE_PATH . trim(substr(');
+    }
+});
+
+test('both copies resolve @FILE and @INCLUDE through the shared rule', function () use ($read, $copies) {
+    foreach ($copies as $file) {
+        $source = $read($file);
+
+        // custom_widget (front end) and custom_tv (manager form), four call
+        // sites across the two files.
+        // custom_widget x2, custom_tv x2, and the custom_tv:<widget> file.
+        expect(substr_count($source, '$modx->atBindFilePath('))->toBe(5)
+            ->and($source)->toContain('atBindFilePath(substr($output, 6))')
+            ->and($source)->toContain('atBindFilePath(substr($output, 9))')
+            ->and($source)->toContain('atBindFilePath(substr($field_elements, 6))')
+            ->and($source)->toContain('atBindFilePath(substr($field_elements, 9))');
+    }
+});
+
+test('a refused binding no longer echoes the path it tried', function () use ($read, $copies) {
+    // The message used to be the absolute server path plus " does not exist",
+    // which told a visitor where the installation lives on disk.
+    foreach ($copies as $file) {
+        expect($read($file))->not->toContain("\$file_name . ' does not exist'");
+    }
+});
+
+test('the custom TV widget name cannot walk out of assets/tvs', function () use ($read, $copies) {
+    // $field_type is "custom_tv:<widget>", and the file it names is included.
+    foreach ($copies as $file) {
+        expect($read($file))
+            ->toContain("atBindFilePath('assets/tvs/' . \$widget . '/' . \$widget . '.customtv.php')")
+            ->and($read($file))->not->toContain("EVO_BASE_PATH.'assets/tvs/'.\$custom['1']");
+    }
+});
+
+test('a TV with no output option does not raise a notice', function () use ($read, $copies) {
+    // $params['output'] was read unconditionally, and display_params is empty
+    // for most TVs.
+    foreach ($copies as $file) {
+        $source = $read($file);
+
+        expect($source)->toContain("\$output = (string) get_by_key(\$params, 'output', '');")
+            ->and($source)->not->toContain("\$params['output']");
+    }
+});
+
+test('Core exposes one containment rule for every binding', function () use ($read) {
+    $core = $read('core/src/Core.php');
+
+    expect($core)->toContain('public function atBindFilePath($relative, array $searchPaths')
+        ->and($core)->toContain('public function resolveAtBindFilePath($candidate)')
+        // atBindInclude() decided containment on the string as typed, which a
+        // `..` segment walked past - the bug fixed for @FILE in 3.5.8.
+        ->and($core)->not->toContain('if (strpos($str, EVO_MANAGER_PATH) === 0)')
+        ->and($core)->toContain("\$this->atBindFilePath(\$str, ['', 'assets/templates/']);");
+});


### PR DESCRIPTION
Four bindings turned a string into a path and only one of them checked the resolved path. atBindInclude() compared the string as typed against EVO_MANAGER_PATH, which a `..` segment walked straight past - and it includes the file rather than reading it. The custom_widget output format and the custom_tv form element, both duplicated in functions/tv.php and functions/actions/mutate_content.php, concatenated EVO_BASE_PATH with the binding and used the result with no check at all; custom_tv:<widget> did the same with a name out of the TV's type column.

Containment now lives in one place, Core::atBindFilePath(), built on the resolver @FILE was hardened with in 3.5.8. Search paths and legitimate syntax are unchanged, including a traversal that normalises back inside the tree.

A refused binding no longer echoes the absolute path it tried, and a TV with no output option no longer reads a missing array key.

