### PR TITLE
fix(core): CLI cookie warning headers already sent

### DIFF
--- a/core/functions/session_proxy.php
+++ b/core/functions/session_proxy.php
@@ -57,7 +57,10 @@ class EvoSessionProxy
         self::migrateLegacySessionIfNeeded($store);
 
         // Start PHP session with cookies disabled (Laravel owns the cookie).
-        if (session_status() === PHP_SESSION_NONE) {
+        // Skipped on CLI: there are no headers to send there, and the merge
+        // below fills $_SESSION either way. The CLI installer reaches this
+        // after it has printed, so each call would only warn.
+        if (PHP_SAPI !== 'cli' && session_status() === PHP_SESSION_NONE) {
             ini_set('session.use_cookies', '0');
             if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) {
                 ini_set('session.use_only_cookies', '0');

--- a/index.php
+++ b/index.php
@@ -82,7 +82,9 @@ if (!defined('IN_INSTALL_MODE')) {
 if (IN_INSTALL_MODE) {
     // Set some settings, and address some IE issues.
     @ini_set('url_rewriter.tags', '');
-    if (session_status() === PHP_SESSION_NONE) {
+    // Browser-only session tweaks. The CLI installer includes this file after
+    // it has already printed, so on CLI these only warn about sent headers.
+    if (PHP_SAPI !== 'cli' && session_status() === PHP_SESSION_NONE) {
         ini_set('session.use_trans_sid', 0);
         ini_set('session.use_only_cookies', 1);
     }


### PR DESCRIPTION
The CLI installer includes index.php after it has already printed, so PHP considers the headers sent by the time the session settings are applied. Every CLI install therefore emitted four warnings:

  Warning: ini_set(): Session ini settings cannot be changed after headers
  have already been sent in index.php on line 86
  Warning: ini_set(): Session ini settings cannot be changed after headers
  have already been sent in core/functions/session_proxy.php on line 61
  Warning: session_id(): Session ID cannot be changed after headers have
  already been sent in core/functions/session_proxy.php on line 67

All of them address cookies and headers, which do not exist on CLI. Skip them there; $_SESSION is still filled by the merge that follows in EvoSessionProxy::init(), so nothing else changes.
