### PR TITLE
fix(config): mirror the nginx deny rules in the Apache template, Secure cookie by scheme

### DIFF
--- a/assets/.thumbs/.htaccess
+++ b/assets/.thumbs/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/backup/.htaccess
+++ b/assets/backup/.htaccess
@@ -1,2 +1,7 @@
-order deny,allow
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/assets/cache/.htaccess
+++ b/assets/cache/.htaccess
@@ -1,2 +1,7 @@
-order deny,allow
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/assets/cache/images/.htaccess
+++ b/assets/cache/images/.htaccess
@@ -1,2 +1,7 @@
-order deny,allow
-allow from all
+<IfModule mod_authz_core.c>
+    Require all granted
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Allow from all
+</IfModule>

--- a/assets/docs/.htaccess
+++ b/assets/docs/.htaccess
@@ -1,9 +1,19 @@
 IndexIgnore */*
 <Files "changelog.txt">
-    Order Allow,Deny
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/export/.htaccess
+++ b/assets/export/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/files/.htaccess
+++ b/assets/files/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/images/.htaccess
+++ b/assets/images/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/import/.htaccess
+++ b/assets/import/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/js/.htaccess
+++ b/assets/js/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/js/fileapi/.htaccess
+++ b/assets/js/fileapi/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/js/jeditable/.htaccess
+++ b/assets/js/jeditable/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/assets/site/.htaccess
+++ b/assets/site/.htaccess
@@ -1,5 +1,10 @@
 IndexIgnore */*
 <Files *.php>
-    Order Deny,Allow
-    Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/core/.htaccess
+++ b/core/.htaccess
@@ -1,2 +1,7 @@
-order deny,allow
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/core/config/session.php
+++ b/core/config/session.php
@@ -151,8 +151,15 @@ return [
     | to the server if the browser has a HTTPS connection. This will keep
     | the cookie from being sent to you if it can not be done securely.
     |
+    | Unset, it follows the current request: an HTTPS site gets the Secure
+    | flag without configuration. Set it explicitly behind a TLS-terminating
+    | proxy that talks plain HTTP to PHP.
+    |
     */
-    'secure' => env('SESSION_SECURE_COOKIE', false),
+    'secure' => env('SESSION_SECURE_COOKIE') ?? (
+        (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+        || (int)($_SERVER['SERVER_PORT'] ?? 0) === 443
+    ),
 
     /*
     |--------------------------------------------------------------------------

--- a/core/tests/Unit/Security/ApacheConfigHardeningTest.php
+++ b/core/tests/Unit/Security/ApacheConfigHardeningTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Apache templates and the session cookie
+|--------------------------------------------------------------------------
+|
+| ng.inx refuses /core, /views, dumps, composer.json and PHP under assets; the Apache template
+| refused none of them and left that to per-directory .htaccess files written in the Apache 2.2
+| dialect, which a 2.4 server without mod_access_compat rejects. The session cookie's Secure flag
+| came from SESSION_SECURE_COOKIE alone, so the session proxy (the default) never set it, even
+| on an HTTPS site.
+|
+*/
+
+function evoFile(string $relative): string
+{
+    return (string)file_get_contents(dirname(__DIR__, 4) . '/' . $relative);
+}
+
+it('refuses the same paths in the apache template as in the nginx one', function () {
+    $htaccess = evoFile('ht.access');
+
+    expect($htaccess)
+        ->toContain('RewriteRule ^(core|views|vendor|tmp)(/|$) - [F,L]')
+        ->toContain('RewriteRule ^assets/(cache|backup|export|import)(/|$) - [F,L]')
+        ->toContain('RewriteRule ^assets/.*\.php$ - [F,L,NC]')
+        ->toContain('RewriteRule \.(sql|sqlite|db|log|bak|old|orig|save|swp|swo|tpl|inc|ini|env|dist|example|yml|yaml|lock|tar)(\.(gz|bz2|xz|zip|tgz))?$ - [F,L,NC]')
+        ->toContain('RewriteRule ^(composer\.(json|lock)|phpstan\.neon|publiccode\.yml|AGENTS\.md|README\.md|ht\.access|ng\.inx|config\.php(\.example)?)$ - [F,L]');
+
+    // the deny rules must run before the assets/manager passthrough that ends rewriting
+    expect(strpos($htaccess, 'RewriteRule ^(core|views|vendor|tmp)'))
+        ->toBeLessThan(strpos($htaccess, 'RewriteRule ^(manager|assets|js|css|images|img)/.*$ - [L]'));
+});
+
+it('writes every shipped per-directory .htaccess in both the 2.2 and the 2.4 dialect', function (string $file) {
+    $source = evoFile($file);
+
+    if (preg_match('/^\s*(Order|Deny|Allow|Require)\b/mi', $source) !== 1) {
+        expect(true)->toBeTrue(); // rewrite-only file, nothing to check
+        return;
+    }
+
+    expect($source)
+        ->toContain('<IfModule mod_authz_core.c>')
+        ->toContain('<IfModule !mod_authz_core.c>')
+        ->and(preg_match_all('/Require all (denied|granted)/', $source))
+        ->toBe(preg_match_all('/(Deny|Allow) from all/i', $source));
+
+    // a bare 2.2 directive outside its guard is a 500 on a 2.4 server without mod_access_compat
+    expect(preg_match('/^\s*(Order|Deny from|Allow from)\b/mi', preg_replace('/<IfModule !mod_authz_core\.c>.*?<\/IfModule>/s', '', $source)))
+        ->toBe(0);
+})->with(function () {
+    $root = dirname(__DIR__, 4);
+    $out = [];
+    foreach (explode("\n", trim((string)shell_exec('git -C ' . escapeshellarg($root) . ' ls-files'))) as $path) {
+        if (preg_match('~(^|/)\.htaccess$~', $path)) {
+            $out[] = $path;
+        }
+    }
+
+    return $out;
+});
+
+it('does not ship an installer .htaccess that strips the CSP the installer sets', function () {
+    expect(file_exists(dirname(__DIR__, 4) . '/install/.htaccess'))->toBeFalse();
+});
+
+it('no longer switches mod_security off for the manager', function () {
+    expect(evoFile('manager/.htaccess'))->not->toContain('SecFilterEngine');
+});
+
+it('marks the session cookie Secure on https unless told otherwise', function () {
+    $source = evoFile('core/config/session.php');
+
+    expect($source)
+        ->toContain("'secure' => env('SESSION_SECURE_COOKIE') ?? (")
+        ->toContain("\$_SERVER['HTTPS'] !== 'off'")
+        ->and($source)->not->toContain("env('SESSION_SECURE_COOKIE', false)");
+});

--- a/ht.access
+++ b/ht.access
@@ -61,6 +61,22 @@ RewriteRule .* - [F,L]
 #RewriteCond %{THE_REQUEST} \s/+index\.php\?q=([^\s&]+) [NC]
 #RewriteRule ^ /%1? [R=301,L]
 
+# Paths that must never be reachable over HTTP (mirrors ng.inx).
+#   core, views, vendor, tmp          - CMS core (config, .env, storage), Blade layouts, deps, scratch
+#   assets/(cache|backup|export|import) - generated and writable areas; the per-directory
+#                                       .htaccess files there only work with AllowOverride
+RewriteRule ^(core|views|vendor|tmp)(/|$) - [F,L]
+RewriteRule ^assets/(cache|backup|export|import)(/|$) - [F,L]
+
+# Root-level files that fingerprint the install or describe its layout.
+RewriteRule ^(composer\.(json|lock)|phpstan\.neon|publiccode\.yml|AGENTS\.md|README\.md|ht\.access|ng\.inx|config\.php(\.example)?)$ - [F,L]
+
+# Backups, dumps, editor leftovers and PHP include fragments anywhere, including compressed copies.
+RewriteRule \.(sql|sqlite|db|log|bak|old|orig|save|swp|swo|tpl|inc|ini|env|dist|example|yml|yaml|lock|tar)(\.(gz|bz2|xz|zip|tgz))?$ - [F,L,NC]
+
+# No PHP execution under assets - uploads live here.
+RewriteRule ^assets/.*\.php$ - [F,L,NC]
+
 # Exclude /assets and /manager directories and images from rewrite rules
 RewriteRule ^(manager|assets|js|css|images|img)/.*$ - [L]
 RewriteRule \.(jpg|jpeg|png|gif|ico)$ - [L]

--- a/install/.htaccess
+++ b/install/.htaccess
@@ -1,3 +1,0 @@
-<IfModule mod_headers.c>
-    Header always unset Content-Security-Policy
-</IfModule>

--- a/install/assets/.htaccess
+++ b/install/assets/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/install/src/.htaccess
+++ b/install/src/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/manager/.htaccess
+++ b/manager/.htaccess
@@ -8,11 +8,6 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php [L,QSA]
 
-<IfModule mod_security.c>
-# Turn the filtering engine Off
-SecFilterEngine Off
-</IfModule>
-
 <IfModule mod_expires.c>
     ExpiresActive off
 </IfModule>

--- a/manager/media/browser/mcpuk/core/.htaccess
+++ b/manager/media/browser/mcpuk/core/.htaccess
@@ -1,4 +1,9 @@
 <Files *>
-Order allow,deny
-Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/manager/media/browser/mcpuk/doc/.htaccess
+++ b/manager/media/browser/mcpuk/doc/.htaccess
@@ -1,4 +1,9 @@
 <Files *>
-Order allow,deny
-Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/manager/media/browser/mcpuk/lang/.htaccess
+++ b/manager/media/browser/mcpuk/lang/.htaccess
@@ -1,4 +1,9 @@
 <Files *>
-Order allow,deny
-Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/manager/media/browser/mcpuk/lib/.htaccess
+++ b/manager/media/browser/mcpuk/lib/.htaccess
@@ -1,4 +1,9 @@
 <Files *>
-Order allow,deny
-Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/manager/media/browser/mcpuk/tpl/.htaccess
+++ b/manager/media/browser/mcpuk/tpl/.htaccess
@@ -1,4 +1,9 @@
 <Files *>
-Order allow,deny
-Deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
 </Files>

--- a/views/.htaccess
+++ b/views/.htaccess
@@ -1,2 +1,7 @@
-order deny,allow
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>


### PR DESCRIPTION
ht.access refused nothing that ng.inx refuses: /core, /views, /vendor, /tmp, the writable assets areas, composer.json/.lock, dumps and backups, and PHP under assets/ were all left to per-directory .htaccess files. Those only apply with AllowOverride, and they were written in the Apache 2.2 dialect, which a 2.4 server without mod_access_compat answers with a 500. The rewrite rules now live in ht.access ahead of the assets/manager passthrough, and every shipped .htaccess carries both dialects behind mod_authz_core guards.

manager/.htaccess switched mod_security off with a 1.x directive; dropped. install/.htaccess stripped the Content-Security-Policy header the installer itself sets with a nonce; dropped.

The session cookie's Secure flag came from SESSION_SECURE_COOKIE alone, and the session proxy, which is the default, reads the config value rather than detecting HTTPS, so an HTTPS site never got the flag without setting the variable. Unset, the option now follows the request scheme; the variable still overrides it for a TLS-terminating proxy.
