### PR TITLE
fix(manager): close authorization gaps in document move, phpinfo and sysinfo

### DIFF
--- a/core/src/Controllers/MoveDocument.php
+++ b/core/src/Controllers/MoveDocument.php
@@ -55,6 +55,9 @@ class MoveDocument extends AbstractController implements ManagerTheme\PageContro
 
         $document = $this->getDocument($documentID);
 
+        // the form (a=51) checks the source document; the action must too, or the check is bypassable
+        $this->checkDocumentPermission($document->getKey(), 'access_permission_denied');
+
         $parents = $this->managerTheme->getCore()->getParentIds($newParentID);
         if (\in_array($document->getKey(), $parents, true)) {
             $this->managerTheme->alertAndQuit('error_movedocument2');
@@ -121,15 +124,7 @@ class MoveDocument extends AbstractController implements ManagerTheme\PageContro
         $id = $this->getElementId();
         $document = $this->getDocument($id);
 
-        // check permissions on the document
-        $udperms = new Permissions();
-        $udperms->user     = $this->managerTheme->getCore()->getLoginUserID('mgr');
-        $udperms->document = $document->getKey();
-        $udperms->role     = $_SESSION['mgrRole'];
-
-        if (!$udperms->checkPermissions()) {
-            $this->managerTheme->alertAndQuit('access_permission_denied');
-        }
+        $this->checkDocumentPermission($document->getKey(), 'access_permission_denied');
 
         // Set the item name for logger
         $_SESSION['itemname'] = $document->pagetitle;
@@ -159,6 +154,16 @@ class MoveDocument extends AbstractController implements ManagerTheme\PageContro
 
     protected function checkNewParentPermission($id)
     {
+        $this->checkDocumentPermission($id, 'access_permission_parent_denied');
+    }
+
+    /**
+     * @param int $id
+     * @param string $lang lexicon key of the alert shown when access is denied
+     * @since 3.5.8
+     */
+    protected function checkDocumentPermission($id, string $lang): void
+    {
         $udperms           = new Permissions;
         $udperms->user     = $this->managerTheme->getCore()->getLoginUserID('mgr');
         $udperms->document = $id;
@@ -168,6 +173,6 @@ class MoveDocument extends AbstractController implements ManagerTheme\PageContro
             return;
         }
 
-        $this->managerTheme->alertAndQuit('access_permission_parent_denied');
+        $this->managerTheme->alertAndQuit($lang);
     }
 }

--- a/core/src/Controllers/Phpinfo.php
+++ b/core/src/Controllers/Phpinfo.php
@@ -21,7 +21,7 @@ class Phpinfo extends AbstractController implements ManagerTheme\PageControllerI
      */
     public function canView(): bool
     {
-        return $this->managerTheme->getCore()->hasPermission('logs');
+        return $this->managerTheme->getCore()->hasPermission('settings');
     }
 
     /**

--- a/core/src/Controllers/SystemInfo.php
+++ b/core/src/Controllers/SystemInfo.php
@@ -27,7 +27,7 @@ class SystemInfo extends AbstractController implements ManagerTheme\PageControll
 
     public function canView(): bool
     {
-        return $this->managerTheme->getCore()->hasPermission('logs');
+        return $this->managerTheme->getCore()->hasPermission('settings');
     }
 
     public function getParameters(array $params = []): array

--- a/core/tests/Unit/Security/ManagerAuthorizationGapsTest.php
+++ b/core/tests/Unit/Security/ManagerAuthorizationGapsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Manager actions that used to check less than the page that leads to them
+|--------------------------------------------------------------------------
+|
+| The move form (a=51) enforces the per-document ACL, but the move action (a=52) it submits to
+| only checked the global save_document right, so the form was the only thing standing between a
+| user and a document outside their groups. Likewise phpinfo and the system info page expose the
+| server environment and the database layout, which is settings-level detail, but they were open
+| to anyone holding the much more common logs right.
+|
+*/
+
+function controllerSource(string $class): string
+{
+    return (string)file_get_contents(dirname(__DIR__, 3) . '/src/Controllers/' . $class . '.php');
+}
+
+it('checks the source document ACL in the move action, not only in the move form', function () {
+    $source = controllerSource('MoveDocument');
+
+    $handle = strpos($source, 'protected function handle()');
+    $display = strpos($source, 'protected function processDisplay()');
+    $check = strpos($source, "\$this->checkDocumentPermission(\$document->getKey(), 'access_permission_denied');", $handle);
+
+    expect($handle)->not->toBeFalse()
+        ->and($check)->not->toBeFalse()
+        ->and($check)->toBeLessThan($display)
+        ->and($check)->toBeLessThan(strpos($source, '$document->save();', $handle));
+
+    // the form keeps its own check
+    expect(strpos($source, "\$this->checkDocumentPermission(\$document->getKey(), 'access_permission_denied');", $display))
+        ->not->toBeFalse();
+});
+
+it('gates the phpinfo and system info pages on the settings right', function (string $class) {
+    $source = controllerSource($class);
+
+    expect($source)
+        ->toContain("hasPermission('settings')")
+        ->and($source)->not->toContain("hasPermission('logs')");
+})->with(['Phpinfo', 'SystemInfo']);

--- a/manager/views/frame/1.blade.php
+++ b/manager/views/frame/1.blade.php
@@ -361,6 +361,8 @@ $managerTitle = evo()->getConfig('site_name') . ' - (Evolution CMS Manager)';
                                                 {{ icon_html($_style['icon_user_secret']) }} {{ManagerTheme::getLexicon('view_logging')}}
                                             </a>
                                         </li>
+                                    @endif
+                                    @if (evo()->hasPermission('settings'))
                                         <li>
                                             <a href="index.php?a=53" target="main">
                                                 {{ icon_html($_style['icon_info_circle']) }} {{ManagerTheme::getLexicon('view_sysinfo')}}


### PR DESCRIPTION
The move form (a=51) checks the per-document ACL, but the move action (a=52) it submits to only checked the global save_document right and the new parent, so anyone holding save_document could reparent a document outside their groups by requesting a=52 directly. Both entry points now share one checkDocumentPermission() helper.

phpinfo (a=200) and the system info page (a=53) reveal the server environment and the database host/name/prefix; they were open to the `logs` right, which editors commonly hold. They now require `settings`, and the sidebar link moved under the same gate.
